### PR TITLE
Permute

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -525,6 +525,25 @@ function Tensor.totable(tensor)
   return result
 end
 
+function Tensor.permute(tensor, ...)
+  local perm = {...}
+  local nDims = tensor:dim()
+  assert(#perm == nDims, 'Invalid permutation')
+  local j
+  for i, p in ipairs(perm) do
+    if p ~= i and p ~= 0 then
+      j = i
+      repeat
+        assert(0 < perm[j] and perm[j] <= nDims, 'Invalid permutation')
+        tensor = tensor:transpose(j, perm[j])
+        j, perm[j] = perm[j], 0
+      until perm[j] == i
+      perm[j] = j
+    end
+  end
+  return tensor
+end
+
 for _,type in ipairs(types) do
    local metatable = torch.getmetatable('torch.' .. type .. 'Tensor')
    for funcname, func in pairs(Tensor) do

--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -1667,6 +1667,37 @@ tensors. The given tensor must be 2 dimensional. Swap dimensions 1 and 2.
 [torch.DoubleTensor of dimension 3x4]
 ```
 
+
+<a name="torch.Tensor.permute"/>
+### [Tensor] permute(dim1, dim2, ..., dimn) ###
+
+Generalizes the function [transpose()](#torch.Tensor.transpose) and can be used
+as a convenience method replacing a sequence of transpose() calls.
+Returns a tensor where the dimensions were permuted according to the permutation
+given by (dim1, dim2, ... , dimn). The permutation must be specified fully, i.e.
+there must be as many parameters as the tensor has dimensions.
+```lua
+> x = torch.Tensor(3,4,2,5)
+> print(x:size())
+
+ 3
+ 4
+ 2
+ 5
+[torch.LongStorage of size 4]
+
+t7> y = x:permute(2,3,1,4) -- equivalent to y = x:transpose(1,3):transpose(1,2)
+t7> print(y:size())
+
+ 4
+ 2
+ 3
+ 5
+[torch.LongStorage of size 4]
+
+```
+
+
 <a name="torch.Tensor.unfold"/>
 ### [Tensor] unfold(dim, size, step) ###
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1856,7 +1856,15 @@ function torchtest.totable()
   mytester:assert(not tensorNonContig:isContiguous(), 'invalid test')
   mytester:assertTableEq(tensorNonContig:totable(), {{3, 4}, {7, 8}},
                          'totable() incorrect for non-contiguous tensors')
+end
 
+function torchtest.permute()
+  local orig = {1,2,3,4,5,6,7}
+  local perm = torch.randperm(7):totable()
+  local x = torch.Tensor(unpack(orig)):fill(0)
+  local new = x:permute(unpack(perm)):size():totable()
+  mytester:assertTableEq(perm, new, 'Tensor:permute incorrect')
+  mytester:assertTableEq(x:size():totable(), orig, 'Tensor:permute changes tensor')
 end
 
 function torch.test(tests)


### PR DESCRIPTION
Added Tensor.permute convenience function to replace sequences of transpose() calls by a more succinct and less error-prone notation x:permute(a1, a2, ...), where a full permutation (a1, a2, ... , aN) is specified for the N dimensions of a tensor.
