### PR TITLE
Added kthvalue and median operations, tests, doc

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -478,7 +478,21 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name=Tensor},
          {name="index", default=lastdim(3)},
          {name="boolean", default=0}})
-   
+
+   wrap("kthvalue",
+        cname("kthvalue"),
+        {{name=Tensor, default=true, returned=true},
+         {name="IndexTensor", default=true, returned=true, noreadadd=true},
+         {name=Tensor},
+         {name="index"},
+         {name="index", default=lastdim(3)}})
+
+   wrap("median",
+        cname("median"),
+        {{name=Tensor, default=true, returned=true},
+         {name=Tensor},
+         {name="index", default=lastdim(2)}})
+
    wrap("tril",
         cname("tril"),
         {{name=Tensor, default=true, returned=true},

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1134,7 +1134,7 @@ each column of `x`.
 `y=torch.mean(x,n)` performs the mean operation over the dimension `n`.
 
 <a name="torch.min"/>
-### torch.min([resval, resind,] x) ###
+### torch.min([resval, resind,] x [,dim]) ###
 
 `y=torch.min(x)` returns the single smallest element of `x`.
 
@@ -1145,6 +1145,33 @@ each column of `x`.
 `y,i=torch.min(x,2)` performs the min operation across rows.
 
 `y,i=torch.min(x,n)` performs the min operation over the dimension `n`.
+
+<a name="torch.median"/>
+### torch.median([resval, resind,] x [,dim]) ###
+
+`y=torch.median(x)` returns the median element of `x`
+(one-before-middle in the case of an even number of elements).
+
+`y,i=torch.median(x,1)` returns the median element in each column
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
+`x`.
+
+`y,i=torch.median(x,2)` performs the median operation across rows.
+
+`y,i=torch.median(x,n)` performs the median operation over the dimension `n`.
+
+<a name="torch.kthvalue"/>
+### torch.kthvalue([resval, resind,] x, k [,dim]) ###
+
+`y=torch.kthvalue(x,k)` returns the k-th smallest element of `x`.
+
+`y,i=torch.kthvalue(x,k,1)` returns the k-th smallest element in each column
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
+`x`.
+
+`y,i=torch.kthvalue(x,k,2)` performs the k-th value operation across rows.
+
+`y,i=torch.kthvalue(x,k,n)` performs the median operation over the dimension `n`.
 
 
 <a name="torch.prod"/>

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -45,6 +45,8 @@ TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain
 TH_API long THTensor_(numel)(THTensor *t);
 TH_API void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
+TH_API void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t, long k, int dimension);
+TH_API void THTensor_(median)(THTensor *values_, THTensor *t, int dimension);
 TH_API void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension);
 TH_API void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension);
 TH_API void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension);


### PR DESCRIPTION
Added kthvalue function, to select k-th smallest value. Interface as close as possible to min/max, i.e. returns values and indices. Based on Quickselect algorithm (i.e. linear time) adapted from 'Numerical Recipes'. 

Also added median function based on same algorithm. Median returns 'middle' element in case of odd-many elements, otherwise one-before-middle element (could also do the other convention to take mean of the two around-the-middle elements, but that would be _twice_ more expensive, so I decided for this one). 