### PR TITLE
Fixed getRNGState in uninitialized case

### DIFF
--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -219,6 +219,8 @@ TH_API void THTensor_(getRNGState)(THGenerator *_generator, THTensor *self)
   THArgCheck(THTensor_(nElement)(self) == size, 1, "RNG state is wrong size");
   THArgCheck(THTensor_(isContiguous)(self), 1, "RNG state needs to be contiguous");
   rng_state = (THGenerator *)THTensor_(data)(self);
+  if(_generator->initf == 0)
+    THRandom_seed(_generator);
   THGenerator_copy(rng_state, _generator);
 }
 


### PR DESCRIPTION
Previously, getRNGState would return an invalid state if called before any random function call. This would mean that

> require 'torch'
> s = torch.getRNGState()
> =torch.uniform()
0.9989492399618
> torch.setRNGState(s)
> = torch.uniform()
0.046927026240155 -- different result from before, though the state is supposedly the same!!

