### PR TITLE
Add batch matrix-matrix multiplication with accumulation.

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -351,9 +351,10 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
      )
 
    for _,f in ipairs({
-                        {name="addmv", dim1=1, dim2=2, dim3=1},
-                        {name="addmm", dim1=2, dim2=2, dim3=2},
-                        {name="addr",  dim1=2, dim2=1, dim3=1},
+                        {name="addmv",  dim1=1, dim2=2, dim3=1},
+                        {name="addmm",  dim1=2, dim2=2, dim3=2},
+                        {name="addr",   dim1=2, dim2=1, dim3=1},
+                        {name="baddmm", dim1=2, dim2=3, dim3=3},
                      }
                   ) do
 

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -63,7 +63,7 @@ end
 <a name="torch.cat"/>
 ### [res] torch.cat( [res,] x_1, x_2, [dimension] ) ###
 <a name="torch.cat"/>
-`x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors x_1 and x_2 along dimension `dimension`. 
+`x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors x_1 and x_2 along dimension `dimension`.
 
 If `dimension` is not specified it is the last dimension.
 
@@ -128,7 +128,7 @@ Examples:
 with elements constructed from the diagonal of x.
 
 `y=torch.diag(x,k)` returns the k-th diagonal of x,
-wher k=0 is the main diagonal, k>0 is above the main diagonal and k<0 
+wher k=0 is the main diagonal, k>0 is above the main diagonal and k<0
 is below the main diagonal.
 
 <a name="torch.eye"/>
@@ -162,21 +162,21 @@ is below the main diagonal.
 <a name="torch.multinomial"/>
 
 `y=torch.multinomial(p,n)` returns a tensor `y` where each row contains
-`n` indices sampled __with replacement__ (`flag=true`) from the 
+`n` indices sampled __with replacement__ (`flag=true`) from the
 [multinomial probability distribution](http://en.wikipedia.org/wiki/Multinomial_distribution)
-located in the corresponding row of tensor `p`. 
+located in the corresponding row of tensor `p`.
 
-The rows of `p` need not sum to one (in which case we use the values as weights), 
-but should be non-negative and have a non-zero sum. 
-Indices are ordered from left to right according to 
-when each was sampled (first samples are placed in first column). 
+The rows of `p` need not sum to one (in which case we use the values as weights),
+but should be non-negative and have a non-zero sum.
+Indices are ordered from left to right according to
+when each was sampled (first samples are placed in first column).
 
 If `p` is an `MxN` matrix, `y` is an `Mxn` matrix.
 
 If `p` is a vector of size `M`, `y` is a vector size `n`.
 
 `y=torch.multinomial(p,n,false)` is like the above, except samples are drawn
-__without replacement__. In other words, when a sample index is drawn for a row, it 
+__without replacement__. In other words, when a sample index is drawn for a row, it
 cannot be drawn again for that row. This implies the constraint `n <= N`.
 
 <a name="torch.ones"/>
@@ -261,7 +261,7 @@ For more than 4 dimensions, you can use a storage:
 
 `y=torch.tril(x)` returns the lower triangular part of x, the other elements of y are set to 0.
 
-`torch.tril(x,k)` returns the elements on and below the k-th diagonal of x as non-zero.   k=0 is the main diagonal, k>0 is above the main diagonal and k<0 
+`torch.tril(x,k)` returns the elements on and below the k-th diagonal of x as non-zero.   k=0 is the main diagonal, k>0 is above the main diagonal and k<0
 is below the main diagonal.
 
 <a name="torch.triu"/>
@@ -271,7 +271,7 @@ is below the main diagonal.
 `y=torch.triu(x)` returns the upper triangular part of x,
 the other elements of y are set to 0.
 
-`torch.triu(x,k)` returns the elements on and above the k-th diagonal of x as non-zero.   k=0 is the main diagonal, k>0 is above the main diagonal and k<0 
+`torch.triu(x,k)` returns the elements on and above the k-th diagonal of x as non-zero.   k=0 is the main diagonal, k>0 is above the main diagonal and k<0
 is below the main diagonal.
 
 <a name="torch.zeros"/>
@@ -638,7 +638,7 @@ number of elements must match, but sizes do not matter.
 
 ```
 > x = torch.Tensor(2,2):fill(1)
-> y = torch.Tensor(4)        
+> y = torch.Tensor(4)
 > for i=1,4 do y[i] = i end
 > x:cdiv(y)
 > = x
@@ -660,8 +660,8 @@ number of elements must match, but sizes do not matter.
 ### [res] torch.addcdiv([res,] x [,value], tensor1, tensor2) ###
 <a name="torch.addcdiv"/>
 
-Performs the element-wise division of `tensor1` by `tensor1`, 
-multiply the result by the scalar `value` and add it to `x`. 
+Performs the element-wise division of `tensor1` by `tensor1`,
+multiply the result by the scalar `value` and add it to `x`.
 The number of elements must match, but sizes do not matter.
 
 ```
@@ -736,7 +736,7 @@ be a vector of size `n`.
 
 `r:addmv(x,y,z)` puts the result of `x+y*z` into `r`.
 
-Optional values `v1` and `v2` are scalars that multiply 
+Optional values `v1` and `v2` are scalars that multiply
 `vec1` and `mat*vec2` respectively.
 
 <a name="torch.addr"/>
@@ -750,11 +750,11 @@ In other words,
 res_ij = v1 * mat_ij + v2 * vec1_i * vec2_j
 ```
 
-If `vec1` is a vector of size `n` and `vec2` is a vector of size `m`, 
+If `vec1` is a vector of size `n` and `vec2` is a vector of size `m`,
 then mat must be a matrix of size `n x m`.
 
 ```
-> x = torch.Tensor(3)        
+> x = torch.Tensor(3)
 > y = torch.Tensor(2)
 > for i=1,3 do x[i] = i end
 > for i=1,2 do y[i] = i end
@@ -776,7 +776,7 @@ then mat must be a matrix of size `n x m`.
 
 `r:addr(M,x,y)` puts the result in `r`.
 
-Optional values `v1` and `v2` are scalars that multiply 
+Optional values `v1` and `v2` are scalars that multiply
 `M` and `vec1 [out] vec2` respectively.
 
 
@@ -791,7 +791,7 @@ and `mat2` (2D tensor). In other words,
 res = v1 * M + v2 * mat1*mat2
 ```
 
-If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix, 
+If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
 `M` must be a `n x p` matrix.
 
 `torch.addmm(M,mat1,mat2)` returns the result in a new tensor.
@@ -802,15 +802,30 @@ If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
 
 `r:addmm(M,mat1,mat2)` puts the result in `r`.
 
-Optional values `v1` and `v2` are scalars that multiply 
+Optional values `v1` and `v2` are scalars that multiply
 `M` and `mat1 * mat2` respectively.
+
+<a name="torch.baddmm"/>
+### [res] torch.baddmm([res,] [v1,] M [v2,] mat1, mat2) ###
+<a name="torch.baddmm"/>
+
+Batch matrix matrix product of matrices stored in `batch1` and `batch2`.
+`batch1` and `batch2` must be 3D tensors each containing the same number
+of matrices. If `batch1` is a `b x n x m` tensor, `batch2` a `b x m x p`
+tensor, res will be a `n x p` tensor.
+
+`torch.baddmm(M,x,y)` puts the result in a new tensor.
+
+`M:baddmm(x,y)` puts the result in `M`, resizing `M` if necessary.
+
+`M:baddmm(beta,M2,alpha,x,y)` puts the result in `M`, resizing `M` if necessary.
 
 <a name="torch.mv"/>
 ### [res] torch.mv([res,] mat, vec) ###
 <a name="torch.mv"/>
 
-Matrix vector product of `mat` and `vec`. Sizes must respect 
-the matrix-multiplication operation: if `mat` is a `n x m` matrix, 
+Matrix vector product of `mat` and `vec`. Sizes must respect
+the matrix-multiplication operation: if `mat` is a `n x m` matrix,
 `vec` must be vector of size `m` and res must be a vector of size `n`.
 
 `torch.mv(x,y)` puts the result in a new tensor.
@@ -823,8 +838,8 @@ the matrix-multiplication operation: if `mat` is a `n x m` matrix,
 ### [res] torch.mm([res,] mat1, mat2) ###
 <a name="torch.mm"/>
 
-Matrix matrix product of `mat1` and `mat2`. If `mat1` is a 
-`n x m` matrix, `mat2` a `m x p` matrix, res must be a 
+Matrix matrix product of `mat1` and `mat2`. If `mat1` is a
+`n x m` matrix, `mat2` a `m x p` matrix, res must be a
 `n x p` matrix.
 
 
@@ -854,8 +869,8 @@ tensor, res will be a `b x n x p` tensor.
 ### [res] torch.ger([res,] vec1, vec2) ###
 <a name="torch.ger"/>
 
-Outer product of `vec1` and `vec2`. If `vec1` is a vector of 
-size `n` and `vec2` is a vector of size `m`, then res must 
+Outer product of `vec1` and `vec2`. If `vec1` is a vector of
+size `n` and `vec2` is a vector of size `m`, then res must
 be a matrix of size `n x m`.
 
 
@@ -982,13 +997,13 @@ Example:
 ### [res] torch.cross([res,] a, b [,n]) ###
 
 `y=torch.cross(a,b)` returns the cross product of the tensors a and b.
-a and b must be 3 element vectors. 
+a and b must be 3 element vectors.
 
 `y=cross(a,b)` returns the cross product of a and b along the first dimension of length 3.
 
 `y=cross(a,b,n)`, where a and b returns the cross
-product of vectors in dimension n of a and b. 
-a and b must have the same size, 
+product of vectors in dimension n of a and b.
+a and b must have the same size,
 and both `a:size(n)` and `b:size(n)` must be 3.
 
 
@@ -1029,7 +1044,7 @@ of `x`, performing the operation over dimension `n`.
 
 `y=torch.mean(x)` returns the mean of all elements of `x`.
 
-`y=torch.mean(x,1)` returns a tensor `y` of the mean of the elements in 
+`y=torch.mean(x,1)` returns a tensor `y` of the mean of the elements in
 each column of `x`.
 
 `y=torch.mean(x,2)` performs the mean operation for each row and
@@ -1053,7 +1068,7 @@ each column of `x`.
 <a name="torch.prod"/>
 ### [res] torch.prod([res,] x [,n]) ###
 
-`y=torch.prod(x)` returns a tensor `y` of the product of all elements in `x`. 
+`y=torch.prod(x)` returns a tensor `y` of the product of all elements in `x`.
 
 `y=torch.prod(x,2)` performs the prod operation for each row and
 
@@ -1111,9 +1126,9 @@ a specific dimension `d`, in __descending__ order.
 <a name="torch.norm"/>
 ### torch.norm(x) ###
 
-`y=torch.norm(x)` returns the 2-norm of the tensor `x`. 
+`y=torch.norm(x)` returns the 2-norm of the tensor `x`.
 
-`y=torch.norm(x,p)` returns the `p`-norm of the tensor `x`. 
+`y=torch.norm(x,p)` returns the `p`-norm of the tensor `x`.
 
 `y=torch.norm(x,p,dim)` returns the `p`-norms of the tensor `x` computed over the dimension dim.
 
@@ -1121,9 +1136,9 @@ a specific dimension `d`, in __descending__ order.
 ### torch.renorm([res], x, p, dim, maxnorm) ###
 Renormalizes the sub-tensors along dimension `dim` such that they do not exceed norm `maxnorm`.
 
-`y=torch.renorm(x,p,dim,maxnorm)` returns a version of `x` with `p`-norms lower than `maxnorm` over non-`dim` dimensions. 
-The `dim` argument is not to be confused with the argument of the same name in function [norm](#torch.norm). 
-In this case, the `p`-norm is measured for each `i`-th sub-tensor `x:select(dim, i)`. This function is 
+`y=torch.renorm(x,p,dim,maxnorm)` returns a version of `x` with `p`-norms lower than `maxnorm` over non-`dim` dimensions.
+The `dim` argument is not to be confused with the argument of the same name in function [norm](#torch.norm).
+In this case, the `p`-norm is measured for each `i`-th sub-tensor `x:select(dim, i)`. This function is
 equivalent to (but faster than) the following:
 ```lua
 function renorm(matrix, value, dim, maxnorm)
@@ -1148,9 +1163,9 @@ Note: this function is particularly useful as a regularizer for constraining the
 <a name="torch.dist"/>
 ### torch.dist(x,y) ###
 
-`y=torch.dist(x,y)` returns the 2-norm of `(x-y)`. 
+`y=torch.dist(x,y)` returns the 2-norm of `(x-y)`.
 
-`y=torch.dist(x,y,p)` returns the `p`-norm of `(x-y)`. 
+`y=torch.dist(x,y,p)` returns the `p`-norm of `(x-y)`.
 
 <a name="torch.numel"/>
 ### torch.numel(x) ###
@@ -1160,7 +1175,7 @@ Note: this function is particularly useful as a regularizer for constraining the
 <a name="torch.trace"/>
 ### torch.trace(x) ###
 
-`y=torch.trace(x)` returns the trace (sum of the diagonal elements) 
+`y=torch.trace(x)` returns the trace (sum of the diagonal elements)
 of a matrix `x`. This is  equal  to the sum of the eigenvalues of `x`.
 The returned value `y` is a number, not a tensor.
 
@@ -1355,8 +1370,8 @@ b=torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
 [torch.DoubleTensor of dimension 6x2]
 
 x = torch.gels(b,a)
-=x 
- -0.4506   0.2497 
+=x
+ -0.4506   0.2497
  -0.8492  -0.9020
   0.7066   0.6323
   0.1289   0.1351
@@ -1446,7 +1461,7 @@ e,v = torch.symeig(a,'V')
 
 Eigen values and eigen vectors of a general real matrix ` A ` of
 size ` m x m `. This function calculates all right eigenvalues (and
-vectors) of ` A ` such that ` A = V' diag(e) V `. 
+vectors) of ` A ` such that ` A = V' diag(e) V `.
 
 Third argument defines computation of eigenvectors or eigenvalues
 only. If ` N `, only eignevalues are computed. If ` V `, both

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -635,11 +635,10 @@ void THTensor_(bmm)(THTensor *result, THTensor *batch1, THTensor *batch2)
   THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
              "wrong matrix size");
 
-  THLongStorage* result_size = THLongStorage_newWithSize3(THTensor_(size)(batch1, 0),
-                                                          THTensor_(size)(batch1, 1),
-                                                          THTensor_(size)(batch2, 2));
-  THTensor_(resize)(result, result_size, NULL);
-  THLongStorage_free(result_size);
+  long bs = THTensor_(size)(batch1, 0);
+  long dim1 = THTensor_(size)(batch1, 1);
+  long dim2 = THTensor_(size)(batch2, 2);
+  THTensor_(resize3d)(result, bs, dim1, dim2);
 
   for (batch = 0; batch < THTensor_(size)(batch1, 0); ++batch) {
     THTensor *matrix1 = THTensor_(newWithTensor)(batch1);
@@ -655,6 +654,42 @@ void THTensor_(bmm)(THTensor *result, THTensor *batch1, THTensor *batch2)
     THTensor_(free)(matrix1);
     THTensor_(free)(matrix2);
     THTensor_(free)(result_matrix);
+  }
+}
+
+void THTensor_(baddmm)(THTensor *result, real beta, THTensor *t, real alpha, THTensor *batch1, THTensor *batch2)
+{
+  long batch;
+
+  THArgCheck(THTensor_(nDimension)(batch1) == 3, 1, "expected 3D tensor");
+  THArgCheck(THTensor_(nDimension)(batch2) == 3, 2, "expected 3D tensor");
+  THArgCheck(THTensor_(size)(batch1, 0) == THTensor_(size)(batch2, 0), 2,
+             "equal number of batches expected");
+  THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
+             "wrong matrix size");
+
+  long dim1 = THTensor_(size)(batch1, 1);
+  long dim2 = THTensor_(size)(batch2, 2);
+  THArgCheck(THTensor_(size)(t, 0) == dim1, 1, "output tensor of incorrect size");
+  THArgCheck(THTensor_(size)(t, 1) == dim2, 1, "output tensor of incorrect size");
+
+  if (t != result) {
+    THTensor_(resizeAs)(result, t);
+    THTensor_(copy)(result, t);
+  }
+
+  for (batch = 0; batch < THTensor_(size)(batch1, 0); ++batch) {
+    THTensor *matrix1 = THTensor_(newWithTensor)(batch1);
+    THTensor *matrix2 = THTensor_(newWithTensor)(batch2);
+
+    THTensor_(select)(matrix1, NULL, 0, batch);
+    THTensor_(select)(matrix2, NULL, 0, batch);
+
+    THTensor_(addmm)(result, beta, result, alpha, matrix1, matrix2);
+    beta = 1; // accumulate output once
+
+    THTensor_(free)(matrix1);
+    THTensor_(free)(matrix2);
   }
 }
 

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -38,6 +38,7 @@ TH_API void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, T
 TH_API void THTensor_(addr)(THTensor *r_,  real beta, THTensor *t, real alpha, THTensor *vec1, THTensor *vec2);
 
 TH_API void THTensor_(bmm)(THTensor *r_,  THTensor *batch1, THTensor *batch2);
+TH_API void THTensor_(baddmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *batch1, THTensor *batch2);
 
 TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain);
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -461,16 +461,46 @@ function torchtest.div()
 end
 
 function torchtest.bmm()
-  local num_batches = 10
-  local M, N, O = 23, 8, 12
-  local b1 = torch.randn(num_batches, M, N)
-  local b2 = torch.randn(num_batches, N, O)
-  local res = torch.bmm(b1, b2)
+   local num_batches = 10
+   local M, N, O = 23, 8, 12
+   local b1 = torch.randn(num_batches, M, N)
+   local b2 = torch.randn(num_batches, N, O)
+   local res = torch.bmm(b1, b2)
 
-  for i = 1, num_batches do
-    local r = torch.mm(b1[i], b2[i])
-    mytester:assertTensorEq(r, res[i], precision, 'result matrix ' .. i .. ' wrong')
-  end
+   for i = 1, num_batches do
+     local r = torch.mm(b1[i], b2[i])
+     mytester:assertTensorEq(r, res[i], precision, 'result matrix ' .. i .. ' wrong')
+   end
+end
+
+function torchtest.baddmm()
+   local num_batches = 10
+   local M, N, O = 12, 8, 5
+   local b1 = torch.randn(num_batches, M, N)
+   local b2 = torch.randn(num_batches, N, O)
+   local res = torch.bmm(b1, b2)
+   local res2 = torch.Tensor():resizeAs(res[1]):zero()
+
+   res2:baddmm(b1,b2)
+   mytester:assertTensorEq(res2, res:sum(1), precision, 'baddmm result wrong')
+
+   res2:baddmm(1,b1,b2)
+   mytester:assertTensorEq(res2, res:sum(1)*2, precision, 'baddmm result wrong')
+
+   res2:baddmm(1,res2,.5,b1,b2)
+   mytester:assertTensorEq(res2, res:sum(1)*2.5, precision, 'baddmm result wrong')
+
+   local res3 = torch.baddmm(1,res2,0,b1,b2)
+   mytester:assertTensorEq(res3, res2, precision, 'baddmm result wrong')
+
+   local res4 = torch.baddmm(1,res2,.5,b1,b2)
+   mytester:assertTensorEq(res4, res:sum(1)*3, precision, 'baddmm result wrong')
+
+   local res5 = torch.baddmm(0,res2,1,b1,b2)
+   mytester:assertTensorEq(res5, res:sum(1), precision, 'baddmm result wrong')
+
+   local res6 = torch.baddmm(.1,res2,.5,b1,b2)
+   mytester:assertTensorEq(res6, res2*.1 + res:sum(1)*.5, precision, 'baddmm result wrong')
 end
 
 function torchtest.clamp()


### PR DESCRIPTION
- behavior is similar to torch.addmm, except that both input
  matrices have an additional dimension, as in torch.bmm
- tests cover all use cases