### PR TITLE
Add batch matrix-matrix multiplication.

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -312,6 +312,13 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name=Tensor, dim=2}}
      )
 
+   wrap("bmm",
+        cname("bmm"),
+        {{name=Tensor, default=true, returned=true},
+         {name=Tensor, dim=3},
+         {name=Tensor, dim=3}}
+     )
+
    wrap("ger",
         cname("addr"),
         {{name=Tensor, default=true, returned=true, method={default='nil'},

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -806,6 +806,22 @@ Matrix matrix product of `mat1` and `mat2`. If `mat1` is a
 
 `M:mm(x,y)` puts the result in `M`.
 
+<a name="torch.bmm"/>
+### [res] torch.bmm([res,] batch1, batch2) ###
+<a name="torch.bmm"/>
+
+Batch matrix matrix product of matrices stored in `batch1` and `batch2`.
+`batch1` and `batch2` must be 3D tensors each containing the same number
+of matrices. If `batch1` is a `b x n x m` tensor, `batch2` a `b x m x p`
+tensor, res will be a `b x n x p` tensor.
+
+
+`torch.bmm(x,y)` puts the result in a new tensor.
+
+`torch.bmm(M,x,y)` puts the result in `M`, resizing `M` if necessary.
+
+`M:bmm(x,y)` puts the result in `M`, resizing `M` if necessary.
+
 <a name="torch.ger"/>
 ### [res] torch.ger([res,] vec1, vec2) ###
 <a name="torch.ger"/>

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -36,6 +36,8 @@ TH_API void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, T
 TH_API void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *mat1, THTensor *mat2);
 TH_API void THTensor_(addr)(THTensor *r_,  real beta, THTensor *t, real alpha, THTensor *vec1, THTensor *vec2);
 
+TH_API void THTensor_(bmm)(THTensor *r_,  THTensor *batch1, THTensor *batch2);
+
 TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain);
 
 TH_API long THTensor_(numel)(THTensor *t);

--- a/test/test.lua
+++ b/test/test.lua
@@ -460,6 +460,19 @@ function torchtest.div()
    mytester:assertlt(err, precision, 'error in torch.div - scalar, non contiguous')
 end
 
+function torchtest.bmm()
+  local num_batches = 10
+  local M, N, O = 23, 8, 12
+  local b1 = torch.randn(num_batches, M, N)
+  local b2 = torch.randn(num_batches, N, O)
+  local res = torch.bmm(b1, b2)
+
+  for i = 1, num_batches do
+    local r = torch.mm(b1[i], b2[i])
+    mytester:assertTensorEq(r, res[i], precision, 'result matrix ' .. i .. ' wrong')
+  end
+end
+
 function torchtest.clamp()
    local m1 = torch.rand(100):mul(5):add(-2.5)  -- uniform in [-2.5, 2.5]
    -- just in case we're extremely lucky:


### PR DESCRIPTION
Add torch.bmm, which expects two 3D tensors as inputs. A 'b x m x n'
tensor is interpreted as a batch of b matrices of size 'm x n'.
The result is a batch of matrices computed by multiplying the
corresponding pair of matrices in the two input batches.