### PR TITLE
format specifier fix for ASCII mode, doubled the precision

### DIFF
--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -307,11 +307,11 @@ READ_WRITE_METHODS(long, Long,
 
 READ_WRITE_METHODS(float, Float,
                    int ret = fscanf(dfself->handle, "%g", &data[i]); if(ret <= 0) break; else nread++,
-                   int ret = fprintf(dfself->handle, "%012.12g", data[i]); if(ret <= 0) break; else nwrite++)
+                   int ret = fprintf(dfself->handle, "%.9g", data[i]); if(ret <= 0) break; else nwrite++)
 
 READ_WRITE_METHODS(double, Double,
                    int ret = fscanf(dfself->handle, "%lg", &data[i]); if(ret <= 0) break; else nread++,
-                   int ret = fprintf(dfself->handle, "%012.12lg", data[i]); if(ret <= 0) break; else nwrite++)
+                   int ret = fprintf(dfself->handle, "%.17g", data[i]); if(ret <= 0) break; else nwrite++)
 
 static long THDiskFile_readString(THFile *self, const char *format, char **str_)
 {


### PR DESCRIPTION
fixes https://github.com/torch/torch7/issues/3

makes the precision 12 digits, from the default 6.
