### PR TITLE
Fix behaviour of torch.isTensor

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -115,7 +115,7 @@ include('Tester.lua')
 include('test.lua')
 
 function torch.isTensor(obj)
-  return torch.isTypeOf(obj, 'torch.*Tensor')
+  return type(obj) == 'userdata' and torch.isTypeOf(obj, 'torch.*Tensor')
 end
 -- alias for convenience
 torch.Tensor.isTensor = torch.isTensor


### PR DESCRIPTION
In my understanding, torch.isTensor should only return true if the tested object is an actual Tensor, not if it is the table torch.Tensor (or torch.FloatTensor, etc)

That means:
t = torch.FloatTensor 
torch.isTensor(t) -- should be false
torch.isTensor(t()) -- should be true
