### PR TITLE
Add argcheck for indexing into tensor with a table

### DIFF
--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -639,6 +639,7 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
     int done = 0;
     tensor = THTensor_(newWithTensor)(tensor);
     ndims = tensor->nDimension;
+    luaL_argcheck(L, lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
     for(dim = 0; dim < ndims; dim++)
     {
       lua_rawgeti(L, 2, dim+1);
@@ -790,6 +791,7 @@ static int torch_Tensor_(__index__)(lua_State *L)
     tensor = THTensor_(newWithTensor)(tensor);
     ndims = tensor->nDimension;
     
+    luaL_argcheck(L, lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
     for(dim = 0; dim < ndims; dim++)
     {
       lua_rawgeti(L, 2, dim+1);


### PR DESCRIPTION
We check that the number of indices provided is
not greater than the number of dimensions.

This is done for both **index** and **newindex**.

Also added unit tests for index lookup and index
assignment.
