### PR TITLE
Add batch matrix-matrix multiplication with accumulation.

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -351,9 +351,10 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
      )
 
    for _,f in ipairs({
-                        {name="addmv", dim1=1, dim2=2, dim3=1},
-                        {name="addmm", dim1=2, dim2=2, dim3=2},
-                        {name="addr",  dim1=2, dim2=1, dim3=1},
+                        {name="addmv",  dim1=1, dim2=2, dim3=1},
+                        {name="addmm",  dim1=2, dim2=2, dim3=2},
+                        {name="addr",   dim1=2, dim2=1, dim3=1},
+                        {name="baddmm", dim1=2, dim2=3, dim3=3},
                      }
                   ) do
 

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -809,6 +809,21 @@ If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
 Optional values `v1` and `v2` are scalars that multiply 
 `M` and `mat1 * mat2` respectively.
 
+<a name="torch.baddmm"/>
+### [res] torch.baddmm([res,] [v1,] M [v2,] mat1, mat2) ###
+<a name="torch.baddmm"/>
+
+Batch matrix matrix product of matrices stored in `batch1` and `batch2`.
+`batch1` and `batch2` must be 3D tensors each containing the same number
+of matrices. If `batch1` is a `b x n x m` tensor, `batch2` a `b x m x p`
+tensor, res will be a `n x p` tensor.
+
+`torch.baddmm(M,x,y)` puts the result in a new tensor.
+
+`M:baddmm(x,y)` puts the result in `M`, resizing `M` if necessary.
+
+`M:baddmm(beta,M2,alpha,x,y)` puts the result in `M`, resizing `M` if necessary.
+
 <a name="torch.mv"/>
 ### [res] torch.mv([res,] mat, vec) ###
 <a name="torch.mv"/>

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -38,6 +38,7 @@ TH_API void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, T
 TH_API void THTensor_(addr)(THTensor *r_,  real beta, THTensor *t, real alpha, THTensor *vec1, THTensor *vec2);
 
 TH_API void THTensor_(bmm)(THTensor *r_,  THTensor *batch1, THTensor *batch2);
+TH_API void THTensor_(baddmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *batch1, THTensor *batch2);
 
 TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain);
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -461,16 +461,46 @@ function torchtest.div()
 end
 
 function torchtest.bmm()
-  local num_batches = 10
-  local M, N, O = 23, 8, 12
-  local b1 = torch.randn(num_batches, M, N)
-  local b2 = torch.randn(num_batches, N, O)
-  local res = torch.bmm(b1, b2)
+   local num_batches = 10
+   local M, N, O = 23, 8, 12
+   local b1 = torch.randn(num_batches, M, N)
+   local b2 = torch.randn(num_batches, N, O)
+   local res = torch.bmm(b1, b2)
 
-  for i = 1, num_batches do
-    local r = torch.mm(b1[i], b2[i])
-    mytester:assertTensorEq(r, res[i], precision, 'result matrix ' .. i .. ' wrong')
-  end
+   for i = 1, num_batches do
+     local r = torch.mm(b1[i], b2[i])
+     mytester:assertTensorEq(r, res[i], precision, 'result matrix ' .. i .. ' wrong')
+   end
+end
+
+function torchtest.baddmm()
+   local num_batches = 10
+   local M, N, O = 12, 8, 5
+   local b1 = torch.randn(num_batches, M, N)
+   local b2 = torch.randn(num_batches, N, O)
+   local res = torch.bmm(b1, b2)
+   local res2 = torch.Tensor():resizeAs(res[1]):zero()
+
+   res2:baddmm(b1,b2)
+   mytester:assertTensorEq(res2, res:sum(1), precision, 'baddmm result wrong')
+
+   res2:baddmm(1,b1,b2)
+   mytester:assertTensorEq(res2, res:sum(1)*2, precision, 'baddmm result wrong')
+
+   res2:baddmm(1,res2,.5,b1,b2)
+   mytester:assertTensorEq(res2, res:sum(1)*2.5, precision, 'baddmm result wrong')
+
+   local res3 = torch.baddmm(1,res2,0,b1,b2)
+   mytester:assertTensorEq(res3, res2, precision, 'baddmm result wrong')
+
+   local res4 = torch.baddmm(1,res2,.5,b1,b2)
+   mytester:assertTensorEq(res4, res:sum(1)*3, precision, 'baddmm result wrong')
+
+   local res5 = torch.baddmm(0,res2,1,b1,b2)
+   mytester:assertTensorEq(res5, res:sum(1), precision, 'baddmm result wrong')
+
+   local res6 = torch.baddmm(.1,res2,.5,b1,b2)
+   mytester:assertTensorEq(res6, res2*.1 + res:sum(1)*.5, precision, 'baddmm result wrong')
 end
 
 function torchtest.clamp()


### PR DESCRIPTION
- behavior is similar to torch.addmm, except that both input
  matrices have an additional dimension, as in torch.bmm
- tests cover all use cases