### PR TITLE
Checking for valid RNG state

### DIFF
--- a/lib/TH/THRandom.h
+++ b/lib/TH/THRandom.h
@@ -10,7 +10,7 @@ typedef struct THGenerator {
   /* The initial seed. */
   unsigned long the_initial_seed;
   int left;  /* = 1; */
-  int initf; /* = 0; */
+  int seeded; /* = 0; */
   unsigned long next;
   unsigned long state[_MERSENNE_STATE_N]; /* the array for the state vector  */
   /********************************/

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -229,6 +229,7 @@ TH_API void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
   THArgCheck(THTensor_(nElement)(self) == size, 1, "RNG state is wrong size");
   THArgCheck(THTensor_(isContiguous)(self), 1, "RNG state needs to be contiguous");
   rng_state = (THGenerator *)THTensor_(data)(self);
+  THArgCheck(THRandom_isValidState(rng_state), 1, "Invalid RNG state");
   THGenerator_copy(_generator, rng_state);
 }
 #endif


### PR DESCRIPTION
After my last PR, the RNG state returned by getRNGState is guaranteed to be valid. RNG states stored previously (with older version of torch) however could be invalid. For this and other reasons, it seems reasonable to check for the edge case of an invalid RNG state in setRNGState and throw an error when invalid. (this seems safer then silently re-seeding such state, leading to non-deterministic behaviour)

I renamed `initf` to `seeded` (as suggested by @timharley) and extracted the validity check into a new function, THRandom_isValidState.