### PR TITLE
Make :data() on an empty Tensor return nil rather than segfault.

### DIFF
--- a/FFI.lua
+++ b/FFI.lua
@@ -88,7 +88,7 @@ typedef struct THRealTensor
              "data",
              function(self)
                 self = Tensor_tt(self)[0]
-                return self.storage.data + self.storageOffset
+                return self.storage ~= nil and self.storage.data + self.storageOffset or nil
              end)
 
       -- faster apply (contiguous case)


### PR DESCRIPTION
Fixes this:

```
$ torch -e "torch.Tensor():data()"
Torch 7.0  Copyright (C) 2001-2011 Idiap, NEC Labs, NYU
Segmentation fault: 11
```

To get this instead:

```
$ torch -e "print(torch.Tensor():data())"
Torch 7.0  Copyright (C) 2001-2011 Idiap, NEC Labs, NYU
nil
```

Also means this doesn't segfault: `torch.Tensor():apply(function() end)`
