### PR TITLE
Make bmm use baddbmm.

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -278,15 +278,8 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                         string.format("TH%s_resize1d(%s, %s->size[0]);", Tensor, arg:carg(), arg.args[5]:carg())
                      }, '\n')
                end,
-          precall=function(arg)
-                     return table.concat(
-                        {
-                           string.format("TH%s_zero(%s);", Tensor, arg:carg()),
-                           arg.__metatable.precall(arg)
-                        }, '\n')
-                  end
        },
-         {name=real, default=1, invisible=true},
+         {name=real, default=0, invisible=true},
          {name=Tensor, default=1, invisible=true},
          {name=real, default=1, invisible=true},
          {name=Tensor, dim=2},
@@ -303,15 +296,8 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                         string.format("TH%s_resize2d(%s, %s->size[0], %s->size[1]);", Tensor, arg:carg(), arg.args[5]:carg(), arg.args[6]:carg())
                      }, '\n')
                end,
-          precall=function(arg)
-                     return table.concat(
-                        {
-                           string.format("TH%s_zero(%s);", Tensor, arg:carg()),
-                           arg.__metatable.precall(arg)
-                        }, '\n')
-                  end
        },
-         {name=real, default=1, invisible=true},
+         {name=real, default=0, invisible=true},
          {name=Tensor, default=1, invisible=true},
          {name=real, default=1, invisible=true},
          {name=Tensor, dim=2},
@@ -319,8 +305,20 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
      )
 
    wrap("bmm",
-        cname("bmm"),
-        {{name=Tensor, default=true, returned=true},
+        cname("baddbmm"),
+        {{name=Tensor, default=true, returned=true, method={default='nil'},
+          init=function(arg)
+                  return table.concat(
+                     {
+                        arg.__metatable.init(arg),
+                        string.format("TH%s_resize3d(%s, %s->size[0], %s->size[1], %s->size[2]);",
+                                      Tensor, arg:carg(), arg.args[5]:carg(), arg.args[5]:carg(), arg.args[6]:carg())
+                     }, '\n')
+               end,
+       },
+         {name=real, default=0, invisible=true},
+         {name=Tensor, default=1, invisible=true},
+         {name=real, default=1, invisible=true},
          {name=Tensor, dim=3},
          {name=Tensor, dim=3}}
      )

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -640,39 +640,6 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
   }
 }
 
-void THTensor_(bmm)(THTensor *result, THTensor *batch1, THTensor *batch2)
-{
-  long batch;
-
-  THArgCheck(THTensor_(nDimension)(batch1) == 3, 1, "expected 3D tensor");
-  THArgCheck(THTensor_(nDimension)(batch2) == 3, 2, "expected 3D tensor");
-  THArgCheck(THTensor_(size)(batch1, 0) == THTensor_(size)(batch2, 0), 2,
-             "equal number of batches expected");
-  THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
-             "wrong matrix size");
-
-  long bs = THTensor_(size)(batch1, 0);
-  long dim1 = THTensor_(size)(batch1, 1);
-  long dim2 = THTensor_(size)(batch2, 2);
-  THTensor_(resize3d)(result, bs, dim1, dim2);
-
-  THTensor *matrix1 = THTensor_(new)();
-  THTensor *matrix2 = THTensor_(new)();
-  THTensor *result_matrix = THTensor_(new)();
-
-  for (batch = 0; batch < THTensor_(size)(batch1, 0); ++batch) {
-    THTensor_(select)(matrix1, batch1, 0, batch);
-    THTensor_(select)(matrix2, batch2, 0, batch);
-    THTensor_(select)(result_matrix, result, 0, batch);
-
-    THTensor_(addmm)(result_matrix, 0, result_matrix, 1, matrix1, matrix2);
-  }
-
-  THTensor_(free)(matrix1);
-  THTensor_(free)(matrix2);
-  THTensor_(free)(result_matrix);
-}
-
 void THTensor_(addbmm)(THTensor *result, real beta, THTensor *t, real alpha, THTensor *batch1, THTensor *batch2)
 {
   long batch;

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -37,7 +37,6 @@ TH_API void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, T
 TH_API void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *mat1, THTensor *mat2);
 TH_API void THTensor_(addr)(THTensor *r_,  real beta, THTensor *t, real alpha, THTensor *vec1, THTensor *vec2);
 
-TH_API void THTensor_(bmm)(THTensor *r_,  THTensor *batch1, THTensor *batch2);
 TH_API void THTensor_(addbmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *batch1, THTensor *batch2);
 TH_API void THTensor_(baddbmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *batch1, THTensor *batch2);
 


### PR DESCRIPTION
Just like mm uses addmm, we can write bmm in terms of baddbmm. This way the
two behave the same in terms of when the output is resized.

Also gets rid of unnecessary zeroing out of output of mm and mv.