### PR TITLE
Fix numel() cwrap return type

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -366,7 +366,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
    wrap("numel",
         cname("numel"),
         {{name=Tensor},
-         {name=real, creturned=true}})
+         {name="long", creturned=true}})
 
    for _,name in ipairs({"prod", "cumsum", "cumprod"}) do
       wrap(name,

--- a/test/test.lua
+++ b/test/test.lua
@@ -527,6 +527,11 @@ function torchtest.testCholeskyErrsOnRankDeficient()
     A[{{},5}]:copy(A[{{},{1}}])
     mytester:assertError(function() torch.potrf(A) end)
 end
+function torchtest.testNumel()
+    local b = torch.ByteTensor(3, 100, 100)
+    mytester:asserteq(b:nElement(), 3*100*100, "nElement not right")
+    mytester:asserteq(b:numel(), 3*100*100, "numel not right")
+end
 
 
 function torch.test()


### PR DESCRIPTION
It should always be long (the type returned by the numel C function) - it was being cast to the element type of the tensor.

This caused incorrect results; for example:

``` lua
t7> x = torch.ByteTensor(3,100,100)
t7> =x:numel()
48
t7> =x:nElement()
30000
t7> y = torch.DoubleTensor(3,100,100)
t7> =y:numel()
30000
t7> =y:nElement()
30000
```

Also added test for nElement and numel.
