### PR TITLE
maskedCopy,maskedFill,maskedSelect

### DIFF
--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -999,9 +999,9 @@ the sub-tensor will have an impact on the primary tensor, and vice-versa.
 These methods are very fast, as they do not involve any memory copy.
 
 <a name="torch.Tensor.narrow"/>
-### [Tensor] narrow(dim, index, size) ###
+### [self] narrow(dim, index, size) ###
 
-Returns a new `Tensor` which is a narrowed version of the current one: the dimension `dim` is narrowed
+Returns a new Tensor` which is a narrowed version of the current one: the dimension `dim` is narrowed
 from `index` to `index+size-1`.
 
 ```lua
@@ -1156,7 +1156,7 @@ Note that "selecting" on the first dimension is equivalent to use the [[] operat
 [torch.DoubleTensor of dimension 5x6]
 ```
 
-<a name="torch.Tensor.index"/>
+<a name="torch.Tensor.indexing"/>
 ### [Tensor] [{ dim1,dim2,... }] or [{ {dim1s,dim1e}, {dim2s,dim2e} }] ###
 
 The indexing operator [] can be used to combine narrow/sub and
@@ -1231,7 +1231,10 @@ elements, e.g with a [logical operator](maths.md#logical-operations-on-tensors).
 <a name="torch.Tensor.index"/>
 ### [Tensor] index(dim, index) ###
 
-Returns a new `Tensor` which indexes the given tensor along dimension `dim` and using the entries in `torch.LongTensor` `index`. The returned tensor has the same number of dimensions as the original tensor. The returned tensor does __not__ use the same storage as the original tensor -- see below for storing the result in an existing tensor.
+Returns a new Tensor which indexes the given tensor along dimension `dim` 
+and using the entries in `torch.LongTensor` `index`. 
+The returned tensor has the same number of dimensions as the original tensor. 
+The returned tensor does __not__ use the same storage as the original tensor -- see below for storing the result in an existing tensor.
 
 ```lua
 t7> x = torch.rand(5,5)
@@ -1264,7 +1267,10 @@ t7> =x
 
 ```
 
-Note the explicit `index` function is different than the indexing operator `[]`. The indexing operator `[]` is a syntactic shortcut for a series of select and narrow operations, therefore it always returns a new view on the original tensor that shares the same storage. However, the explicit `index` function can not use the same storage.
+Note the explicit `index` function is different than the indexing operator `[]`. 
+The indexing operator `[]` is a syntactic shortcut for a series of select and narrow operations, 
+therefore it always returns a new view on the original tensor that shares the same storage. 
+However, the explicit `index` function can not use the same storage.
 
 It is possible to store the result into an existing Tensor with `result:index(source, ...)`:
 
@@ -1347,6 +1353,114 @@ t7> =x
 [torch.DoubleTensor of dimension 5x5]
 
 ```
+
+<a name="torch.Tensor.maskedSelect"/>
+### [Tensor] maskedSelect(mask) ###
+
+Returns a new Tensor which contains all elements aligned to a `1` in the corresponding
+`mask`. This `mask` is a `torch.ByteTensor` of zeros and ones. The `mask` and 
+`Tensor` must have the same number of elements. The resulting Tensor will 
+be a 1D tensor of the same type as `Tensor` having size `mask:sum()`.
+
+```lua
+t7> x = torch.range(1,12):double():resize(3,4)
+t7> =x
+  1   2   3   4
+  5   6   7   8
+  9  10  11  12
+[torch.DoubleTensor of dimension 3x4]
+
+t7> mask = torch.DoubleTensor():rand(12):mul(2):floor():byte():resize(2,6)
+t7> =mask 
+ 1  0  1  0  0  0
+ 1  1  0  0  0  1
+[torch.ByteTensor of dimension 2x6]
+
+t7> y = x:maskedSelect(mask)
+t7> =y
+  1
+  3
+  7
+  8
+ 12
+[torch.DoubleTensor of dimension 5]
+
+t7> z = torch.DoubleTensor()
+t7> z:maskedSelect(x, mask)
+t7> =z
+  1
+  3
+  7
+  8
+ 12
+```
+
+Note how the dimensions of the above `x`, `mask` and `y' do not match.
+Also note how an existing tensor `z` can be used to store the results.
+
+
+<a name="torch.Tensor.maskedCopy"/>
+### [Tensor] maskedCopy(mask, tensor) ###
+
+Copies the masked elements of `tensor` into itself. The masked elements are those elements having a 
+corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor` 
+of zeros and ones. The `mask`, `tensor` and `Tensor` must have the same number of elements.
+
+```lua
+t7> x = torch.range(1,8):double():resize(2,4)
+t7> =x
+ 1  2  3  4
+ 5  6  7  8
+[torch.DoubleTensor of dimension 2x4]
+
+t7> mask = torch.DoubleTensor():rand(8):mul(2):floor():byte():resize(1,8)
+t7> =mask
+ 1  0  0  1  1  0  0  1
+[torch.ByteTensor of dimension 1x8]
+
+t7> y = x:clone():fill(-1)
+t7> =y
+-1 -1 -1 -1
+-1 -1 -1 -1
+[torch.DoubleTensor of dimension 2x4]
+
+t7> y:maskedCopy(mask, x)
+t7> =y
+ 1 -1 -1  2
+ 3 -1 -1  4
+[torch.DoubleTensor of dimension 2x4]
+```
+
+Note how the dimensions of the above `x`, `mask` and `y' do not match, 
+but the number of elements do.
+
+<a name="torch.Tensor.maskedFill"/>
+### [Tensor] maskedFill(mask, val) ###
+
+Fills the masked elements of itself with value `val`. The masked elements are those elements having a 
+corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor` 
+of zeros and ones. The `mask` and `Tensor` must have the same number of elements.
+
+```lua
+t7> x = torch.range(1,4):double():resize(1,4)
+t7> =x
+ 1  2  3  4
+[torch.DoubleTensor of dimension 1x4]
+
+t7> mask = torch.DoubleTensor():rand(4):mul(2):floor():byte():resize(2,2)
+t7> =mask
+ 0  0
+ 1  1
+[torch.ByteTensor of dimension 2x2]
+
+t7> x:maskedFill(mask, -1)
+t7> =x
+ 1  2 -1 -1
+[torch.DoubleTensor of dimension 1x4]
+
+```
+Note how the dimensions of the above `x` and `mask` do not match, 
+but the number of elements do.
 
 ## Expanding/Replicating/Squeezing Tensors ##
 

--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -456,6 +456,83 @@ static int torch_Tensor_(indexFill)(lua_State *L)
   return 1;
 }
 
+static int torch_Tensor_(maskedSelect)(lua_State *L)
+{
+  int narg = lua_gettop(L);
+  THTensor *tensor, *src;
+  THByteTensor *mask;
+  
+  if (narg == 2)
+  {
+    tensor = THTensor_(new)();
+    src = luaT_checkudata(L, 1, torch_Tensor);
+    mask = luaT_checkudata(L, 2, "torch.ByteTensor");
+    luaT_pushudata(L,tensor,torch_Tensor);
+  }
+  else if(narg == 3)
+  {
+    src = luaT_checkudata(L, 2, torch_Tensor);
+    mask = luaT_checkudata(L, 3, "torch.ByteTensor");
+    tensor = luaT_checkudata(L,1,torch_Tensor);
+    luaT_pushudata(L,tensor,torch_Tensor);
+  }
+  else
+  {
+    luaL_error(L,"Tensor, ByteTensor | Tensor, Tensor, ByteTensor expected");
+    return 0;
+  }
+
+  THTensor_(maskedSelect)(tensor,src,mask);
+
+  return 1;
+}
+
+static int torch_Tensor_(maskedCopy)(lua_State *L)
+{
+  int narg = lua_gettop(L);
+  THTensor *tensor, *src;
+  THByteTensor *mask;
+  
+  if(narg == 3)
+  {
+    mask = luaT_checkudata(L, 2, "torch.ByteTensor");
+    src = luaT_checkudata(L, 3, torch_Tensor);
+    tensor = luaT_checkudata(L,1,torch_Tensor);
+  }
+  else
+  {
+    luaL_error(L,"Tensor, ByteTensor, Tensor expected");
+    return 0;
+  }
+
+  THTensor_(maskedCopy)(tensor,mask,src);
+
+  return 1;
+}
+
+static int torch_Tensor_(maskedFill)(lua_State *L)
+{
+  int narg = lua_gettop(L);
+  THTensor *tensor;
+  THByteTensor *mask;
+  real val;
+  if(narg == 3)
+  {
+    mask = luaT_checkudata(L, 2, "torch.ByteTensor");
+    val = luaL_checknumber(L, 3);
+    tensor = luaT_checkudata(L,1,torch_Tensor);
+  }
+  else
+  {
+    luaL_error(L,"Tensor, ByteTensor, number expected");
+    return 0;
+  }
+
+  THTensor_(maskedFill)(tensor,mask,val);
+
+  return 1;
+}
+
 static int torch_Tensor_(transpose)(lua_State *L)
 {
   THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
@@ -1152,6 +1229,9 @@ static const struct luaL_Reg torch_Tensor_(_) [] = {
   {"index", torch_Tensor_(indexSelect)},
   {"indexCopy", torch_Tensor_(indexCopy)},
   {"indexFill", torch_Tensor_(indexFill)},
+  {"maskedSelect", torch_Tensor_(maskedSelect)},
+  {"maskedCopy", torch_Tensor_(maskedCopy)},
+  {"maskedFill", torch_Tensor_(maskedFill)},
   {"transpose", torch_Tensor_(transpose)},
   {"t", torch_Tensor_(t)},
   {"unfold", torch_Tensor_(unfold)},

--- a/test/test.lua
+++ b/test/test.lua
@@ -1657,6 +1657,53 @@ function torchtest.indexCopy()
    mytester:assertTensorEq(dest, dest2, 0.000001, "indexCopy scalar error")
 end
 
+function torchtest.maskedCopy()
+   local nCopy, nDest = 3, 10
+   local dest = torch.randn(nDest)
+   local src = torch.randn(nCopy)
+   local mask = torch.ByteTensor{0,0,0,0,1,0,1,0,1,0}
+   local dest2 = dest:clone()
+   dest:maskedCopy(mask, src)
+   local j = 1
+   for i=1,nDest do
+      if mask[i] == 1 then
+         dest2[i] = src[j]
+         j = j + 1
+      end
+   end
+   mytester:assertTensorEq(dest, dest2, 0.000001, "maskedCopy error")
+end
+
+function torchtest.maskedSelect()
+   local nSrc = 10
+   local src = torch.randn(nSrc)
+   local mask = torch.rand(nSrc):mul(2):floor():byte()
+   local dst = torch.Tensor()
+   dst:maskedSelect(src, mask)
+   local dst2 = {}
+   for i=1,nSrc do
+      if mask[i] == 1 then
+         table.insert(dst2, src[i])
+      end
+   end
+   mytester:assertTensorEq(dst, torch.DoubleTensor(dst2), 0.000001, "maskedSelect error")
+end
+
+function torchtest.maskedFill()
+   local nDst = 10
+   local dst = torch.randn(nDst)
+   local mask = torch.rand(nDst):mul(2):floor():byte()
+   local val = math.random()
+   local dst2 = dst:clone()
+   dst:maskedFill(mask, val)
+   for i=1,nDst do
+      if mask[i] == 1 then
+         dst2[i] = val
+      end
+   end
+   mytester:assertTensorEq(dst, dst2, 0.000001, "maskedFill error")
+end
+
 function torchtest.abs()
    local size = 1000
    local range = 1000


### PR DESCRIPTION
This PR exposes the above C functions as Tensor methods. Useful when you want to avoid reallocating memory, which isn't possible with the current `Tensor[mask]` schemes (`maskedSelect` in particular). The PR includes unit tests and doc.