### PR TITLE
Used long instead of int for the mmap file size.

### DIFF
--- a/lib/TH/THAllocator.c
+++ b/lib/TH/THAllocator.c
@@ -168,7 +168,7 @@ static void *THMapAllocator_alloc(void* ctx_, long size)
   {
     /* open file */
     int fd;
-    int fdsz;
+    long fdsz;
 
     if(ctx->shared)
     {
@@ -220,10 +220,11 @@ static void *THMapAllocator_alloc(void* ctx_, long size)
     else
       data = mmap(NULL, ctx->size, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
 
-    if(data == MAP_FAILED)
-      data = NULL; /* let's be sure it is NULL */
-
     close(fd);
+    if(data == MAP_FAILED) {
+      data = NULL; /* let's be sure it is NULL */
+      THError("$ Torch: unable to mmap memory: you tried to mmap %dGB.", ctx->size/1073741824);
+    }
   }
 #endif
 


### PR DESCRIPTION
Mmapping of 2GB+ files is failing.
This pull request fixes that by using `long` to hold the file size.

Example failing code:

```
require 'torch'
local storage = torch.ByteStorage("more_than_2GB.bin")
print("storage:size():", storage:size())
print("storage[1]:", storage[1])
```
