### PR TITLE
Change display of null tensors

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -23,10 +23,14 @@ local function Storage__printformat(self)
    local expMin = tensor:min()
    if expMin ~= 0 then
       expMin = math.floor(math.log10(expMin)) + 1
+   else
+      expMin = 1
    end
    local expMax = tensor:max()
    if expMax ~= 0 then
       expMax = math.floor(math.log10(expMax)) + 1
+   else
+      expMax = 1
    end
 
    local format


### PR DESCRIPTION
They where displayed with narrower columns than others.

For instance, before this commit:

```lua
> torch.Tensor(2,2):zero()
0 0
0 0
[torch.DoubleTensor of dimension 2x2]

> torch.Tensor(2,2):fill(1)
 1  1
 1  1
[torch.DoubleTensor of dimension 2x2]
```

This is because `log10()` is used to determine number width in base 10
but the case where it is 0 is handled differently.