### PR TITLE
Cmd line error message streams to stderr.  Exit with code 1 instead of 0...

### DIFF
--- a/CmdLine.lua
+++ b/CmdLine.lua
@@ -10,10 +10,10 @@ end
 
 function CmdLine:error(msg)
    print('')
-   print(msg)
+   io.stderr:print(msg)
    print('')
    self:help()
-   os.exit(0)
+   os.exit(1)
 end
 
 function CmdLine:__readArgument__(params, arg, i, nArgument)


### PR DESCRIPTION
....