### PR TITLE
Fix parent class validity check

### DIFF
--- a/lib/luaT/luaT.c
+++ b/lib/luaT/luaT.c
@@ -544,8 +544,7 @@ int luaT_lua_newmetatable(lua_State *L)
     else
     {
       const char* parenttname = luaL_checkstring(L, 2);
-      luaT_pushmetatable(L, parenttname);
-      if(lua_isnil(L, -1))
+      if(!luaT_pushmetatable(L, parenttname))
         luaL_error(L, "bad argument #2 (invalid parent class name %s)", parenttname);
       lua_setmetatable(L, -2);
     }


### PR DESCRIPTION
Previously, the existence of the parent class wasn't actually verified, since the return value of luaT_pushmetatable wasn't checked. 
This for instance allowed the following:

my = {}
MyC, p = torch.class('my.class', 'nonexistent.class')
MyC:__init() print('constructor') end

Weird effect:
x = my.class() -- constructor not actually called here! (broken metatable?)