### PR TITLE
Improve consistency of documentation typography

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -53,6 +53,7 @@ The advantage of second case is, same `res2` tensor can be used successively in 
 for i=1,100 do
     torch.conv2(res2,x,k)
 end
+
 =res2:dist(res1)
 0
 ```
@@ -63,11 +64,11 @@ end
 <a name="torch.cat"/>
 ### [res] torch.cat( [res,] x_1, x_2, [dimension] ) ###
 <a name="torch.cat"/>
-`x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors x_1 and x_2 along dimension `dimension`. 
+`x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors `x_1` and `x_2` along dimension `dimension`. 
 
 If `dimension` is not specified it is the last dimension.
 
-The other dimensions of x_1 and x_2 have to be equal.
+The other dimensions of `x_1` and `x_2` have to be equal.
 
 Examples:
 ```lua
@@ -122,70 +123,102 @@ Examples:
 ### [res] torch.diag([res,] x [,k]) ###
 <a name="torch.diag"/>
 
-`y=torch.diag(x)` when x is of dimension 1 returns a diagonal matrix with diagonal elements constructed from x.
+`y=torch.diag(x)` when `x` is of dimension 1 returns a diagonal matrix with diagonal elements constructed from `x`.
 
-`y=torch.diag(x)` when x is of dimension 2 returns a tensor of dimension 1
-with elements constructed from the diagonal of x.
+`y=torch.diag(x)` when `x` is of dimension 2 returns a tensor of dimension 1
+with elements constructed from the diagonal of `x`.
 
-`y=torch.diag(x,k)` returns the k-th diagonal of x,
-wher k=0 is the main diagonal, k>0 is above the main diagonal and k<0 
+`y=torch.diag(x,k)` returns the k-th diagonal of `x`,
+where `k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0` 
 is below the main diagonal.
 
 <a name="torch.eye"/>
 ### [res] torch.eye([res,] n [,m]) ###
 <a name="torch.eye"/>
 
-`y=torch.eye(n)` returns the n-by-n identity matrix.
+`y=torch.eye(n)` returns the `n x n` identity matrix.
 
-`y=torch.eye(n,m)` returns an n-by-m identity matrix with ones on the diagonal and zeros elsewhere.
+`y=torch.eye(n,m)` returns an `n x m` identity matrix with ones on the diagonal and zeros elsewhere.
+
+
+<a name="torch.histc"/>
+### [res] torch.histc([res,] x [,nbins, min_value, max_value]) ###
+<a name="torch.histc"/>
+
+`y=torch.histc(x)` returns the histogram of the elements in `x`. By default the
+elements are sorted into 100 equally spaced bins between the minimum and maximum
+values of `x`.
+
+`y=torch.histc(x,n)` same as above with `n` bins.
+
+`y=torch.histc(x,n,min,max)` same as above with `n` bins and `[min, max]` as elements
+range.
 
 
 <a name="torch.linspace"/>
 ### [res] torch.linspace([res,] x1, x2, [,n]) ###
 <a name="torch.linspace"/>
 
-`y=torch.linspace(x1,x2)` returns a one-dimensional tensor of size 100 equally spaced points between x1 and x2.
+`y=torch.linspace(x1,x2)` returns a one-dimensional tensor of size 100 equally spaced points between `x1` and `x2`.
 
-`y=torch.linspace(x1,x2,n)` returns a one-dimensional tensor of n equally spaced points between x1 and x2.
+`y=torch.linspace(x1,x2,n)` returns a one-dimensional tensor of `n` equally spaced points between `x1` and `x2`.
 
 
 <a name="torch.logspace"/>
 ### [res] torch.logspace([res,] x1, x2, [,n]) ###
 <a name="torch.logspace"/>
 
-`y=torch.logspace(x1,x2)` returns a one-dimensional tensor of 50 logarithmically eqally spaced points between x1 and x2.
+`y=torch.logspace(x1,x2)` returns a one-dimensional tensor of 50 logarithmically eqally spaced points between `x1` and `x2`.
 
-`y=torch.logspace(x1,x2,n)` returns a one-dimensional tensor of n logarithmically equally spaced points between x1 and x2.
+`y=torch.logspace(x1,x2,n)` returns a one-dimensional tensor of `n` logarithmically equally spaced points between `x1` and `x2`.
 
 <a name="torch.multinomial"/>
-### [res] torch.multinomial([res,], p, n, [,flag]) ###
+### [res] torch.multinomial([res,], p, n, [,replacement]) ###
 <a name="torch.multinomial"/>
 
 `y=torch.multinomial(p,n)` returns a tensor `y` where each row contains
-`n` indices sampled __with replacement__ (`flag=true`) from the 
+`n` indices sampled from the 
 [multinomial probability distribution](http://en.wikipedia.org/wiki/Multinomial_distribution)
 located in the corresponding row of tensor `p`. 
 
-The rows of `p` need not sum to one (in which case we use the values as weights), 
-but should be non-negative and have a non-zero sum. 
+The rows of `p` do not need to sum to one (in which case we use the values as weights), 
+but must be non-negative and have a non-zero sum. 
 Indices are ordered from left to right according to 
 when each was sampled (first samples are placed in first column). 
 
-If `p` is an `MxN` matrix, `y` is an `Mxn` matrix.
+If `p` is a vector, `y` is a vector size `n`.
 
-If `p` is a vector of size `M`, `y` is a vector size `n`.
+If `p` is a m-rows matrix, `y` is an `m x n` matrix.
 
-`y=torch.multinomial(p,n,false)` is like the above, except samples are drawn
-__without replacement__. In other words, when a sample index is drawn for a row, it 
-cannot be drawn again for that row. This implies the constraint `n <= N`.
+If `replacement` is `true`, samples are drawn __with replacement__. 
+If not, they are drawn __without replacement__, which means that when a sample index is drawn for a row, it 
+cannot be drawn again for that row. This implies the constraint that `n` must be lower than `p` length (or number of columns of `p` if it is a matrix).
+
+The default value for `replacement` is `false`.
+
+
+```lua
+p = torch.Tensor{1, 1, 0.5, 0}
+a = torch.multinomial(p, 10000, true)
+
+> a
+...
+[torch.LongTensor of dimension 10000]
+
+> for i=1,4 do print(a:eq(i):sum()) end
+3967  
+4016  
+2017  
+0 
+```
 
 <a name="torch.ones"/>
 ### [res] torch.ones([res,] m [,n...]) ###
 <a name="torch.ones"/>
 
-`y=torch.ones(n)` returns a one-dimensional tensor of size n filled with ones.
+`y=torch.ones(n)` returns a one-dimensional tensor of size `n` filled with ones.
 
-`y=torch.ones(m,n)` returns a mxn tensor filled with ones.
+`y=torch.ones(m,n)` returns a `m x n` tensor filled with ones.
 
 For more than 4 dimensions, you can use a storage as argument:
 `y=torch.ones(torch.LongStorage{m,n,k,l,o})`.
@@ -194,9 +227,9 @@ For more than 4 dimensions, you can use a storage as argument:
 ### [res] torch.rand([res,] m [,n...]) ###
 <a name="torch.rand"/>
 
-`y=torch.rand(n)` returns a one-dimensional tensor of size n filled with random numbers from a uniform distribution on the interval (0,1).
+`y=torch.rand(n)` returns a one-dimensional tensor of size `n` filled with random numbers from a uniform distribution on the interval `(0,1)`.
 
-`y=torch.rand(m,n)` returns a mxn tensor of random numbers from a uniform distribution on the interval (0,1).
+`y=torch.rand(m,n)` returns a `m x n` tensor of random numbers from a uniform distribution on the interval `(0,1)`.
 
 For more than 4 dimensions, you can use a storage as argument:
 `y=torch.rand(torch.LongStorage{m,n,k,l,o})`
@@ -205,9 +238,9 @@ For more than 4 dimensions, you can use a storage as argument:
 ### [res] torch.randn([res,] m [,n...]) ###
 <a name="torch.randn"/>
 
-`y=torch.randn(n)` returns a one-dimensional tensor of size n filled with random numbers from a normal distribution with mean zero and variance one.
+`y=torch.randn(n)` returns a one-dimensional tensor of size `n` filled with random numbers from a normal distribution with mean zero and variance one.
 
-`y=torch.randn(m,n)` returns a mxn tensor of random numbers from a normal distribution with mean zero and variance one.
+`y=torch.randn(m,n)` returns a `m x n` tensor of random numbers from a normal distribution with mean zero and variance one.
 
 For more than 4 dimensions, you can use a storage as argument:
 `y=torch.rand(torch.LongStorage{m,n,k,l,o})`
@@ -216,23 +249,18 @@ For more than 4 dimensions, you can use a storage as argument:
 ### [res] torch.range([res,] x, y [,step]) ###
 <a name="torch.range"/>
 
-`y=torch.range(x,y)` returns a tensor of size (int)(y-x)+1 with values
-from x to y with step 1. You can modifiy the default step with:
-`y=torch.range(x,y,step)`
+`y=torch.range(x,y)` returns a tensor of size `floor((y - x) / step) + 1` with values
+from `x` to `y` with step `setp` (default to 1).
 
 ```lua
 > print(torch.range(2,5))
-
  2
  3
  4
  5
 [torch.Tensor of dimension 4]
-```
 
-`y=torch.range(n,m,incr)` returns a tensor filled in range n to m with incr increments.
-```lua
-print(torch.range(2,5,1.2))
+> print(torch.range(2,5,1.2))
  2.0000
  3.2000
  4.4000
@@ -243,14 +271,14 @@ print(torch.range(2,5,1.2))
 ### [res] torch.randperm([res,] n) ###
 <a name="torch.randperm"/>
 
-`y=torch.randperm(n)` returns a random permutation of integers from 1 to n.
+`y=torch.randperm(n)` returns a random permutation of integers from 1 to `n`.
 
 <a name="torch.reshape"/>
 ### [res] torch.reshape([res,] x, m [,n...]) ###
 <a name="torch.reshape"/>
 
-`y=torch.reshape(x,m,n)` returns a new mxn tensor y whose elements
-are taken rowwise from x, which must have m*n elements. The elements are copied into the new tensor.
+`y=torch.reshape(x,m,n)` returns a new `m x n` tensor y whose elements
+are taken rowwise from `x`, which must have `m*n` elements. The elements are copied into the new tensor.
 
 For more than 4 dimensions, you can use a storage:
 `y=torch.reshape(x,torch.LongStorage{m,n,k,l,o})`
@@ -259,19 +287,21 @@ For more than 4 dimensions, you can use a storage:
 ### [res] torch.tril([res,] x [,k]) ###
 <a name="torch.tril"/>
 
-`y=torch.tril(x)` returns the lower triangular part of x, the other elements of y are set to 0.
+`y=torch.tril(x)` returns the lower triangular part of `x`, the other elements of `y` are set to 0.
 
-`torch.tril(x,k)` returns the elements on and below the k-th diagonal of x as non-zero.   k=0 is the main diagonal, k>0 is above the main diagonal and k<0 
+`torch.tril(x,k)` returns the elements on and below the k-th diagonal of `x` as non-zero. 
+`k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0` 
 is below the main diagonal.
 
 <a name="torch.triu"/>
 ### [res] torch.triu([res,] x, [,k]) ###
 <a name="torch.triu"/>
 
-`y=torch.triu(x)` returns the upper triangular part of x,
-the other elements of y are set to 0.
+`y=torch.triu(x)` returns the upper triangular part of `x`,
+the other elements of `y` are set to 0.
 
-`torch.triu(x,k)` returns the elements on and above the k-th diagonal of x as non-zero.   k=0 is the main diagonal, k>0 is above the main diagonal and k<0 
+`torch.triu(x,k)` returns the elements on and above the k-th diagonal of `x` as non-zero. 
+`k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0` 
 is below the main diagonal.
 
 <a name="torch.zeros"/>
@@ -280,82 +310,70 @@ is below the main diagonal.
 
 `y=torch.zeros(n)` returns a one-dimensional tensor of size n filled with zeros.
 
-`y=torch.zeros(m,n)` returns a mxn tensor filled with zeros.
+`y=torch.zeros(m,n)` returns a `m x n` tensor filled with zeros.
 
 For more than 4 dimensions, you can use a storage:
 `y=torch.zeros(torch.LongStorage{m,n,k,l,o})`
 
-<a name="torch.histc"/>
-### [res] torch.histc([res,] x [,nbins, min_value, max_value]) ###
-<a name="torch.histc"/>
-
-`y=torch.histc(x)` returns the histogram of the elements in x. By default the
-elements are sorted into 100 equally spaced bins between the minimum and maximum
-values of x.
-
-`y=torch.histc(x,n)` same as above with n bins.
-
-`y=torch.histc(x,n,min,max)` same as above with n bins and min, max as elements
-range.
 
 <a name="torch.elementwise.dok"/>
-### Element-wise Mathematical Operations ###
+## Element-wise Mathematical Operations ##
 
 <a name="torch.abs"/>
 ### [res] torch.abs([res,] x) ###
 <a name="torch.abs"/>
 
-`y=torch.abs(x)` returns a new tensor with the absolute values of the elements of x.
+`y=torch.abs(x)` returns a new tensor with the absolute values of the elements of `x`.
 
-`x:abs()` replaces all elements in-place with the absolute values of the elements of x.
+`x:abs()` replaces all elements in-place with the absolute values of the elements of `x`.
 
 <a name="torch.acos"/>
 ### [res] torch.acos([res,] x) ###
 <a name="torch.acos"/>
 
-`y=torch.acos(x)` returns a new tensor with the arcosine of the elements of x.
+`y=torch.acos(x)` returns a new tensor with the arcosine of the elements of `x`.
 
-`x:acos()` replaces all elements in-place with the arcosine of the elements of x.
+`x:acos()` replaces all elements in-place with the arcosine of the elements of `x`.
 
 <a name="torch.asin"/>
 ### [res] torch.asin([res,] x) ###
 <a name="torch.asin"/>
 
-`y=torch.asin(x)` returns a new tensor with the arcsine  of the elements of x.
+`y=torch.asin(x)` returns a new tensor with the arcsine  of the elements of `x`.
 
-`x:asin()` replaces all elements in-place with the arcsine  of the elements of x.
+`x:asin()` replaces all elements in-place with the arcsine  of the elements of `x`.
 
 <a name="torch.atan"/>
 ### [res] torch.atan([res,] x) ###
 <a name="torch.atan"/>
 
-`y=torch.atan(x)` returns a new tensor with the arctangent of the elements of x.
+`y=torch.atan(x)` returns a new tensor with the arctangent of the elements of `x`.
 
-`x:atan()` replaces all elements in-place with the arctangent of the elements of x.
+`x:atan()` replaces all elements in-place with the arctangent of the elements of `x`.
 
 <a name="torch.ceil"/>
 ### [res] torch.ceil([res,] x) ###
 <a name="torch.ceil"/>
 
-`y=torch.ceil(x)` returns a new tensor with the values of the elements of x rounded up to the nearest integers.
+`y=torch.ceil(x)` returns a new tensor with the values of the elements of `x` rounded up to the nearest integers.
 
-`x:ceil()` replaces all elements in-place with the values of the elements of x rounded up to the nearest integers.
+`x:ceil()` replaces all elements in-place with the values of the elements of `x` rounded up to the nearest integers.
 
 <a name="torch.cos"/>
 ### [res] torch.cos([res,] x) ###
 <a name="torch.cos"/>
 
-`y=torch.cos(x)` returns a new tensor with the cosine of the elements of x.
+`y=torch.cos(x)` returns a new tensor with the cosine of the elements of `x`.
 
-`x:cos()` replaces all elements in-place with the cosine of the elements of x.
+`x:cos()` replaces all elements in-place with the cosine of the elements of `x`.
 
 <a name="torch.cosh"/>
 ### [res] torch.cosh([res,] x) ###
 <a name="torch.cosh"/>
 
-`y=torch.cosh(x)` returns a new tensor with the hyberbolic cosine of the elements of x.
+`y=torch.cosh(x)` returns a new tensor with the hyberbolic cosine of the elements of `x`.
 
-`x:cosh()` replaces all elements in-place with the hyberbolic cosine of the elements of x.
+`x:cosh()` replaces all elements in-place with the hyberbolic cosine of the elements of `x`.
 
 <a name="torch.exp"/>
 ### [res] torch.exp([res,] x) ###
@@ -369,86 +387,86 @@ range.
 ### [res] torch.floor([res,] x) ###
 <a name="torch.floor"/>
 
-`y=torch.floor(x)` returns a new tensor with the values of the elements of x rounded down to the nearest integers.
+`y=torch.floor(x)` returns a new tensor with the values of the elements of `x` rounded down to the nearest integers.
 
-`x:floor()` replaces all elements in-place with the values of the elements of x rounded down to the nearest integers.
+`x:floor()` replaces all elements in-place with the values of the elements of `x` rounded down to the nearest integers.
 
 <a name="torch.log"/>
 ### [res] torch.log([res,] x) ###
 <a name="torch.log"/>
 
-`y=torch.log(x)` returns a new tensor with the natural logarithm of the elements of x.
+`y=torch.log(x)` returns a new tensor with the natural logarithm of the elements of `x`.
 
-`x:log()` replaces all elements in-place with the natural logarithm of the elements of x.
+`x:log()` replaces all elements in-place with the natural logarithm of the elements of `x`.
 
 <a name="torch.log1p"/>
 ### [res] torch.log1p([res,] x) ###
 <a name="torch.log1p"/>
 
-`y=torch.log1p(x)` returns a new tensor with the natural logarithm of the elements of x+1.
+`y=torch.log1p(x)` returns a new tensor with the natural logarithm of the elements of `x+1`.
 
-`x:log1p()` replaces all elements in-place with the natural logarithm of the elements of x+1.
-This function is more accurate than [log()](#torch.log) for small values of x.
+`x:log1p()` replaces all elements in-place with the natural logarithm of the elements of `x+1`.
+This function is more accurate than [log()](#torch.log) for small values of `x`.
 
 <a name="torch.pow"/>
-### [res] torch.pow([res,] x) ###
+### [res] torch.pow([res,] x, n) ###
 <a name="torch.pow"/>
 
-Let x be a tensor and n a number.
+Let `x` be a tensor and `n` a number.
 
-`y=torch.pow(x,n)` returns a new tensor with the elements of x to the power of n.
+`y=torch.pow(x,n)` returns a new tensor with the elements of `x` to the power of `n`.
 
-`y=torch.pow(n,x)` returns, for each element in x, n raised to the power of the element in x.
+`y=torch.pow(n,x)` returns, a new tensor with `n` to the power of the elements of `x`.
 
-`x:pow(n)` replaces all elements in-place with the elements of x to the power of n.
+`x:pow(n)` replaces all elements in-place with the elements of `x` to the power of `n`.
 
 <a name="torch.round"/>
 ### [res] torch.round([res,] x) ###
 <a name="torch.round"/>
 
-`y=torch.round(x)` returns a new tensor with the values of the elements of x rounded to the nearest integers.
+`y=torch.round(x)` returns a new tensor with the values of the elements of `x` rounded to the nearest integers.
 
-`x:round()` replaces all elements in-place with the values of the elements of x rounded to the nearest integers.
+`x:round()` replaces all elements in-place with the values of the elements of `x` rounded to the nearest integers.
 
 <a name="torch.sin"/>
 ### [res] torch.sin([res,] x) ###
 <a name="torch.sin"/>
 
-`y=torch.sin(x)` returns a new tensor with the sine  of the elements of x.
+`y=torch.sin(x)` returns a new tensor with the sine  of the elements of `x`.
 
-`x:sin()` replaces all elements in-place with the sine  of the elements of x.
+`x:sin()` replaces all elements in-place with the sine  of the elements of `x`.
 
 <a name="torch.sinh"/>
 ### [res] torch.sinh([res,] x) ###
 <a name="torch.sinh"/>
 
-`y=torch.sinh(x)` returns a new tensor with the hyperbolic sine of the elements of x.
+`y=torch.sinh(x)` returns a new tensor with the hyperbolic sine of the elements of `x`.
 
-`x:sinh()` replaces all elements in-place with the hyperbolic sine of the elements of x.
+`x:sinh()` replaces all elements in-place with the hyperbolic sine of the elements of `x`.
 
 <a name="torch.sqrt"/>
 ### [res] torch.sqrt([res,] x) ###
 <a name="torch.sqrt"/>
 
-`y=torch.sqrt(x)` returns a new tensor with the square root of the elements of x.
+`y=torch.sqrt(x)` returns a new tensor with the square root of the elements of `x`.
 
-`x:sqrt()` replaces all elements in-place with the square root of the elements of x.
+`x:sqrt()` replaces all elements in-place with the square root of the elements of `x`.
 
 <a name="torch.tan"/>
 ### [res] torch.tan([res,] x) ###
 <a name="torch.tan"/>
 
-`y=torch.tan(x)` returns a new tensor with the tangent of the elements of x.
+`y=torch.tan(x)` returns a new tensor with the tangent of the elements of `x`.
 
-`x:tan()` replaces all elements in-place with the tangent of the elements of x.
+`x:tan()` replaces all elements in-place with the tangent of the elements of `x`.
 
 <a name="torch.tanh"/>
 ### [res] torch.tanh([res,] x) ###
 <a name="torch.tanh"/>
 
-`y=torch.tanh(x)` returns a new tensor with the hyperbolic tangent of the elements of x.
+`y=torch.tanh(x)` returns a new tensor with the hyperbolic tangent of the elements of `x`.
 
-`x:tanh()` replaces all elements in-place with the hyperbolic tangent of the elements of x.
+`x:tanh()` replaces all elements in-place with the hyperbolic tangent of the elements of `x`.
 
 <a name="torch.basicoperations.dok"/>
 ## Basic operations ##
@@ -472,7 +490,7 @@ Add the given value to all elements in the tensor.
 Add `tensor1` to `tensor2` and put result into `res`. The number
 of elements must match, but sizes do not matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > x:add(y)
@@ -499,7 +517,7 @@ Multiply elements of `tensor2` by the scalar `value` and add it to
 `tensor1`. The number of elements must match, but sizes do not
 matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > x:add(2, y)
@@ -539,7 +557,7 @@ Multiply all elements in the tensor by the given `value`.
 Clamp all elements in the tensor into the range `[min_value, max_value]`.  ie:
 
 ```
-y_i = x_i, if x_i >= min_value or x_i <= max_value
+y_i = x_i,       if x_i >= min_value or x_i <= max_value
     = min_value, if x_i < min_value
     = max_value, if x_i > max_value
 ```
@@ -559,7 +577,7 @@ y_i = x_i, if x_i >= min_value or x_i <= max_value
 Element-wise multiplication of `tensor1` by `tensor2`. The number
 of elements must match, but sizes do not matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > x:cmul(y)
@@ -586,7 +604,7 @@ Element-wise power operation, taking the elements of `tensor1` to the powers
 given by elements of `tensor2`. The number of elements must match,
 but sizes do not matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > x:cpow(y)
@@ -614,7 +632,7 @@ Performs the element-wise multiplication of `tensor1` by `tensor2`,
 multiply the result by the scalar `value` (1 if not present) and add it
 to `x`. The number of elements must match, but sizes do not matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > z = torch.Tensor(2,2):fill(5)
@@ -653,7 +671,7 @@ Divide all elements in the tensor by the given `value`.
 Performs the element-wise division of `tensor1` by `tensor2`.  The
 number of elements must match, but sizes do not matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(1)
 > y = torch.Tensor(4)        
 > for i=1,4 do y[i] = i end
@@ -681,7 +699,7 @@ Performs the element-wise division of `tensor1` by `tensor1`,
 multiply the result by the scalar `value` and add it to `x`. 
 The number of elements must match, but sizes do not matter.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(1)
 > y = torch.Tensor(4)
 > z = torch.Tensor(2,2):fill(5)
@@ -704,10 +722,10 @@ The number of elements must match, but sizes do not matter.
 ### [number] torch.dot(tensor1,tensor2) ###
 <a name="torch.dot"/>
 
-Performs the dot product between `tensor` and self. The number of
+Performs the dot product between `tensor1` and `tensor2`. The number of
 elements must match: both tensors are seen as a 1D vector.
 
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > = x:dot(y)
@@ -722,17 +740,24 @@ elements must match: both tensors are seen as a 1D vector.
 <a name="torch.addmv"/>
 
 Performs a matrix-vector multiplication between `mat` (2D tensor)
-and `vec` (1D tensor) and add it to vec1. In other words,
+and `vec2` (1D tensor) and add it to `vec1`.
+
+Optional values `v1` and `v2` are scalars that multiply 
+`vec1` and `vec2` respectively.
+
+Optional value `beta` is  a scalar that scales the result tensor, before accumulating the result into the tensor. Defaults to 1.0.
+
+In other words,
 
 ```
-res = beta * res + v1 * vec1 + v2 * mat*vec2
+res = beta * res + v1 * vec1 + v2 * mat * vec2
 ```
 
 Sizes must respect the matrix-multiplication operation: if `mat` is
 a `n x m` matrix, `vec2` must be vector of size `m` and `vec1` must
 be a vector of size `n`.
 
-```
+```lua
 > x = torch.Tensor(3):fill(0)
 > M = torch.Tensor(3,2):fill(3)
 > y = torch.Tensor(2):fill(2)
@@ -753,16 +778,18 @@ be a vector of size `n`.
 
 `r:addmv(x,y,z)` puts the result of `x+y*z` into `r`.
 
-Optional values `v1` and `v2` are scalars that multiply 
-`vec1` and `mat*vec2` respectively.
 
-Optional value `beta` is  a scalar that scales the result tensor, before accumulating the result into the tensor. Defaults to 1.0
+
 
 <a name="torch.addr"/>
 ### [res] torch.addr([res,] [v1,] mat, [v2,] vec1, vec2) ###
 <a name="torch.addr"/>
 
 Performs the outer-product between `vec1` (1D tensor) and `vec2` (1D tensor).
+
+Optional values `v1` and `v2` are scalars that multiply 
+`M` and `vec1 [out] vec2` respectively.
+
 In other words,
 
 ```
@@ -772,7 +799,7 @@ res_ij = v1 * mat_ij + v2 * vec1_i * vec2_j
 If `vec1` is a vector of size `n` and `vec2` is a vector of size `m`, 
 then mat must be a matrix of size `n x m`.
 
-```
+```lua
 > x = torch.Tensor(3)        
 > y = torch.Tensor(2)
 > for i=1,3 do x[i] = i end
@@ -795,8 +822,6 @@ then mat must be a matrix of size `n x m`.
 
 `r:addr(M,x,y)` puts the result in `r`.
 
-Optional values `v1` and `v2` are scalars that multiply 
-`M` and `vec1 [out] vec2` respectively.
 
 
 <a name="torch.addmm"/>
@@ -804,7 +829,14 @@ Optional values `v1` and `v2` are scalars that multiply
 <a name="torch.addmm"/>
 
 Performs a matrix-matrix multiplication between `mat1` (2D tensor)
-and `mat2` (2D tensor). In other words,
+and `mat2` (2D tensor).
+
+Optional values `v1` and `v2` are scalars that multiply 
+`M` and `mat1 * mat2` respectively.
+
+Optional value `beta` is  a scalar that scales the result tensor, before accumulating the result into the tensor. Defaults to 1.0.
+
+In other words,
 
 ```
 res = res * beta + v1 * M + v2 * mat1*mat2
@@ -821,21 +853,24 @@ If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
 
 `r:addmm(M,mat1,mat2)` puts the result in `r`.
 
-Optional values `v1` and `v2` are scalars that multiply 
-`M` and `mat1 * mat2` respectively.
-
-Optional value `beta` is  a scalar that scales the result tensor, before accumulating the result into the tensor. Defaults to 1.0
 
 <a name="torch.addbmm"/>
-### [res] torch.addbmm([res,] [v1,] M [v2,] mat1, mat2) ###
+### [res] torch.addbmm([res,] [v1,] M [v2,] batch1, batch2) ###
 <a name="torch.addbmm"/>
 
 Batch matrix matrix product of matrices stored in `batch1` and `batch2`, 
 with a reduced add step (all matrix multiplications get accumulated in a
 single place).
+
 `batch1` and `batch2` must be 3D tensors each containing the same number
 of matrices. If `batch1` is a `b x n x m` tensor, `batch2` a `b x m x p`
 tensor, res will be a `n x p` tensor.
+
+In other words,
+
+```
+res = v1 * M + v2 * sum(batch1_i * batch2_i, i=1,b)
+```
 
 `torch.addbmm(M,x,y)` puts the result in a new tensor.
 
@@ -844,14 +879,21 @@ tensor, res will be a `n x p` tensor.
 `M:addbmm(beta,M2,alpha,x,y)` puts the result in `M`, resizing `M` if necessary.
 
 <a name="torch.baddbmm"/>
-### [res] torch.baddbmm([res,] [v1,] M [v2,] mat1, mat2) ###
+### [res] torch.baddbmm([res,] [v1,] M [v2,] batch1, batch2) ###
 <a name="torch.baddbmm"/>
 
 Batch matrix matrix product of matrices stored in `batch1` and `batch2`,
 with batch add.
+
 `batch1` and `batch2` must be 3D tensors each containing the same number
 of matrices. If `batch1` is a `b x n x m` tensor, `batch2` a `b x m x p`
 tensor, res will be a `b x n x p` tensor.
+
+In other words,
+
+```
+res_i = v1 * M_i + v2 * batch1_i * batch2_i
+```
 
 `torch.baddbmm(M,x,y)` puts the result in a new tensor.
 
@@ -929,7 +971,8 @@ results. They are thus not as fast as the operations available in the
 [previous section](#torch.BasicOperations.dok).
 
 Another important point to note is that these operators are only overloaded when the first operand is a tensor. For example, this will NOT work:
-```
+
+```lua
 > x = 5 + torch.rand(3)
 ```
 
@@ -938,7 +981,8 @@ Another important point to note is that these operators are only overloaded when
 You can add a tensor to another one with the `+` operator. Subtraction is done with `-`.
 The number of elements in the tensors must match, but the sizes do not matter. The size
 of the returned tensor will be the size of the first tensor.
-```
+
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > = x+y
@@ -957,7 +1001,8 @@ of the returned tensor will be the size of the first tensor.
 ```
 
 A scalar might also be added or subtracted to a tensor. The scalar needs to be on the right of the operator.
-```
+
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > = x+3
 
@@ -970,7 +1015,8 @@ A scalar might also be added or subtracted to a tensor. The scalar needs to be o
 ### Negation ###
 
 A tensor can be negated with the `-` operator placed in front:
-```
+
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > = -x
 
@@ -994,7 +1040,7 @@ Sizes must be relevant for the corresponding operation.
 A tensor might also be multiplied by a scalar. The scalar might be on the right or left of the operator.
 
 Examples:
-```
+```lua
 > M = torch.Tensor(2,2):fill(2)
 > N = torch.Tensor(2,4):fill(3)
 > x = torch.Tensor(2):fill(4)
@@ -1018,8 +1064,9 @@ Examples:
 ### Division ###
 
 Only the division of a tensor by a scalar is supported with the operator `/`.
+
 Example:
-```
+```lua
 > x = torch.Tensor(2,2):fill(2)
 > = x/3
 
@@ -1035,15 +1082,11 @@ Example:
 <a name="torch.cross"/>
 ### [res] torch.cross([res,] a, b [,n]) ###
 
-`y=torch.cross(a,b)` returns the cross product of the tensors a and b.
-a and b must be 3 element vectors. 
+`y=torch.cross(a,b)` returns the cross product of `a` and `b` along the first dimension of length 3.
 
-`y=cross(a,b)` returns the cross product of a and b along the first dimension of length 3.
+`y=torch.cross(a,b,n)`  returns the cross product of vectors in dimension `n` of `a` and `b`.
 
-`y=cross(a,b,n)`, where a and b returns the cross
-product of vectors in dimension n of a and b. 
-a and b must have the same size, 
-and both `a:size(n)` and `b:size(n)` must be 3.
+`a` and `b` must have the same size, and both `a:size(n)` and `b:size(n)` must be 3.
 
 
 <a name="torch.cumprod"/>
@@ -1070,10 +1113,10 @@ of `x`, performing the operation over dimension `n`.
 `y=torch.max(x)` returns the single largest element of `x`.
 
 `y,i=torch.max(x,1)` returns the largest element in each column
-(across rows) of `x`, and a tensor i of their corresponding indices in
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.max(x,2)` performs the max operation across rows and
+`y,i=torch.max(x,2)` performs the max operation across rows.
 
 `y,i=torch.max(x,n)` performs the max operation over the dimension `n`.
 
@@ -1086,7 +1129,7 @@ of `x`, performing the operation over dimension `n`.
 `y=torch.mean(x,1)` returns a tensor `y` of the mean of the elements in 
 each column of `x`.
 
-`y=torch.mean(x,2)` performs the mean operation for each row and
+`y=torch.mean(x,2)` performs the mean operation for each row.
 
 `y=torch.mean(x,n)` performs the mean operation over the dimension `n`.
 
@@ -1096,10 +1139,10 @@ each column of `x`.
 `y=torch.min(x)` returns the single smallest element of `x`.
 
 `y,i=torch.min(x,1)` returns the smallest element in each column
-(across rows) of `x`, and a tensor i of their corresponding indices in
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.min(x,2)` performs the min operation across rows and
+`y,i=torch.min(x,2)` performs the min operation across rows.
 
 `y,i=torch.min(x,n)` performs the min operation over the dimension `n`.
 
@@ -1107,11 +1150,29 @@ each column of `x`.
 <a name="torch.prod"/>
 ### [res] torch.prod([res,] x [,n]) ###
 
-`y=torch.prod(x)` returns a tensor `y` of the product of all elements in `x`. 
+`y=torch.prod(x)` returns the product of all elements in `x`. 
 
-`y=torch.prod(x,2)` performs the prod operation for each row and
+`y=torch.prod(x,n)` returns a tensor `y` whom size in dimension `n` is 1 and where elements are the product of elements of `x` with respect to dimension `n`.
 
-`y=torch.prod(x,n)` performs the prod operation over the dimension `n`.
+```lua
+> a = torch.Tensor{{{1,2},{3,4}}, {{5,6},{7,8}}}
+> a
+(1,.,.) = 
+  1  2
+  3  4
+
+(2,.,.) = 
+  5  6
+  7  8
+[torch.DoubleTensor of dimension 2x2x2]
+
+> torch.prod(a, 1)
+(1,.,.) = 
+   5  12
+  21  32
+[torch.DoubleTensor of dimension 1x2x2]
+```
+
 
 <a name="torch.sort"/>
 ### torch.sort([resval, resind,] x [,d] [,flag]) ###
@@ -1130,22 +1191,23 @@ a specific dimension `d`.
 a specific dimension `d`, in __descending__ order.
 
 <a name="torch.std"/>
-### [res] torch.std([res,] x, [flag] [dim]) ###
+### [res] torch.std([res,] x, [,dim] [,flag]) ###
 
 `y=torch.std(x)` returns the standard deviation of the elements of `x`.
 
-`y=torch.std(x,dim)` performs the std operation over the dimension dim.
+`y=torch.std(x,dim)` performs the `std` operation over the dimension `dim`.
 
-`y=torch.std(x,dim,false)` performs the std operation normalizing by `n-1` (this is the default).
+`y=torch.std(x,dim,false)` performs the `std` operation normalizing by `n-1` (this is the default).
 
-`y=torch.std(x,dim,true)` performs the std operation normalizing by `n` instead of `n-1`.
+`y=torch.std(x,dim,true)` performs the `std` operation normalizing by `n` instead of `n-1`.
 
 <a name="torch.sum"/>
 ### [res] torch.sum([res,] x) ###
 
 `y=torch.sum(x)` returns the sum of the elements of `x`.
 
-`y=torch.sum(x,2)` performs the sum operation for each row and
+`y=torch.sum(x,2)` performs the sum operation for each row.
+
 `y=torch.sum(x,n)` performs the sum operation over the dimension `n`.
 
 <a name="torch.var"/>
@@ -1163,13 +1225,13 @@ a specific dimension `d`, in __descending__ order.
 ## Matrix-wide operations  (tensor-wide operations) ##
 
 <a name="torch.norm"/>
-### torch.norm(x) ###
+### torch.norm(x [,p] [,dim]) ###
 
 `y=torch.norm(x)` returns the 2-norm of the tensor `x`. 
 
 `y=torch.norm(x,p)` returns the `p`-norm of the tensor `x`. 
 
-`y=torch.norm(x,p,dim)` returns the `p`-norms of the tensor `x` computed over the dimension dim.
+`y=torch.norm(x,p,dim)` returns the `p`-norms of the tensor `x` computed over the dimension `dim`.
 
 <a name="torch.renorm"/>
 ### torch.renorm([res], x, p, dim, maxnorm) ###
@@ -1179,6 +1241,7 @@ Renormalizes the sub-tensors along dimension `dim` such that they do not exceed 
 The `dim` argument is not to be confused with the argument of the same name in function [norm](#torch.norm). 
 In this case, the `p`-norm is measured for each `i`-th sub-tensor `x:select(dim, i)`. This function is 
 equivalent to (but faster than) the following:
+
 ```lua
 function renorm(matrix, value, dim, maxnorm)
   local m1 = matrix:transpose(dim, 1):contiguous()
@@ -1202,9 +1265,9 @@ Note: this function is particularly useful as a regularizer for constraining the
 <a name="torch.dist"/>
 ### torch.dist(x,y) ###
 
-`y=torch.dist(x,y)` returns the 2-norm of `(x-y)`. 
+`y=torch.dist(x,y)` returns the 2-norm of `x-y`. 
 
-`y=torch.dist(x,y,p)` returns the `p`-norm of `(x-y)`. 
+`y=torch.dist(x,y,p)` returns the `p`-norm of `x-y`. 
 
 <a name="torch.numel"/>
 ### torch.numel(x) ###
@@ -1228,29 +1291,29 @@ input/kernel dimensions and produces corresponding outputs. The
 general form of operations always remain the same.
 
 <a name="torch.conv2"/>
-### [res] torch.conv2([res,] x, k, ['F' or 'V']) ###
+### [res] torch.conv2([res,] x, k, [, 'F' or 'V']) ###
 <a name="torch.conv2"/>
 
-This function computes 2 dimensional convolutions between ` x ` and ` k `. These operations are similar to BLAS operations when number of dimensions of input and kernel are reduced by 2.
+This function computes 2 dimensional convolutions between `x` and `k`. These operations are similar to BLAS operations when number of dimensions of input and kernel are reduced by 2.
 
-  * ` x `  and ` k ` are 2D : convolution of a single image with a single kernel (2D output). This operation is similar to multiplication of two scalars.
-  * ` x `  and ` k ` are 3D : convolution of each input slice with corresponding kernel (3D output).
-  * ` x (p x m x n) ` 3D, ` k (q x p x ki x kj)` 4D : convolution of all input slices with the corresponding slice of kernel. Output is 3D ` (q x m x n) `. This operation is similar to matrix vector product of matrix ` k ` and vector ` x `.
+  * `x`  and `k` are 2D : convolution of a single image with a single kernel (2D output). This operation is similar to multiplication of two scalars.
+  * `x` (`p x m x n`)  and `k` (`p x ki x kj`) are 3D : convolution of each input slice with corresponding kernel (3D output).
+  * `x` (`p x m x n`) 3D, `k` (`q x p x ki x kj`) 4D : convolution of all input slices with the corresponding slice of kernel. Output is 3D (`q x m x n`). This operation is similar to matrix vector product of matrix `k` and vector `x`.
 
-The last argument controls if the convolution is a full (`'F'`) or valid (`'V'`) convolution. The default is `'valid'` convolution.
+The last argument controls if the convolution is a full (`'F'`) or valid (`'V'`) convolution. The default is **valid** convolution.
 
 ```lua
-x=torch.rand(100,100)
-k=torch.rand(10,10)
+x = torch.rand(100,100)
+k = torch.rand(10,10)
 c = torch.conv2(x,k)
-=c:size()
+> c:size()
 
  91
  91
 [torch.LongStorage of size 2]
 
 c = torch.conv2(x,k,'F')
-=c:size()
+> c:size()
 
  109
  109
@@ -1259,30 +1322,30 @@ c = torch.conv2(x,k,'F')
 ```
 
 <a name="torch.xcorr2"/>
-### [res] torch.xcorr2([res,] x, k, ['F' or 'V']) ###
+### [res] torch.xcorr2([res,] x, k, [, 'F' or 'V']) ###
 <a name="torch.xcorr2"/>
 
 This function operates with same options and input/output
 configurations as [torch.conv2](#torch.conv2), but performs
-cross-correlation of the input with the kernel ` k `.
+cross-correlation of the input with the kernel `k`.
 
 <a name="torch.conv3"/>
-### [res] torch.conv3([res,] x, k, ['F' or 'V']) ###
+### [res] torch.conv3([res,] x, k, [, 'F' or 'V']) ###
 <a name="torch.conv3"/>
 
-This function computes 3 dimensional convolutions between ` x ` and ` k `. These operations are similar to BLAS operations when number of dimensions of input and kernel are reduced by 3.
+This function computes 3 dimensional convolutions between `x` and `k`. These operations are similar to BLAS operations when number of dimensions of input and kernel are reduced by 3.
 
-  * ` x `  and ` k ` are 3D : convolution of a single image with a single kernel (3D output). This operation is similar to multiplication of two scalars.
-  * ` x `  and ` k ` are 4D : convolution of each input slice with corresponding kernel (4D output).
-  * ` x (p x m x n x o) ` 4D, ` k (q x p x ki x kj x kk)` 5D : convolution of all input slices with the corresponding slice of kernel. Output is 4D ` (q x m x n x o) `. This operation is similar to matrix vector product of matrix ` k ` and vector ` x `.
+  * `x`  and `k` are 3D : convolution of a single image with a single kernel (3D output). This operation is similar to multiplication of two scalars.
+  * `x` (`p x m x n x o`)  and `k` (`p x ki x kj x kk`) are 4D : convolution of each input slice with corresponding kernel (4D output).
+  * `x` (`p x m x n x o`) 4D, `k` (`q x p x ki x kj x kk`) 5D : convolution of all input slices with the corresponding slice of kernel. Output is 4D `q x m x n x o`. This operation is similar to matrix vector product of matrix `k` and vector `x`.
 
-The last argument controls if the convolution is a full (`'F'`) or valid (`'V'`) convolution. The default is `'valid'` convolution.
+The last argument controls if the convolution is a full (`'F'`) or valid (`'V'`) convolution. The default is **valid** convolution.
 
 ```lua
-x=torch.rand(100,100,100)
-k=torch.rand(10,10,10)
+x = torch.rand(100,100,100)
+k = torch.rand(10,10,10)
 c = torch.conv3(x,k)
-=c:size()
+> c:size()
 
  91
  91
@@ -1290,7 +1353,7 @@ c = torch.conv3(x,k)
 [torch.LongStorage of size 3]
 
 c = torch.conv3(x,k,'F')
-=c:size()
+> c:size()
 
  109
  109
@@ -1300,44 +1363,48 @@ c = torch.conv3(x,k,'F')
 ```
 
 <a name="torch.xcorr3"/>
-### [res] torch.xcorr3([res,] x, k, ['F' or 'V']) ###
+### [res] torch.xcorr3([res,] x, k, [, 'F' or 'V']) ###
 <a name="torch.xcorr3"/>
 
 This function operates with same options and input/output
 configurations as [torch.conv3](#torch.conv3), but performs
-cross-correlation of the input with the kernel ` k `.
+cross-correlation of the input with the kernel `k`.
 
 <a name="torch.linalg.dok"/>
 ## Eigenvalues, SVD, Linear System Solution ##
 
-Functions in this section are implemented with an interface to LAPACK
-libraries. If LAPACK libraries are not found during compilation step,
+Functions in this section are implemented with an interface to 
+[LAPACK](https://en.wikipedia.org/wiki/LAPACK) libraries. 
+If LAPACK libraries are not found during compilation step,
 then these functions will not be available.
 
 <a name="torch.gesv"/>
-### torch.gesv([resb, resa,] b,a) ###
+### [x,lu] torch.gesv([res1, res2,] b,a) ###
 
-Solution of ` AX=B ` and `A` has to be square and non-singular.
-`A` is `m x m`, `X` is `m x k`, `B` is `m x k`.
+`X,LU=torch.gesv(B,A)` returns the solution of `AX=B` and `LU` contains 
+`L` and `U` factors for `LU` factorization of `A`.
 
-If `resb` and `resa` are given, then they will be used for
+`A` has to be a square and non-singular matrix (2D tensor).
+`A` and `LU` are `m x m`, `X` is `m x k` and `B` is `m x k`.
+
+If `res1` and `res2` are given, then they will be used for
 temporary storage and returning the result.
 
-  * `resa` will contain L and U factors for `LU` factorization of `A`.
-  * `resb` will contain the solution.
+  * `resa` will contain `L` and `U` factors for `LU` factorization of `A`.
+  * `resb` will contain the solution `X`.
 
 ```lua
-a=torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
-                {-6.05, -3.30,  5.36, -4.44,  1.08},
-                {-0.45,  2.58, -2.70,  0.27,  9.04},
-                {8.32,  2.71,  4.35,  -7.17,  2.14},
-                {-9.67, -5.14, -7.26,  6.08, -6.87}}):t()
+a = torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
+                  {-6.05, -3.30,  5.36, -4.44,  1.08},
+                  {-0.45,  2.58, -2.70,  0.27,  9.04},
+                  {8.32,  2.71,  4.35,  -7.17,  2.14},
+                  {-9.67, -5.14, -7.26,  6.08, -6.87}}):t()
 
-b=torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
-                {-1.56,  4.00, -8.67,  1.75,  2.86},
-                {9.81, -4.09, -4.57, -8.61,  8.99}}):t()
+b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
+                  {-1.56,  4.00, -8.67,  1.75,  2.86},
+                  {9.81, -4.09, -4.57, -8.61,  8.99}}):t()
 
- =b
+> b
  4.0200 -1.5600  9.8100
  6.1900  4.0000 -4.0900
 -8.2200 -8.6700 -4.5700
@@ -1345,7 +1412,7 @@ b=torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
 -3.0300  2.8600  8.9900
 [torch.DoubleTensor of dimension 5x3]
 
-=a
+> a
  6.8000 -6.0500 -0.4500  8.3200 -9.6700
 -2.1100 -3.3000  2.5800  2.7100 -5.1400
  5.6600  5.3600 -2.7000  4.3500 -7.2600
@@ -1354,8 +1421,8 @@ b=torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
 [torch.DoubleTensor of dimension 5x5]
 
 
-x=torch.gesv(b,a)
- =x
+x = torch.gesv(b,a)
+> x
 -0.8007 -0.3896  0.9555
 -0.6952 -0.5544  0.2207
  0.5939  0.8422  1.9006
@@ -1363,7 +1430,7 @@ x=torch.gesv(b,a)
  0.5658  0.1057  4.0406
 [torch.DoubleTensor of dimension 5x3]
 
-=b:dist(a*x)
+> b:dist(a*x)
 1.1682163181673e-14
 
 ```
@@ -1371,26 +1438,27 @@ x=torch.gesv(b,a)
 <a name="torch.gels"/>
 ### torch.gels([resb, resa,] b,a) ###
 
-Solution of least squares and least norm  problems for a full rank ` A ` that is ` m x n`.
-  * If ` n <= m `, then solve ` ||AX-B||_F `.
-  * If ` n > m ` , then solve ` min ||X||_F s.t. AX=B `.
+Solution of least squares and least norm problems for a full rank `m x n` matrix `A`.
 
-On return, first ` n ` rows of ` X ` matrix contains the solution
+  * If `n <= m`, then solve `||AX-B||_F`.
+  * If `n > m` , then solve `min ||X||_F` s.t. `AX=B`.
+
+On return, first `n` rows of `x` matrix contains the solution
 and the rest contains residual information. Square root of sum squares
-of elements of each column of ` X ` starting at row ` n + 1 ` is
+of elements of each column of `x` starting at row `n + 1` is
 the residual for corresponding column.
 
 ```lua
 
-a=torch.Tensor({{ 1.44, -9.96, -7.55,  8.34,  7.08, -5.45},
-                {-7.84, -0.28,  3.24,  8.09,  2.52, -5.70},
-                {-4.39, -3.24,  6.27,  5.28,  0.74, -1.19},
-                {4.53,  3.83, -6.64,  2.06, -2.47,  4.70}}):t()
+a = torch.Tensor({{ 1.44, -9.96, -7.55,  8.34,  7.08, -5.45},
+                  {-7.84, -0.28,  3.24,  8.09,  2.52, -5.70},
+                  {-4.39, -3.24,  6.27,  5.28,  0.74, -1.19},
+                  {4.53,  3.83, -6.64,  2.06, -2.47,  4.70}}):t()
 
-b=torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
-                {9.35, -4.43, -0.70, -0.26, -7.36, -2.52}}):t()
+b = torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
+                  {9.35, -4.43, -0.70, -0.26, -7.36, -2.52}}):t()
 
-=a
+> a
  1.4400 -7.8400 -4.3900  4.5300
 -9.9600 -0.2800 -3.2400  3.8300
 -7.5500  3.2400  6.2700 -6.6400
@@ -1399,7 +1467,7 @@ b=torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
 -5.4500 -5.7000 -1.1900  4.7000
 [torch.DoubleTensor of dimension 6x4]
 
-=b
+> b
  8.5800  9.3500
  8.2600 -4.4300
  8.4800 -0.7000
@@ -1409,7 +1477,7 @@ b=torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
 [torch.DoubleTensor of dimension 6x2]
 
 x = torch.gels(b,a)
-=x 
+> x 
  -0.4506   0.2497 
  -0.8492  -0.9020
   0.7066   0.6323
@@ -1418,37 +1486,42 @@ x = torch.gels(b,a)
  -4.8214  -7.1361
 [torch.DoubleTensor of dimension 6x2]
 
-=b:dist(a*x:narrow(1,1,4))
+> b:dist(a*x:narrow(1,1,4))
 17.390200628863
 
-=math.sqrt(x:narrow(1,5,2):pow(2):sumall())
+> math.sqrt(x:narrow(1,5,2):pow(2):sumall())
 17.390200628863
 
 ```
 
 <a name="torch.symeig"/>
-### torch.symeig([rese, resv,] a, [, 'N' or 'V'] ['U' or 'L']) ###
+### torch.symeig([rese, resv,] a [, 'N' or 'V'] [, 'U' or 'L']) ###
 
-Eigen values and eigen vectors of a symmetric real matrix ` A ` of
-size ` m x m `. This function calculates all eigenvalues (and
-vectors) of ` A ` such that ` A = V' diag(e) V `. Since the input
-matrix ` A ` is supposed to be symmetric, only upper triangular
-portion is used by default. If the 4th argument is 'L', then lower
-triangular portion is used.
+`e,V=torch.symeig(A)` returns eigen values and eigen vectors of a 
+symmetric real matrix `A`.
+
+`A` and `V` are `m x m` matrices and `e` is a `m` dimensional vector.
+
+This function calculates all eigenvalues (and vectors) of `A` such 
+that `A = V' diag(e) V`.
 
 Third argument defines computation of eigenvectors or eigenvalues
-only. If ` N `, only eignevalues are computed. If ` V `, both
+only. If it is `'N'`, only eignevalues are computed. If it is `'V'`, both
 eigenvalues and eigenvectors are computed.
 
+Since the input matrix `A` is supposed to be symmetric, only upper 
+triangular portion is used by default. If the 4th argument is `'L'`, 
+then lower triangular portion is used.
+
+
 ```lua
+a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
+                  {-6.49,  3.80,  0.00,  0.00,  0.00},
+                  {-0.47, -6.39,  4.17,  0.00,  0.00},
+                  {-7.20,  1.50, -1.51,  5.70,  0.00},
+                  {-0.65, -6.34,  2.67,  1.80, -7.10}}):t()
 
-a=torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
-                {-6.49,  3.80,  0.00,  0.00,  0.00},
-                {-0.47, -6.39,  4.17,  0.00,  0.00},
-		{-7.20,  1.50, -1.51,  5.70,  0.00},
-		{-0.65, -6.34,  2.67,  1.80, -7.10}}):t()
-
-=a
+> a
  1.9600 -6.4900 -0.4700 -7.2000 -0.6500
  0.0000  3.8000 -6.3900  1.5000 -6.3400
  0.0000  0.0000  4.1700 -1.5100  2.6700
@@ -1457,7 +1530,7 @@ a=torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
 [torch.DoubleTensor of dimension 5x5]
 
 e = torch.symeig(a)
-=e
+> e
 -11.0656
  -6.2287
   0.8640
@@ -1466,7 +1539,7 @@ e = torch.symeig(a)
 [torch.DoubleTensor of dimension 5]
 
 e,v = torch.symeig(a,'V')
-=e
+> e
 -11.0656
  -6.2287
   0.8640
@@ -1474,7 +1547,7 @@ e,v = torch.symeig(a,'V')
  16.0948
 [torch.DoubleTensor of dimension 5]
 
-=v
+> v
 -0.2981 -0.6075  0.4026 -0.3745  0.4896
 -0.5078 -0.2880 -0.4066 -0.3572 -0.6053
 -0.0816 -0.3843 -0.6600  0.5008  0.3991
@@ -1482,7 +1555,7 @@ e,v = torch.symeig(a,'V')
 -0.8041  0.4480  0.1725  0.3108  0.1622
 [torch.DoubleTensor of dimension 5x5]
 
-=v*torch.diag(e)*v:t()
+> v*torch.diag(e)*v:t()
  1.9600 -6.4900 -0.4700 -7.2000 -0.6500
 -6.4900  3.8000 -6.3900  1.5000 -6.3400
 -0.4700 -6.3900  4.1700 -1.5100  2.6700
@@ -1490,33 +1563,39 @@ e,v = torch.symeig(a,'V')
 -0.6500 -6.3400  2.6700  1.8000 -7.1000
 [torch.DoubleTensor of dimension 5x5]
 
-=a:dist(torch.triu(v*torch.diag(e)*v:t()))
+> a:dist(torch.triu(v*torch.diag(e)*v:t()))
 1.0219480822443e-14
 
 ```
 
 <a name="torch.eig"/>
-### torch.eig([rese, resv,] a, [, 'N' or 'V']) ###
+### torch.eig([rese, resv,] a [, 'N' or 'V']) ###
 
-Eigen values and eigen vectors of a general real matrix ` A ` of
-size ` m x m `. This function calculates all right eigenvalues (and
-vectors) of ` A ` such that ` A = V' diag(e) V `. 
+
+`e,V=torch.eig(A)` returns eigen values and eigen vectors of a 
+general real square matrix `A`.
+
+`A` and `V` are `m x m` matrices and `e` is a `m` dimensional vector.
+
+This function calculates all right eigenvalues (and vectors) of `A` such 
+that `A = V' diag(e) V`.
 
 Third argument defines computation of eigenvectors or eigenvalues
-only. If ` N `, only eignevalues are computed. If ` V `, both
+only. If it is `'N'`, only eignevalues are computed. If it is `'V'`, both
 eigenvalues and eigenvectors are computed.
 
-The eigen values returned follow [LAPACK convention](https://software.intel.com/sites/products/documentation/hpc/mkl/mklman/GUID-16EB5901-5644-4DA6-A332-A052309010C4.htm) and are returned as complex (real/imaginary) pairs of numbers (Nx2 dimensional tensor).
+The eigen values returned follow 
+[LAPACK convention](https://software.intel.com/sites/products/documentation/hpc/mkl/mklman/GUID-16EB5901-5644-4DA6-A332-A052309010C4.htm) 
+and are returned as complex (real/imaginary) pairs of numbers (`2*m` dimensional tensor).
 
 ```lua
+a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
+                  {-6.49,  3.80,  0.00,  0.00,  0.00},
+                  {-0.47, -6.39,  4.17,  0.00,  0.00},
+                  {-7.20,  1.50, -1.51,  5.70,  0.00},
+                  {-0.65, -6.34,  2.67,  1.80, -7.10}}):t()
 
-a=torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
-                {-6.49,  3.80,  0.00,  0.00,  0.00},
-                {-0.47, -6.39,  4.17,  0.00,  0.00},
-    {-7.20,  1.50, -1.51,  5.70,  0.00},
-    {-0.65, -6.34,  2.67,  1.80, -7.10}}):t()
-
-=a
+> a
  1.9600 -6.4900 -0.4700 -7.2000 -0.6500
  0.0000  3.8000 -6.3900  1.5000 -6.3400
  0.0000  0.0000  4.1700 -1.5100  2.6700
@@ -1524,8 +1603,8 @@ a=torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
  0.0000  0.0000  0.0000  0.0000 -7.1000
 [torch.DoubleTensor of dimension 5x5]
 
-b = a+torch.triu(a,1):t()
-=b
+b = a + torch.triu(a,1):t()
+> b
 
   1.9600 -6.4900 -0.4700 -7.2000 -0.6500
  -6.4900  3.8000 -6.3900  1.5000 -6.3400
@@ -1535,7 +1614,7 @@ b = a+torch.triu(a,1):t()
 [torch.DoubleTensor of dimension 5x5]
 
 e = torch.eig(b)
-=e
+> e
  16.0948   0.0000
 -11.0656   0.0000
  -6.2287   0.0000
@@ -1544,7 +1623,7 @@ e = torch.eig(b)
 [torch.DoubleTensor of dimension 5x2]
 
 e,v = torch.eig(b,'V')
-=e
+> e
  16.0948   0.0000
 -11.0656   0.0000
  -6.2287   0.0000
@@ -1552,7 +1631,7 @@ e,v = torch.eig(b,'V')
   8.8655   0.0000
 [torch.DoubleTensor of dimension 5x2]
 
-=v
+> v
 -0.4896  0.2981 -0.6075 -0.4026 -0.3745
  0.6053  0.5078 -0.2880  0.4066 -0.3572
 -0.3991  0.0816 -0.3843  0.6600  0.5008
@@ -1560,7 +1639,7 @@ e,v = torch.eig(b,'V')
 -0.1622  0.8041  0.4480 -0.1725  0.3108
 [torch.DoubleTensor of dimension 5x5]
 
-=v*torch.diag(e:select(2,1))*v:t()
+> v * torch.diag(e:select(2,1))*v:t()
  1.9600 -6.4900 -0.4700 -7.2000 -0.6500
 -6.4900  3.8000 -6.3900  1.5000 -6.3400
 -0.4700 -6.3900  4.1700 -1.5100  2.6700
@@ -1568,28 +1647,30 @@ e,v = torch.eig(b,'V')
 -0.6500 -6.3400  2.6700  1.8000 -7.1000
 [torch.DoubleTensor of dimension 5x5]
 
-=b:dist(v*torch.diag(e:select(2,1))*v:t())
+> b:dist(v * torch.diag(e:select(2,1)) * v:t())
 3.5423944346685e-14
 
 ```
 
 <a name="torch.svd"/>
-### torch.svd([resu, ress, resv] a, [, 'S' or 'A']) ###
+### torch.svd([resu, ress, resv] a [, 'S' or 'A']) ###
 
-Singular value decomposition of a real matrix `A` of size `n x m`
-such that `A = USV'*T`. The call to `svd` returns `U,S,V`.
+`U,S,V=torch.svd(A)` returns the singular value decomposition of a real matrix `A` of size `n x m`
+such that `A = USV'*`.
+
+`U` is `n x n`, `S` is `n x m` and `V` is `m x m`.
 
 The last argument, if it is string, represents the number of singular
-values to be computed. `'S'` stands for 'some' and `'A'` stands for 'all'.
+values to be computed. `'S'` stands for *some* and `'A'` stands for *all*.
 
 ```lua
+a = torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
+                  {9.93,  6.91, -7.93,  1.64,  4.02,  0.15},
+                  {9.83,  5.04,  4.86,  8.83,  9.80, -8.99},
+                  {5.45, -0.27,  4.85,  0.74, 10.00, -6.02},
+                  {3.16,  7.98,  3.01,  5.80,  4.27, -5.31}}):t()
 
-a=torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
-		{9.93,  6.91, -7.93,  1.64,  4.02,  0.15},
-		{9.83,  5.04,  4.86,  8.83,  9.80, -8.99},
-		{5.45, -0.27,  4.85,  0.74, 10.00, -6.02},
-		{3.16,  7.98,  3.01,  5.80,  4.27, -5.31}}):t()
-=a
+> a
   8.7900   9.9300   9.8300   5.4500   3.1600
   6.1100   6.9100   5.0400  -0.2700   7.9800
  -9.1500  -7.9300   4.8600   4.8500   3.0100
@@ -1598,8 +1679,7 @@ a=torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
   9.8400   0.1500  -8.9900  -6.0200  -5.3100
 
 u,s,v = torch.svd(a)
-
-=u
+> u
 -0.5911  0.2632  0.3554  0.3143  0.2299
 -0.3976  0.2438 -0.2224 -0.7535 -0.3636
 -0.0335 -0.6003 -0.4508  0.2334 -0.3055
@@ -1608,7 +1688,7 @@ u,s,v = torch.svd(a)
  0.2934  0.5763 -0.0209  0.3791 -0.6526
 [torch.DoubleTensor of dimension 6x5]
 
-=s
+> s
  27.4687
  22.6432
   8.5584
@@ -1616,7 +1696,7 @@ u,s,v = torch.svd(a)
   2.0149
 [torch.DoubleTensor of dimension 5]
 
-=v
+> v
 -0.2514  0.8148 -0.2606  0.3967 -0.2180
 -0.3968  0.3587  0.7008 -0.4507  0.1402
 -0.6922 -0.2489 -0.2208  0.2513  0.5891
@@ -1624,7 +1704,7 @@ u,s,v = torch.svd(a)
 -0.4076 -0.0980 -0.4933 -0.6227 -0.4396
 [torch.DoubleTensor of dimension 5x5]
 
-=u*torch.diag(s)*v:t()
+> u * torch.diag(s) * v:t()
   8.7900   9.9300   9.8300   5.4500   3.1600
   6.1100   6.9100   5.0400  -0.2700   7.9800
  -9.1500  -7.9300   4.8600   4.8500   3.0100
@@ -1633,7 +1713,7 @@ u,s,v = torch.svd(a)
   9.8400   0.1500  -8.9900  -6.0200  -5.3100
 [torch.DoubleTensor of dimension 6x5]
 
- =a:dist(u*torch.diag(s)*v:t())
+> a:dist(u * torch.diag(s) * v:t())
 2.8923773593204e-14
 
 ```
@@ -1648,10 +1728,10 @@ Computes the inverse of square matrix `x`.
 `torch.inverse(y,x)` puts the result in `y`.
 
 ```lua
-x=torch.rand(10,10)
-y=torch.inverse(x)
-z=x*y
-print(z)
+x = torch.rand(10,10)
+y = torch.inverse(x)
+z = x * y
+> z
  1.0000 -0.0000  0.0000 -0.0000  0.0000  0.0000  0.0000 -0.0000  0.0000  0.0000
  0.0000  1.0000 -0.0000 -0.0000  0.0000  0.0000 -0.0000 -0.0000 -0.0000  0.0000
  0.0000 -0.0000  1.0000 -0.0000  0.0000  0.0000 -0.0000 -0.0000  0.0000  0.0000
@@ -1664,15 +1744,15 @@ print(z)
  0.0000 -0.0000  0.0000 -0.0000  0.0000  0.0000  0.0000 -0.0000  0.0000  1.0000
 [torch.DoubleTensor of dimension 10x10]
 
-print('Max nonzero = ', torch.max(torch.abs(z-torch.eye(10))))
-Max nonzero =     2.3092638912203e-14
+> torch.max(torch.abs(z- torch.eye(10))) -- Max nonzero
+2.3092638912203e-14
 
 ```
 
 <a name="torch.logical.dok"/>
-## Logical Operations on Tensors ##
-
-These functions implement logical comparison operators that take a
+## Logical Operations on Tensors ##`
+`
+Th`ese functions implement logical comparison operators that takea
 tensor as input and another tensor or a number as the comparison
 target.  They return a `ByteTensor` in which each element is 0 or 1
 indicating if the comparison for the corresponding element was
@@ -1717,16 +1797,15 @@ Implements `!=` operator comparing each element in `a` with `b`
 ### torch.all(a) ###
 ### torch.any(a) ###
 
-Additionally, `any` and `all` logically sum a `ByteTensor` returning true
+Additionally, `any` and `all` logically sum a `ByteTensor` returning `true`
 if any or all elements are logically true respectively. Note that logically true
-here is meant in the C sense (zero is false, non-zero is true) such as the output
+here is meant in the C sense (zero is `false`, non-zero is `true`) such as the output
 of the tensor element-wise logical operations.
 
 ```lua
-
 > a = torch.rand(10)
 > b = torch.rand(10)
-> =a
+> a
  0.5694
  0.5264
  0.3041
@@ -1739,7 +1818,7 @@ of the tensor element-wise logical operations.
  0.0740
 [torch.DoubleTensor of dimension 10]
 
-> =b
+> b
  0.2950
  0.4867
  0.9133
@@ -1752,7 +1831,7 @@ of the tensor element-wise logical operations.
  0.1737
 [torch.DoubleTensor of dimension 10]
 
-> =torch.lt(a,b)
+> torch.lt(a,b)
  0
  0
  1
@@ -1765,7 +1844,7 @@ of the tensor element-wise logical operations.
  1
 [torch.ByteTensor of dimension 10]
 
-> return torch.eq(a,b)
+> torch.eq(a,b)
 0
 0
 0
@@ -1778,7 +1857,7 @@ of the tensor element-wise logical operations.
 0
 [torch.ByteTensor of dimension 10]
 
-> return torch.ne(a,b)
+> torch.ne(a,b)
  1
  1
  1
@@ -1791,7 +1870,7 @@ of the tensor element-wise logical operations.
  1
 [torch.ByteTensor of dimension 10]
 
-> return torch.gt(a,b)
+> torch.gt(a,b)
  1
  1
  0
@@ -1804,8 +1883,8 @@ of the tensor element-wise logical operations.
  0
 [torch.ByteTensor of dimension 10]
 
-> a[torch.gt(a,b)] = 10
-> =a
+a[torch.gt(a,b)] = 10
+> a
  10.0000
  10.0000
   0.3041
@@ -1818,8 +1897,8 @@ of the tensor element-wise logical operations.
   0.0740
 [torch.DoubleTensor of dimension 10]
 
-> a[torch.gt(a,1)] = -1
-> =a
+a[torch.gt(a,1)] = -1
+> a
 -1.0000
 -1.0000
  0.3041
@@ -1832,16 +1911,20 @@ of the tensor element-wise logical operations.
  0.0740
 [torch.DoubleTensor of dimension 10]
 
-> a = torch.ones(3):byte()
-> =torch.all(a)
+a = torch.ones(3):byte()
+> torch.all(a)
 true
-> a[2] = 0
-> =torch.all(a)
+
+a[2] = 0
+> torch.all(a)
 false
-> =torch.any(a)
+
+> torch.any(a)
 true
-> a:zero()
-> =torch.any(a)
+
+a:zero()
+> torch.any(a)
 false
+
 ```
 

--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -1001,7 +1001,7 @@ These methods are very fast, as they do not involve any memory copy.
 <a name="torch.Tensor.narrow"/>
 ### [self] narrow(dim, index, size) ###
 
-Returns a new Tensor` which is a narrowed version of the current one: the dimension `dim` is narrowed
+Returns a new `Tensor` which is a narrowed version of the current one: the dimension `dim` is narrowed
 from `index` to `index+size-1`.
 
 ```lua
@@ -1573,7 +1573,7 @@ This is equivalent to self:expand(tensor:size())
  resized. `sizes` specify the number of times the tensor is repeated in each dimension.
 
  ```lua
- t7> x=torch.rand(5)
+t7> x=torch.rand(5)
 t7> =x
  0.7160
  0.6514


### PR DESCRIPTION
All these changes are superficial typograhic changes, but they
try and unify a bit its consistency.

I had to make some choices among the different usages I found:

 * Display all tensor sizes with the syntax `m x n`
   (found mxn, m-by-n)

 * Add `` arround isolated variables and everything that is code

 * Specify that code blacks are in Lua using the GitHub ```lua syntax

 * Put commas inside brackets when arguments are optional
   e.g. commas for [resval, resind,] x [,d] [,flag]
   or also [res,] x, k [, 'F' or 'V']

 * Use '> ' as prompt and display it only if the returned value is then
   shown (and so don't use = or print)
   (found '>', '=', '= ', '> = ', 't7> ', etc. )
   Still work to do on it.

 * Add spaces around * or = but not after commas (this is the guideline
   used in the majority of cases), except in inline code.

+ Correct some typos
+ Move `torch.histc` at its correct place in alphabetical order
+ Review doc for torch.multinomial, esepcially default flag value
+ Review doc for LAPACK related functions

TODO:

 * torch.gels doc not clear
 * Improve signature consistency, especially in tensor.md
 * Continue on other files…