### PR TITLE
Used double to hold the 'p' for bernoulli() and geometric()

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -537,7 +537,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
            cname(f.name),
            {{name=Tensor, returned=true},
             {name='Generator', default=true},
-            {name=real, default=f.a}})
+            {name="double", default=f.a}})
    end
 
    wrap("squeeze",


### PR DESCRIPTION
The following call was generating 100 zeros:

```
    torch.bernoulli(torch.ByteTensor(100), 0.5)
```

The 0.5 probability was converted to 0, when casting the argument to 'unsigned char'.
I now used double to hold the probability. 
