### PR TITLE
Substitute ~ for user home dir in File.load and File.save

### DIFF
--- a/File.lua
+++ b/File.lua
@@ -258,6 +258,7 @@ end
 -- simple helpers to save/load arbitrary objects/tables
 function torch.save(filename, object, mode)
    mode = mode or 'binary'
+   local filename = filename:gsub('~',os.getenv('HOME'))
    local file = torch.DiskFile(filename, 'w')
    file[mode](file)
    file:writeObject(object)
@@ -266,6 +267,7 @@ end
 
 function torch.load(filename, mode)
    mode = mode or 'binary'
+   local filename = filename:gsub('~',os.getenv('HOME'))
    local file = torch.DiskFile(filename, 'r')
    file[mode](file)
    local object = file:readObject()


### PR DESCRIPTION
Really miss this in torch. Let's say you use th and type ```torch.load '~/Docume..'``` and it autocompletes the path for you, but can't save or load after!