### PR TITLE
adding torch.isSameSizeAs

### DIFF
--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -708,6 +708,20 @@ false
 [torch.LongStorage of size 1]
 ```
 
+<a name="torch.Tensor.isSameSizeAs"/>
+### [boolean] isSameSizeAs(tensor) ###
+
+Returns `true` iff the dimensions of the `Tensor` and the argument `Tensor` are exactly the same.
+```lua
+> x = torch.Tensor(4,5)
+> y = torch.Tensor(4,5)
+> = x:isSameSizeAs(y)
+true
+> y = torch.Tensor(4, 6)
+> = x:isSameSizeAs(y)
+false
+```
+
 <a name="torch.Tensor.nElement"/>
 ### [number] nElement() ###
 

--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -512,6 +512,14 @@ static int torch_Tensor_(isContiguous)(lua_State *L)
   return 1;
 }
 
+static int torch_Tensor_(isSameSizeAs)(lua_State *L)
+{
+  THTensor *tensor1 = luaT_checkudata(L, 1, torch_Tensor);
+  THTensor *tensor2 = luaT_checkudata(L, 2, torch_Tensor);
+  lua_pushboolean(L, THTensor_(isSameSizeAs)(tensor1, tensor2));
+  return 1;
+}
+
 static int torch_Tensor_(nElement)(lua_State *L)
 {
   THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
@@ -1148,6 +1156,7 @@ static const struct luaL_Reg torch_Tensor_(_) [] = {
   {"t", torch_Tensor_(t)},
   {"unfold", torch_Tensor_(unfold)},
   {"isContiguous", torch_Tensor_(isContiguous)},
+  {"isSameSizeAs", torch_Tensor_(isSameSizeAs)},
   {"nElement", torch_Tensor_(nElement)},
   {"copy", torch_Tensor_(copy)},
   {"apply", torch_Tensor_(apply)},

--- a/lib/TH/generic/THTensor.c
+++ b/lib/TH/generic/THTensor.c
@@ -531,6 +531,19 @@ int THTensor_(isContiguous)(const THTensor *self)
   return 1;
 }
 
+int THTensor_(isSameSizeAs)(const THTensor *self, const THTensor* src)
+{
+  int d;
+  if (self->nDimension != src->nDimension)
+    return 0;
+  for(d = 0; d < self->nDimension; ++d)
+  {
+    if(self->size[d] != src->size[d])
+      return 0;
+  }
+  return 1;
+}
+
 long THTensor_(nElement)(const THTensor *self)
 {
   if(self->nDimension == 0)

--- a/lib/TH/generic/THTensor.h
+++ b/lib/TH/generic/THTensor.h
@@ -103,6 +103,7 @@ TH_API void THTensor_(squeeze)(THTensor *self, THTensor *src);
 TH_API void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension_);
     
 TH_API int THTensor_(isContiguous)(const THTensor *self);
+TH_API int THTensor_(isSameSizeAs)(const THTensor *self, const THTensor *src);
 TH_API long THTensor_(nElement)(const THTensor *self);
 
 TH_API void THTensor_(retain)(THTensor *self);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1426,6 +1426,17 @@ function torchtest.view()
    mytester:asserteq((target_tensor-tensor):abs():max(), 0, 'Error in viewAs')
 end
 
+function torchtest.isSameSizeAs()
+   local t1 = torch.Tensor(3, 4, 9, 10)
+   local t2 = torch.Tensor(3, 4)
+   local t3 = torch.Tensor(1, 9, 3, 3)
+   local t4 = torch.Tensor(3, 4, 9, 10)
+
+   mytester:assert(t1:isSameSizeAs(t2) == false, "wrong answer ")
+   mytester:assert(t1:isSameSizeAs(t3) == false, "wrong answer ")
+   mytester:assert(t1:isSameSizeAs(t4) == true, "wrong answer ")
+end
+
 function torch.test(tests)
    math.randomseed(os.time())
    if torch.getdefaulttensortype() == 'torch.FloatTensor' then


### PR DESCRIPTION
A small function to check if two tensors are of the same order.

doc + unit test included.

``` lua
 > x = torch.Tensor(4,5)
 > y = torch.Tensor(4,5)
 > = x:isSameSizeAs(y)
 true
 > y = torch.Tensor(4, 6)
 > = x:isSameSizeAs(y)
 false
> y = torch.Tensor(1)
 > = x:isSameSizeAs(y)
 false
```
