### PR TITLE
torch.totable for Storages and for Tensors.

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -277,7 +277,7 @@ end
 function Tensor.expand(result,tensor,...)
    -- get sizes
    local sizes = {...}
-   
+
    local t = torch.type(tensor)
    if (t == 'number' or t == 'torch.LongStorage') then
       table.insert(sizes,1,tensor)
@@ -334,7 +334,7 @@ torch.expandAs = Tensor.expandAs
 function Tensor.repeatTensor(result,tensor,...)
    -- get sizes
    local sizes = {...}
-   
+
    local t = torch.type(tensor)
    if (t == 'number' or t == 'torch.LongStorage') then
       table.insert(sizes,1,tensor)
@@ -512,6 +512,18 @@ function Tensor.chunk(result, tensor, nChunk, dim)
    return torch.split(result, tensor, splitSize, dim)
 end
 torch.chunk = Tensor.chunk
+
+function Tensor.totable(tensor)
+  local result = {}
+  if tensor:dim() == 1 then
+    tensor:apply(function(i) table.insert(result, i) end)
+  else
+    for i = 1, tensor:size(1) do
+      table.insert(result, tensor[i]:totable())
+    end
+  end
+  return result
+end
 
 for _,type in ipairs(types) do
    local metatable = torch.getmetatable('torch.' .. type .. 'Tensor')

--- a/init.lua
+++ b/init.lua
@@ -17,7 +17,7 @@ function torch.packageLuaPath(name)
        if not ret then --windows?
            ret = string.match(torch.packageLuaPath('torch'), '(.*)\\')
        end
-       return ret 
+       return ret
    end
    for path in string.gmatch(package.path, "[^;]+") do
       path = string.gsub(path, "%?", name)
@@ -38,7 +38,7 @@ function include(file, depth)
 end
 
 function torch.include(package, file)
-   dofile(torch.packageLuaPath(package) .. '/' .. file) 
+   dofile(torch.packageLuaPath(package) .. '/' .. file)
 end
 
 function torch.class(tname, parenttname)
@@ -51,7 +51,7 @@ function torch.class(tname, parenttname)
       end
       return self
    end
-   
+
    local function factory()
       local self = {}
       torch.setmetatable(self, tname)
@@ -114,8 +114,20 @@ include('FFI.lua')
 include('Tester.lua')
 include('test.lua')
 
+function torch.totable(obj)
+  if torch.isTensor(obj) or torch.isStorage(obj) then
+    return obj:totable()
+  else
+    error("obj must be a Storage or a Tensor")
+  end
+end
+
 function torch.isTensor(obj)
   return type(obj) == 'userdata' and torch.isTypeOf(obj, 'torch.*Tensor')
+end
+
+function torch.isStorage(obj)
+  return type(obj) == 'userdata' and torch.isTypeOf(obj, 'torch.*Storage')
 end
 -- alias for convenience
 torch.Tensor.isTensor = torch.isTensor

--- a/test/test.lua
+++ b/test/test.lua
@@ -1536,7 +1536,7 @@ function torchtest.indexCopy()
       dest2[idx[i]]:copy(src[i])
    end
    mytester:assertTensorEq(dest, dest2, 0.000001, "indexCopy tensor error")
-   
+
    local dest = torch.randn(nDest)
    local src = torch.randn(nCopy)
    local idx = torch.randperm(nDest):narrow(1, 1, nCopy):long()
@@ -1616,6 +1616,12 @@ function torchtest.isTensor()
    mytester:assert(torch.isTensor(t[1]), 'error in isTensor for subTensor')
    mytester:assert(not torch.isTensor(t[1][2]), 'false positive in isTensor')
    mytester:assert(torch.Tensor.isTensor(t), 'alias not working')
+end
+
+function torchtest.isStorage()
+  local t = torch.randn(3,4)
+  mytester:assert(torch.isStorage(t:storage()), 'error in isStorage')
+  mytester:assert(not torch.isStorage(t), 'false positive in isStorage')
 end
 
 function torchtest.view()
@@ -1726,6 +1732,27 @@ function torchtest.chunk()
       mytester:assertTensorEq(tensor:narrow(dim, start, targetSize[i][dim]), split, 0.000001, 'Result content error in chunk '..i)
       start = start + targetSize[i][dim]
    end
+end
+
+function torchtest.totable()
+  local table1D = {1, 2, 3}
+  local tensor1D = torch.Tensor(table1D)
+  local storage = torch.Storage(table1D)
+  mytester:assertTableEq(tensor1D:totable(), table1D, 'tensor1D:totable incorrect')
+  mytester:assertTableEq(storage:totable(), table1D, 'storage:totable incorrect')
+  mytester:assertTableEq(torch.totable(tensor1D), table1D, 'torch.totable incorrect for Tensors')
+  mytester:assertTableEq(torch.totable(storage), table1D, 'torch.totable incorrect for Storages')
+
+  local table2D = {{1, 2}, {3, 4}}
+  local tensor2D = torch.Tensor(table2D)
+  mytester:assertTableEq(tensor2D:totable(), table2D, 'tensor2D:totable incorrect')
+
+  local tensor3D = torch.Tensor({{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}})
+  local tensorNonContig = tensor3D:select(2, 2)
+  mytester:assert(not tensorNonContig:isContiguous(), 'invalid test')
+  mytester:assertTableEq(tensorNonContig:totable(), {{3, 4}, {7, 8}},
+                         'totable() incorrect for non-contiguous tensors')
+
 end
 
 function torch.test(tests)


### PR DESCRIPTION
* Currently, you can convert a Storage to a lua table with `storage:totable()`. This patch adds the same functionality to Tensors: `tensor:totable()`. Multidimensional tensors give nested tables of equal shape to the source tensor.

* Add general function for storages and tensors: `torch.totable(...)`.

* Added `torch.isStorage` function.