### PR TITLE
Stop =torch.Tensor()[0] from segfaulting

### DIFF
--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -553,10 +553,11 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
 
   if(lua_isnumber(L, 2))
   {
-    luaL_argcheck(L, tensor->nDimension > 0, 1, "empty tensor");
-
     void *src;
-    long index = luaL_checklong(L,2)-1;
+    long index;
+
+    luaL_argcheck(L, tensor->nDimension > 0, 1, "empty tensor");
+    index = luaL_checklong(L,2)-1;
     if (index < 0) index = tensor->size[0] + index + 1;
     if (lua_isnumber(L,3)) {
       real value = (real)luaL_checknumber(L,3);
@@ -746,9 +747,11 @@ static int torch_Tensor_(__index__)(lua_State *L)
 
   if(lua_isnumber(L, 2))
   {
-    luaL_argcheck(L, tensor->nDimension > 0, 1, "empty tensor");
+    long index;
 
-    long index = luaL_checklong(L,2)-1;
+    luaL_argcheck(L, tensor->nDimension > 0, 1, "empty tensor");
+    index = luaL_checklong(L,2)-1;
+
     if (index < 0) index = tensor->size[0] + index + 1;
 
     luaL_argcheck(L, index >= 0 && index < tensor->size[0], 2, "out of range");


### PR DESCRIPTION
Move precondition checks up to prevent element access from seg-faulting.
