### PR TITLE
Make sure RNG is always seeded

### DIFF
--- a/doc/random.md
+++ b/doc/random.md
@@ -8,15 +8,15 @@ random number generator.
 <a name=":torch.seed.dok"/>
 ## Seed Handling ##
 
-If no seed is provided to the random generator (using
-[seed()](#torch.seed) or [manualSeed()](#torch.manualSeed)), a
-random seed will be set according to [seed()](#torch.seed) the first
-time a random number is generated.
+The random number generator is provided with a random seed via 
+[seed()](#torch.seed) when torch is being initialised. It can be 
+reinitialized using
+[seed()](#torch.seed) or [manualSeed()](#torch.manualSeed). 
 
 Initial seed can be obtained using [initialSeed()](#torch.initialSeed).
 
-Setting a particular seed allows the user to (re)-generate a particular serie of
-random numbers. Example:
+Setting a particular seed allows the user to (re)-generate a particular sequence
+of random numbers. Example:
 ```
 > torch.manualSeed(123)
 > = torch.uniform()
@@ -44,8 +44,9 @@ random numbers. Example:
 <a name="torch.seed"/>
 ### [number] seed() ###
 
-Set the seed of the random number generator according to the time of the
-computer. Granularity is seconds. Returns the seed obtained.
+Set the seed of the random number generator using `/dev/urandom`
+(on Windows the time of the computer with granularity of seconds is used).
+Returns the seed obtained.
 
 <a name="torch.manualSeed"/>
 ### manualSeed(number) ###

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -219,8 +219,6 @@ TH_API void THTensor_(getRNGState)(THGenerator *_generator, THTensor *self)
   THArgCheck(THTensor_(nElement)(self) == size, 1, "RNG state is wrong size");
   THArgCheck(THTensor_(isContiguous)(self), 1, "RNG state needs to be contiguous");
   rng_state = (THGenerator *)THTensor_(data)(self);
-  if(_generator->initf == 0)
-    THRandom_seed(_generator);
   THGenerator_copy(rng_state, _generator);
 }
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1523,7 +1523,6 @@ function torchtest.BugInAssertTableEq()
 end
 
 function torchtest.RNGState()
-   local ignored = torch.rand(1000)
    local state = torch.getRNGState()
    local stateCloned = state:clone()
    local before = torch.rand(1000)


### PR DESCRIPTION
The current way the torch RNG is initialized  (THGenerator_new) creates an invalid (unseeded) first RNG state, which is then lazily seeded in a number of functions depending on a valid state. This is error prone (as was seen previously, where getRNGState would potentially return an invalid state). 

I suggest a minor refactor (thanks to @timharley for the suggestion): THGenerator_newUnseeded is provided as a static function in THRandom.c, so that THRandom_manualSeed which does not need a seeded generator can still obtain an unseeded one. On the other hand, THGenerator_new is changed to always return a seeded generator, so that unseeded generators never leak outside of THRandom.c. The lazy seeding is removed from all places where this was previously needed.

Further, THRandom_getState and _setState are removed (their use from within getRNGState and setRNGState has been removed a while ago and they seem deprecated). 

@koraykv 
