### PR TITLE
File: explicit the expected storage type (R/W)

### DIFF
--- a/File.c
+++ b/File.c
@@ -88,7 +88,7 @@ IMPLEMENT_TORCH_FILE_FUNC(close)
       }                                                                 \
     }                                                                   \
                                                                         \
-    luaL_error(L, "nothing, number, or Storage expected");              \
+    luaL_error(L, "nothing, number, or " #TYPEC "Storage expected");    \
     return 0;                                                           \
   }                                                                     \
                                                                         \
@@ -113,7 +113,7 @@ IMPLEMENT_TORCH_FILE_FUNC(close)
       }                                                                 \
     }                                                                   \
                                                                         \
-    luaL_error(L, "number, or Storage expected");                       \
+    luaL_error(L, "number, or " #TYPEC "Storage expected");             \
     return 0;                                                           \
   }
 


### PR DESCRIPTION
A tiny fix used to make the error message a bit clearer, e.g:

``` Lua
require 'torch'

local t = torch.rand(3):float()
local f = torch.DiskFile('out.bin', 'w'):binary()
-- This misuse (passing a float storage) gives a `number, or Storage expected`
-- error. It could be easier to debug (IMHO) if the expected type is explicit:
-- `number, or DoubleStorage expected`
f:writeDouble(t:storage())
f:close()
```
