### PR TITLE
Make the THGenerator next field an offset.

### DIFF
--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -138,7 +138,7 @@ void THRandom_nextState(THGenerator *_generator)
     THRandom_seed(_generator);
 
   _generator->left = n;
-  _generator->next = _generator->state;
+  _generator->next = 0;
     
   for(j = n-m+1; --j; p++) 
     *p = p[m] ^ TWIST(p[0], p[1]);
@@ -155,7 +155,7 @@ unsigned long THRandom_random(THGenerator *_generator)
 
   if (--(_generator->left) == 0)
     THRandom_nextState(_generator);
-  y = *((_generator->next)++);
+  y = *(_generator->state + (_generator->next)++);
   
   /* Tempering */
   y ^= (y >> 11);
@@ -173,7 +173,7 @@ static double __uniform__(THGenerator *_generator)
 
   if (--(_generator->left) == 0)
     THRandom_nextState(_generator);
-  y = *((_generator->next)++);
+  y = *(_generator->state + (_generator->next)++);
 
   /* Tempering */
   y ^= (y >> 11);
@@ -257,7 +257,7 @@ void THRandom_getState(THGenerator *_generator, unsigned long *_state, long *off
   if(_generator->initf == 0)
     THRandom_seed(_generator);
   memmove(_state, _generator->state, n*sizeof(long));
-  *offset = (long)(_generator->next - _generator->state);
+  *offset = _generator->next;
   *_left = _generator->left;
 }
 
@@ -265,7 +265,7 @@ void THRandom_getState(THGenerator *_generator, unsigned long *_state, long *off
 void THRandom_setState(THGenerator *_generator, unsigned long *_state, long offset, long _left)
 {
   memmove(_generator->state, _state, n*sizeof(long));
-  _generator->next = _generator->state + offset;
+  _generator->next = offset;
   _generator->left = _left;
   _generator->initf = 1;
 }

--- a/lib/TH/THRandom.h
+++ b/lib/TH/THRandom.h
@@ -11,7 +11,7 @@ typedef struct THGenerator {
   unsigned long the_initial_seed;
   int left;  /* = 1; */
   int initf; /* = 0; */
-  unsigned long *next;
+  unsigned long next;
   unsigned long state[_MERSENNE_STATE_N]; /* the array for the state vector  */
   /********************************/
 

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -220,9 +220,6 @@ TH_API void THTensor_(getRNGState)(THGenerator *_generator, THTensor *self)
   THArgCheck(THTensor_(isContiguous)(self), 1, "RNG state needs to be contiguous");
   rng_state = (THGenerator *)THTensor_(data)(self);
   THGenerator_copy(rng_state, _generator);
-
-  /* We must make the 'next' pointer in RNGState a relative offset, rather than an absolute address */
-  rng_state->next = (unsigned long *)(_generator->next - _generator->state);
 }
 
 TH_API void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
@@ -233,9 +230,6 @@ TH_API void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
   THArgCheck(THTensor_(isContiguous)(self), 1, "RNG state needs to be contiguous");
   rng_state = (THGenerator *)THTensor_(data)(self);
   THGenerator_copy(_generator, rng_state);
-
-  /* We must make the 'next' pointer in Generator an absolute address, it is stored as a relative offset. */
-  _generator->next = (unsigned long *)(_generator->state + (long)(rng_state->next));
 }
 #endif
 


### PR DESCRIPTION
@soumith

It wasn't actually that hard to make the next field a relative offset vs a pointer and feels _much_ cleaner.

To test I diff'd the stdout from this before and after this patch - no change.

> th -e "torch.manualSeed(1) ; print(torch.rand(1000000)) ; print(torch.randn(1000000))"

There is no discernible difference in speed at this level, I would need to do more involved testing to be sure it doesn't cause any problems. I'll run it through the tests from this pull request tomorrow:
https://github.com/torch/torch7/pull/13
