### PR TITLE
Added torch.[de]serialize{To/From}Storage to File.lua.

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -1873,6 +1873,23 @@ function torchtest.permute()
   mytester:assertTableEq(x:size():totable(), orig, 'Tensor:permute changes tensor')
 end
 
+function torchtest.serialize()
+   local tableObj = {6, a = 42}
+   local tensObj = torch.randn(3,4,5)
+
+   -- Test serializing a table
+   local serString = torch.serialize(tableObj)
+   local serStorage = torch.serializeToStorage(tableObj)
+   mytester:assertTableEq(tableObj, torch.deserialize(serString))
+   mytester:assertTableEq(tableObj, torch.deserializeFromStorage(serStorage))
+
+   -- Test serializing a Tensor
+   serString = torch.serialize(tensObj)
+   serStorage = torch.serializeToStorage(tensObj)
+   mytester:assertTensorEq(tensObj, torch.deserialize(serString), 1e-10)
+   mytester:assertTensorEq(tensObj, torch.deserializeFromStorage(serStorage), 1e-10)
+end
+
 function torch.test(tests)
    math.randomseed(os.time())
    if torch.getdefaulttensortype() == 'torch.FloatTensor' then


### PR DESCRIPTION
These match the previous [de]serialize functions, but return
a torch.CharStorage instead of a Lua string. This can be used to
prevent hitting the LuaJIT 2GB limit for very large objects, because the
CharStorage is allocated on the C side (not counting towards this limit)
but the Lua string will count towards this limit.

This modification fixed a repeatable OOM crash I found for trying to
serialize certain large models.