### PR TITLE
Stop __index__ and __newindex__ leaking a tensor during torch.test()

### DIFF
--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -635,13 +635,13 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
   }
   else if(lua_istable(L, 2))
   {
-	int dim;
+    int dim;
     int cdim = 0;
     int ndims;
     int done = 0;
-    tensor = THTensor_(newWithTensor)(tensor);
     ndims = tensor->nDimension;
     luaL_argcheck(L, lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
+    tensor = THTensor_(newWithTensor)(tensor);
     for(dim = 0; dim < ndims; dim++)
     {
       lua_rawgeti(L, 2, dim+1);
@@ -790,10 +790,11 @@ static int torch_Tensor_(__index__)(lua_State *L)
     int cdim = 0;
     int ndims;
     int done = 0;
-    tensor = THTensor_(newWithTensor)(tensor);
+
     ndims = tensor->nDimension;
-    
     luaL_argcheck(L, lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
+    tensor = THTensor_(newWithTensor)(tensor);
+
     for(dim = 0; dim < ndims; dim++)
     {
       lua_rawgeti(L, 2, dim+1);


### PR DESCRIPTION
This change fixes leaks that occur during the tests - but not all possible leaks from `__index__` and `__newindex__`

Any `luaL_argcheck` after this line:

>  tensor = THTensor_(newWithTensor)(tensor);

Will cause tensor to leak.

There are ~8 other `luaL_argcheck` lines across these two functions which the tests don't hit that will do this - is it worth fixing them?
