### PR TITLE
Homogenize style of code blocks

### DIFF
--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -31,9 +31,9 @@ containing all the dimensions can be returned by
 [size()](#torch.Tensor.size).
 
 ```lua
-> print(x:nDimension())
+> x:nDimension()
 6
-> print(x:size())
+> x:size()
  4
  5
  6
@@ -61,23 +61,23 @@ x = torch.Tensor(7,7,7)
 ```
 accessing the element `(3,4,5)` can be done by
 ```lua
-= x[3][4][5]
+> x[3][4][5]
 ```
 or equivalently (but slowly!)
 ```lua
-= x:storage()[x:storageOffset()
-           +(3-1)*x:stride(1)+(4-1)*x:stride(2)+(5-1)*x:stride(3)]
+> x:storage()[x:storageOffset()
+              +(3-1)*x:stride(1)+(4-1)*x:stride(2)+(5-1)*x:stride(3)]
 ```
 One could say that a `Tensor` is a particular way of _viewing_ a
 `Storage`: a `Storage` only represents a chunk of memory, while the
 `Tensor` interprets this chunk of memory as having dimensions:
 ```lua
-> x = torch.Tensor(4,5)
-> s = x:storage()
-> for i=1,s:size() do -- fill up the Storage
->> s[i] = i
->> end
-> print(x) -- s is interpreted by x as a 2D matrix
+x = torch.Tensor(4,5)
+s = x:storage()
+for i=1,s:size() do -- fill up the Storage
+  s[i] = i
+end
+> x -- s is interpreted by x as a 2D matrix
   1   2   3   4   5
   6   7   8   9  10
  11  12  13  14  15
@@ -88,22 +88,22 @@ One could say that a `Tensor` is a particular way of _viewing_ a
 Note also that in Torch7 ___elements in the same row___ [elements along the __last__ dimension]
 are contiguous in memory for a matrix [tensor]:
 ```lua
-> x = torch.Tensor(4,5)
-> i = 0
->
-> x:apply(function()
->> i = i + 1
->> return i
->> end)
->
-> print(x)
+x = torch.Tensor(4,5)
+i = 0
+
+x:apply(function()
+  i = i + 1
+  return i
+end)
+
+> x
   1   2   3   4   5
   6   7   8   9  10
  11  12  13  14  15
  16  17  18  19  20
 [torch.DoubleTensor of dimension 4x5]
 
-> return  x:stride()
+> x:stride()
  5
  1  -- element in the last dimension are contiguous!
 [torch.LongStorage of size 2]
@@ -144,8 +144,8 @@ referencing _the same storage_. This magical behavior is internally
 obtained by good usage of the [stride()](#torch.Tensor.stride) and
 [storageOffset()](#torch.storageOffset). Example:
 ```lua
-> x = torch.Tensor(5):zero()
-> print(x)
+x = torch.Tensor(5):zero()
+> x
 0
 0
 0
@@ -154,7 +154,7 @@ obtained by good usage of the [stride()](#torch.Tensor.stride) and
 [torch.DoubleTensor of dimension 5]
 > x:narrow(1, 2, 3):fill(1) -- narrow() returns a Tensor
                             -- referencing the same Storage as x
-> print(x)
+> x
  0
  1
  1
@@ -165,11 +165,11 @@ obtained by good usage of the [stride()](#torch.Tensor.stride) and
 
 If you really need to copy a `Tensor`, you can use the [copy()](#torch.Tensor.copy) method:
 ```lua
-> y = torch.Tensor(x:size()):copy(x)
+y = torch.Tensor(x:size()):copy(x)
 ```
 Or the convenience method
 ```lua
-> y = x:clone()
+y = x:clone()
 ```
 
 We now describe all the methods for `Tensor`. If you want to specify the Tensor type,
@@ -203,23 +203,20 @@ of the `Tensor` will have a impact on the elements of the given
 `tensor`, and vice-versa. No memory copy!
 
 ```lua
-> x = torch.Tensor(2,5):fill(3.14)
-> print(x)
-
+x = torch.Tensor(2,5):fill(3.14)
+> x
  3.1400  3.1400  3.1400  3.1400  3.1400
  3.1400  3.1400  3.1400  3.1400  3.1400
 [torch.DoubleTensor of dimension 2x5]
 
-> y = torch.Tensor(x)
-> print(y)
-
+y = torch.Tensor(x)
+> y
  3.1400  3.1400  3.1400  3.1400  3.1400
  3.1400  3.1400  3.1400  3.1400  3.1400
 [torch.DoubleTensor of dimension 2x5]
 
-> y:zero()
-> print(x) -- elements of x are the same as y!
-
+y:zero()
+> x -- elements of x are the same as y!
 0 0 0 0 0
 0 0 0 0 0
 [torch.DoubleTensor of dimension 2x5]
@@ -252,8 +249,7 @@ Playing with the strides can give some interesting things:
 ```lua
 x = torch.Tensor(torch.LongStorage({4}), torch.LongStorage({0})):zero() -- zeroes the tensor
 x[1] = 1 -- all elements point to the same address!
-print(x)
-
+> x
  1
  1
  1
@@ -288,28 +284,27 @@ no memory copy!
 
 ```lua
 -- creates a storage with 10 elements
-> s = torch.Storage(10):fill(1)
+s = torch.Storage(10):fill(1)
 
-  -- we want to see it as a 2x5 tensor
-> x = torch.Tensor(s, 1, torch.LongStorage{2,5})
-> print(x)
-
+-- we want to see it as a 2x5 tensor
+x = torch.Tensor(s, 1, torch.LongStorage{2,5})
+> x
  1  1  1  1  1
  1  1  1  1  1
 [torch.DoubleTensor of dimension 2x5]
-> x:zero()
-> print(s) -- the storage contents have been modified
-> print(s)
-0
-0
-0
-0
-0
-0
-0
-0
-0
-0
+
+x:zero()
+> s -- the storage contents have been modified
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
 [torch.DoubleStorage of size 10]
 ```
 
@@ -330,7 +325,7 @@ elements. The table might be multi-dimensional.
 
 Example:
 ```lua
-> = torch.Tensor({{1,2,3,4}, {5,6,7,8}})
+> torch.Tensor({{1,2,3,4}, {5,6,7,8}})
  1  2  3  4
  5  6  7  8
 [torch.DoubleTensor of dimension 2x4]
@@ -346,11 +341,10 @@ Returns a clone of a tensor. The memory is copied.
 ```lua
 i = 0
 x = torch.Tensor(5):apply(function(x)
-i = i + 1
-return i
+  i = i + 1
+  return i
 end)
-= x
-
+> x
  1
  2
  3
@@ -360,9 +354,7 @@ end)
 
 -- create a clone of x
 y = x:clone()
-
-= y
-
+> y
  1
  2
  3
@@ -372,8 +364,7 @@ y = x:clone()
 
 -- fill up y with 1
 y:fill(1)
-= y
-
+> y
  1
  1
  1
@@ -382,8 +373,7 @@ y:fill(1)
 [torch.DoubleTensor of dimension 5]
 
 -- the contents of x were not changed:
-= x
-
+> x
  1
  2
  3
@@ -400,39 +390,34 @@ y:fill(1)
 
 ```lua
 x = torch.Tensor(2,3):fill(1)
-= x
-
+> x
  1  1  1
  1  1  1
 [torch.DoubleTensor of dimension 2x3]
 
 -- x is contiguous, so y points to the same thing
 y = x:contiguous():fill(2)
-= y
-
+> y
  2  2  2
  2  2  2
 [torch.DoubleTensor of dimension 2x3]
 
 -- contents of x have been changed
-= x
-
+> x
  2  2  2
  2  2  2
 [torch.DoubleTensor of dimension 2x3]
 
 -- x:t() is not contiguous, so z is a clone
 z = x:t():contiguous():fill(3.14)
-= z
-
+> z
  3.1400  3.1400
  3.1400  3.1400
  3.1400  3.1400
 [torch.DoubleTensor of dimension 3x2]
 
 -- contents of x have not been changed
-= x
-
+> x
  2  2  2
  2  2  2
 [torch.DoubleTensor of dimension 2x3]
@@ -455,16 +440,14 @@ copy//).
 
 ```lua
 x = torch.Tensor(3):fill(3.14)
-= x
-
+> x
  3.1400
  3.1400
  3.1400
 [torch.DoubleTensor of dimension 3]
 
 y = x:type('torch.DoubleTensor')
-= y
-
+> y
  3.1400
  3.1400
  3.1400
@@ -474,11 +457,10 @@ y = x:type('torch.DoubleTensor')
 y:zero()
 
 -- contents of x have been changed
-= x
-
-0
-0
-0
+> x
+ 0
+ 0
+ 0
 [torch.DoubleTensor of dimension 3]
 
 ```
@@ -491,16 +473,14 @@ possible loss of precision//).
 
 ```lua
 x = torch.Tensor(3):fill(3.14)
-= x
-
+> x
  3.1400
  3.1400
  3.1400
 [torch.DoubleTensor of dimension 3]
 
 y = x:type('torch.IntTensor')
-= y
-
+> y
  3
  3
  3
@@ -522,11 +502,13 @@ type(tensor:type())
 Returns `true` iff the provided `object` is one of the `torch.*Tensor` types.
 
 ```lua
-> =torch.isTensor(torch.randn(3,4))
+> torch.isTensor(torch.randn(3,4))
 true
-> =torch.isTensor(torch.randn(3,4)[1])
+
+> torch.isTensor(torch.randn(3,4)[1])
 true
-> =torch.isTensor(torch.randn(3,4)[1][2])
+
+> torch.isTensor(torch.randn(3,4)[1][2])
 false
 ```
 
@@ -542,16 +524,14 @@ false
 Convenience methods for the [type](#torch.type) method. For e.g.,
 ```lua
 x = torch.Tensor(3):fill(3.14)
-
-= x
+> x
  3.1400
  3.1400
  3.1400
 [torch.DoubleTensor of dimension 3]
 
 -- calling type('torch.IntTensor')
-= x:type('torch.IntTensor')
-
+> x:type('torch.IntTensor')
  3
  3
  3
@@ -559,8 +539,7 @@ x = torch.Tensor(3):fill(3.14)
 
 
 -- is equivalent to calling int()
-= x:int()
-
+> x:int()
  3
  3
  3
@@ -574,8 +553,8 @@ x = torch.Tensor(3):fill(3.14)
 
 Returns the number of dimensions in a `Tensor`.
 ```lua
-> x = torch.Tensor(4,5) -- a matrix
-> = x:nDimension()
+x = torch.Tensor(4,5) -- a matrix
+> x:nDimension()
 2
 ```
 
@@ -589,16 +568,15 @@ Same as [nDimension()](#torch.nDimension).
 
 Returns the size of the specified dimension `dim`. Example:
 ```lua
-> x = torch.Tensor(4,5):zero()
-> print(x)
-
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
+x = torch.Tensor(4,5):zero()
+> x
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
 [torch.DoubleTensor of dimension 4x5]
 
-> return  x:size(2) -- gets the number of columns
+> x:size(2) -- gets the number of columns
 5
 ```
 
@@ -608,16 +586,15 @@ Returns the size of the specified dimension `dim`. Example:
 Returns a [LongStorage](storage.md) containing the size of each dimension
 of the tensor.
 ```lua
-> x = torch.Tensor(4,5):zero()
-> print(x)
-
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
+x = torch.Tensor(4,5):zero()
+> x
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
 [torch.DoubleTensor of dimension 4x5]
 
-> return  x:size()
+> x:size()
  4
  5
 [torch.LongStorage of size 2]
@@ -634,22 +611,21 @@ Same as [size()](#torch.Tensor.size) method.
 Returns the jump necessary to go from one element to the next one in the
 specified dimension `dim`. Example:
 ```lua
-> x = torch.Tensor(4,5):zero()
-> print(x)
-
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
+x = torch.Tensor(4,5):zero()
+> x
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
 [torch.DoubleTensor of dimension 4x5]
 
-  --- elements in a row are contiguous in memory
-> return  x:stride(2)
+-- elements in a row are contiguous in memory
+> x:stride(2)
 1
 
-  --- to go from one element to the next one in a column
-  --- we need here to jump the size of the row
-> return  x:stride(1)
+-- to go from one element to the next one in a column
+-- we need here to jump the size of the row
+> x:stride(1)
 5
 ```
 
@@ -661,16 +637,15 @@ are contiguous in memory for a matrix [tensor].
 
 Returns the jump necessary to go from one element to the next one in each dimension. Example:
 ```lua
-> x = torch.Tensor(4,5):zero()
-> print(x)
-
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
-0 0 0 0 0
+x = torch.Tensor(4,5):zero()
+> x
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
+ 0 0 0 0 0
 [torch.DoubleTensor of dimension 4x5]
 
-> return  x:stride()
+> x:stride()
  5
  1 -- elements are contiguous in a row [last dimension]
 [torch.LongStorage of size 2]
@@ -685,13 +660,13 @@ are contiguous in memory for a matrix [tensor].
 Returns the [Storage](storage.md) used to store all the elements of the `Tensor`.
 Basically, a `Tensor` is a particular way of _viewing_ a `Storage`.
 ```lua
-> x = torch.Tensor(4,5)
-> s = x:storage()
-> for i=1,s:size() do -- fill up the Storage
->> s[i] = i
->> end
-> print(x) -- s is interpreted by x as a 2D matrix
+x = torch.Tensor(4,5)
+s = x:storage()
+for i=1,s:size() do -- fill up the Storage
+  s[i] = i
+end
 
+> x -- s is interpreted by x as a 2D matrix
   1   2   3   4   5
   6   7   8   9  10
  11  12  13  14  15
@@ -704,19 +679,21 @@ Basically, a `Tensor` is a particular way of _viewing_ a `Storage`.
 
 Returns `true` iff the elements of the `Tensor` are contiguous in memory.
 ```lua
-  -- normal tensors are contiguous in memory
-> x = torch.Tensor(4,5):zero()
-> = x:isContiguous()
+-- normal tensors are contiguous in memory
+x = torch.Tensor(4,5):zero()
+> x:isContiguous()
 true
-  -- y now "views" the 3rd column of x
-  -- the storage of y is the same than x
-  -- so the memory cannot be contiguous
-> y = x:select(2, 3)
-> = y:isContiguous()
+
+-- y now "views" the 3rd column of x
+-- the storage of y is the same than x
+-- so the memory cannot be contiguous
+y = x:select(2, 3)
+> y:isContiguous()
 false
-  -- indeed, to jump to one element to
-  -- the next one, the stride is 4
-> = y:stride()
+
+-- indeed, to jump to one element to
+-- the next one, the stride is 4
+> y:stride()
  5
 [torch.LongStorage of size 1]
 ```
@@ -726,12 +703,13 @@ false
 
 Returns `true` iff the dimensions of the `Tensor` and the argument `Tensor` are exactly the same.
 ```lua
-> x = torch.Tensor(4,5)
-> y = torch.Tensor(4,5)
-> = x:isSameSizeAs(y)
+x = torch.Tensor(4,5)
+y = torch.Tensor(4,5)
+> x:isSameSizeAs(y)
 true
-> y = torch.Tensor(4, 6)
-> = x:isSameSizeAs(y)
+
+y = torch.Tensor(4, 6)
+> x:isSameSizeAs(y)
 false
 ```
 
@@ -740,8 +718,8 @@ false
 
 Returns the number of elements of a tensor.
 ```lua
-> x = torch.Tensor(4,5)
-> = x:nElement() -- 4x5 = 20!
+x = torch.Tensor(4,5)
+> x:nElement() -- 4x5 = 20!
 20
 ```
 
@@ -775,33 +753,30 @@ like [`torch.le`](maths.md#torchlea-b).
 
 Example:
 ```lua
-> x = torch.Tensor(3,3)
-> i = 0; x:apply(function() i = i + 1; return i end)
-> = x
-
+x = torch.Tensor(3,3)
+i = 0; x:apply(function() i = i + 1; return i end)
+> x
  1  2  3
  4  5  6
  7  8  9
 [torch.DoubleTensor of dimension 3x3]
 
-> = x[2] -- returns row 2
-
+> x[2] -- returns row 2
  4
  5
  6
 [torch.DoubleTensor of dimension 3]
 
-> = x[2][3] -- returns row 2, column 3
+> x[2][3] -- returns row 2, column 3
 6
 
-> = x[{2,3}] -- another way to return row 2, column 3
+> x[{2,3}] -- another way to return row 2, column 3
 6
 
-> = x[torch.LongStorage{2,3}] -- yet another way to return row 2, column 3
+> x[torch.LongStorage{2,3}] -- yet another way to return row 2, column 3
 6
 
-> = x[torch.le(x,3)] -- torch.le returns a ByteTensor that acts as a mask
-
+> x[torch.le(x,3)] -- torch.le returns a ByteTensor that acts as a mask
  1
  2
  3
@@ -835,25 +810,22 @@ the `Tensor` will have an impact on the elements of the given `tensor`, and
 vice-versa. This is an efficient method, as there is no memory copy!
 
 ```lua
-> x = torch.Tensor(2,5):fill(3.14)
-> print(x)
-
+x = torch.Tensor(2,5):fill(3.14)
+> x
  3.1400  3.1400  3.1400  3.1400  3.1400
  3.1400  3.1400  3.1400  3.1400  3.1400
 [torch.DoubleTensor of dimension 2x5]
 
-> y = torch.Tensor():set(x)
-> print(y)
-
+y = torch.Tensor():set(x)
+> y
  3.1400  3.1400  3.1400  3.1400  3.1400
  3.1400  3.1400  3.1400  3.1400  3.1400
 [torch.DoubleTensor of dimension 2x5]
 
-> y:zero()
-> print(x) -- elements of x are the same than y!
-
-0 0 0 0 0
-0 0 0 0 0
+y:zero()
+> x -- elements of x are the same than y!
+ 0 0 0 0 0
+ 0 0 0 0 0
 [torch.DoubleTensor of dimension 2x5]
 ```
 
@@ -871,31 +843,30 @@ memory copy!
 If only `storage` is provided, the whole storage will be viewed as a 1D Tensor.
 
 ```lua
-  -- creates a storage with 10 elements
-> s = torch.Storage(10):fill(1)
+-- creates a storage with 10 elements
+s = torch.Storage(10):fill(1)
 
-  -- we want to see it as a 2x5 tensor
-> sz = torch.LongStorage({2,5})
-> x = torch.Tensor()
-> x:set(s, 1, sz)
-> print(x)
-
+-- we want to see it as a 2x5 tensor
+sz = torch.LongStorage({2,5})
+x = torch.Tensor()
+x:set(s, 1, sz)
+> x
  1  1  1  1  1
  1  1  1  1  1
 [torch.DoubleTensor of dimension 2x5]
-> x:zero()
-> print(s) -- the storage contents have been modified
-> print(s)
-0
-0
-0
-0
-0
-0
-0
-0
-0
-0
+
+x:zero()
+> s -- the storage contents have been modified
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
+ 0
 [torch.DoubleStorage of size 10]
 ```
 
@@ -916,18 +887,16 @@ Copy the elements of the given `tensor`. The
 sizes might be different.
 
 ```lua
-> x = torch.Tensor(4):fill(1)
-> y = torch.Tensor(2,2):copy(x)
-> print(x)
-
+x = torch.Tensor(4):fill(1)
+y = torch.Tensor(2,2):copy(x)
+> x
  1
  1
  1
  1
 [torch.DoubleTensor of dimension 4]
 
-> print(y)
-
+> y
  1  1
  1  1
 [torch.DoubleTensor of dimension 2x2]
@@ -941,8 +910,7 @@ which, of course, might result in loss of precision.
 
 Fill the tensor with the given `value`.
 ```lua
-> = torch.DoubleTensor(4):fill(3.14)
-
+> torch.DoubleTensor(4):fill(3.14)
  3.1400
  3.1400
  3.1400
@@ -955,12 +923,11 @@ Fill the tensor with the given `value`.
 
 Fill the tensor with zeros.
 ```lua
-> = torch.Tensor(4):zero()
-
-0
-0
-0
-0
+> torch.Tensor(4):zero()
+ 0
+ 0
+ 0
+ 0
 [torch.DoubleTensor of dimension 4]
 ```
 
@@ -1005,8 +972,8 @@ Returns a new `Tensor` which is a narrowed version of the current one: the dimen
 from `index` to `index+size-1`.
 
 ```lua
-> x = torch.Tensor(5, 6):zero()
-> print(x)
+x = torch.Tensor(5, 6):zero()
+> x
 
 0 0 0 0 0 0
 0 0 0 0 0 0
@@ -1015,17 +982,15 @@ from `index` to `index+size-1`.
 0 0 0 0 0 0
 [torch.DoubleTensor of dimension 5x6]
 
-> y = x:narrow(1, 2, 3) -- narrow dimension 1 from index 2 to index 2+3-1
-> y:fill(1) -- fill with 1
-> print(y)
-
+y = x:narrow(1, 2, 3) -- narrow dimension 1 from index 2 to index 2+3-1
+y:fill(1) -- fill with 1
+> y
  1  1  1  1  1  1
  1  1  1  1  1  1
  1  1  1  1  1  1
 [torch.DoubleTensor of dimension 3x6]
 
-> print(x) -- memory in x has been modified!
-
+> x -- memory in x has been modified!
  0  0  0  0  0  0
  1  1  1  1  1  1
  1  1  1  1  1  1
@@ -1045,26 +1010,23 @@ interpreted index starting from the end: `-1` is the last index,
 `-2` is the index before the last index, ...
 
 ```lua
-> x = torch.Tensor(5, 6):zero()
-> print(x)
-
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
+x = torch.Tensor(5, 6):zero()
+> x
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
 [torch.DoubleTensor of dimension 5x6]
 
-> y = x:sub(2,4):fill(1) -- y is sub-tensor of x: 
-> print(y)               -- dimension 1 starts at index 2, ends at index 4
-
+y = x:sub(2,4):fill(1) -- y is sub-tensor of x: 
+> y                    -- dimension 1 starts at index 2, ends at index 4
  1  1  1  1  1  1
  1  1  1  1  1  1
  1  1  1  1  1  1
 [torch.DoubleTensor of dimension 3x6]
 
-> print(x)               -- x has been modified!
-
+> x                    -- x has been modified!
  0  0  0  0  0  0
  1  1  1  1  1  1
  1  1  1  1  1  1
@@ -1072,15 +1034,15 @@ interpreted index starting from the end: `-1` is the last index,
  0  0  0  0  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> z = x:sub(2,4,3,4):fill(2) -- we now take a new sub-tensor
-> print(z)                   -- dimension 1 starts at index 2, ends at index 4
-                             -- dimension 2 starts at index 3, ends at index 4
+z = x:sub(2,4,3,4):fill(2) -- we now take a new sub-tensor
+> z                        -- dimension 1 starts at index 2, ends at index 4
+                           -- dimension 2 starts at index 3, ends at index 4
  2  2
  2  2
  2  2
 [torch.DoubleTensor of dimension 3x2]
 
-> print(x)                  -- x has been modified
+> x                        -- x has been modified
 
  0  0  0  0  0  0
  1  1  2  2  1  1
@@ -1089,8 +1051,7 @@ interpreted index starting from the end: `-1` is the last index,
  0  0  0  0  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> print(y:sub(-1, -1, 3, 4)) -- negative values = bounds
-
+> y:sub(-1, -1, 3, 4)      -- negative values = bounds
  2  2
 [torch.DoubleTensor of dimension 1x2]
 ```
@@ -1106,19 +1067,17 @@ tensor.
 Note that "selecting" on the first dimension is equivalent to use the [[] operator](#torch.__index__ )
 
 ```lua
-> x = torch.Tensor(5,6):zero()
-> print(x)
-
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
+x = torch.Tensor(5,6):zero()
+> x
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
 [torch.DoubleTensor of dimension 5x6]
 
-> y = x:select(1, 2):fill(2) -- select row 2 and fill up
-> print(y)
-
+y = x:select(1, 2):fill(2) -- select row 2 and fill up
+> y
  2
  2
  2
@@ -1127,8 +1086,7 @@ Note that "selecting" on the first dimension is equivalent to use the [[] operat
  2
 [torch.DoubleTensor of dimension 6]
 
-> print(x)
-
+> x
  0  0  0  0  0  0
  2  2  2  2  2  2
  0  0  0  0  0  0
@@ -1136,9 +1094,8 @@ Note that "selecting" on the first dimension is equivalent to use the [[] operat
  0  0  0  0  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> z = x:select(2,5):fill(5) -- select column 5 and fill up
-> print(z)
-
+z = x:select(2,5):fill(5) -- select column 5 and fill up
+> z
  5
  5
  5
@@ -1146,8 +1103,7 @@ Note that "selecting" on the first dimension is equivalent to use the [[] operat
  5
 [torch.DoubleTensor of dimension 5]
 
-> print(x)
-
+> x
  0  0  0  0  5  0
  2  2  2  2  5  2
  0  0  0  0  5  0
@@ -1167,19 +1123,17 @@ This operator also works with an input mask made of a `ByteTensor` with 0 and 1
 elements, e.g with a [logical operator](maths.md#logical-operations-on-tensors).
 
 ```lua
-> x = torch.Tensor(5, 6):zero()
-> print(x)
-
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
-0 0 0 0 0 0
+x = torch.Tensor(5, 6):zero()
+> x
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
+ 0 0 0 0 0 0
 [torch.DoubleTensor of dimension 5x6]
 
-> x[{ 1,3 }] = 1 -- sets element at (i=1,j=3) to 1
-> print(x)
- 
+x[{ 1,3 }] = 1 -- sets element at (i=1,j=3) to 1
+> x
  0  0  1  0  0  0
  0  0  0  0  0  0
  0  0  0  0  0  0
@@ -1187,9 +1141,8 @@ elements, e.g with a [logical operator](maths.md#logical-operations-on-tensors).
  0  0  0  0  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> x[{ 2,{2,4} }] = 2  -- sets a slice of 3 elements to 2
-> print(x)
-
+x[{ 2,{2,4} }] = 2  -- sets a slice of 3 elements to 2
+> x
  0  0  1  0  0  0
  0  2  2  2  0  0
  0  0  0  0  0  0
@@ -1197,9 +1150,8 @@ elements, e.g with a [logical operator](maths.md#logical-operations-on-tensors).
  0  0  0  0  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> x[{ {},4 }] = -1 -- sets the full 4th column to -1
-> print(x)
-
+x[{ {},4 }] = -1 -- sets the full 4th column to -1
+> x
  0  0  1 -1  0  0
  0  2  2 -1  0  0
  0  0  0 -1  0  0
@@ -1207,8 +1159,8 @@ elements, e.g with a [logical operator](maths.md#logical-operations-on-tensors).
  0  0  0 -1  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> x[{ {},2 }] = torch.range(1,5) -- copy a 1D tensor to a slice of x
-> print(x)
+x[{ {},2 }] = torch.range(1,5) -- copy a 1D tensor to a slice of x
+> x
 
  0  1  1 -1  0  0
  0  2  2 -1  0  0
@@ -1217,8 +1169,8 @@ elements, e.g with a [logical operator](maths.md#logical-operations-on-tensors).
  0  5  0 -1  0  0
 [torch.DoubleTensor of dimension 5x6]
 
-> x[torch.lt(x,0)] = -2 -- sets all negative elements to -2 via a mask
-> print(x)
+x[torch.lt(x,0)] = -2 -- sets all negative elements to -2 via a mask
+> x
 
  0  1  1 -2  0  0
  0  2  2 -2  0  0
@@ -1237,8 +1189,8 @@ The returned tensor has the same number of dimensions as the original tensor.
 The returned tensor does __not__ use the same storage as the original tensor -- see below for storing the result in an existing tensor.
 
 ```lua
-t7> x = torch.rand(5,5)
-t7> =x
+x = torch.rand(5,5)
+> x
  0.8020  0.7246  0.1204  0.3419  0.4385
  0.0369  0.4158  0.0985  0.3024  0.8186
  0.2746  0.9362  0.2546  0.8586  0.6674
@@ -1246,18 +1198,19 @@ t7> =x
  0.1412  0.6784  0.1624  0.8113  0.3949
 [torch.DoubleTensor of dimension 5x5]
 
-t7> y = x:index(1,torch.LongTensor{3,1})
-t7> =y
+y = x:index(1,torch.LongTensor{3,1})
+> y
  0.2746  0.9362  0.2546  0.8586  0.6674
  0.8020  0.7246  0.1204  0.3419  0.4385
 [torch.DoubleTensor of dimension 2x5]
-t7> y:fill(1)
-t7> =y
+
+y:fill(1)
+> y
  1  1  1  1  1
  1  1  1  1  1
 [torch.DoubleTensor of dimension 2x5]
 
-t7> =x
+> x
  0.8020  0.7246  0.1204  0.3419  0.4385
  0.0369  0.4158  0.0985  0.3024  0.8186
  0.2746  0.9362  0.2546  0.8586  0.6674
@@ -1275,8 +1228,8 @@ However, the explicit `index` function can not use the same storage.
 It is possible to store the result into an existing Tensor with `result:index(source, ...)`:
 
 ```lua
-t7> x = torch.rand(5,5)
-t7> =x
+x = torch.rand(5,5)
+> x
  0.8020  0.7246  0.1204  0.3419  0.4385
  0.0369  0.4158  0.0985  0.3024  0.8186
  0.2746  0.9362  0.2546  0.8586  0.6674
@@ -1284,9 +1237,9 @@ t7> =x
  0.1412  0.6784  0.1624  0.8113  0.3949
 [torch.DoubleTensor of dimension 5x5]
 
-t7> y = torch.Tensor()
-ty> y:index(x,1,torch.LongTensor{3,1})
-t7> =y
+y = torch.Tensor()
+y:index(x,1,torch.LongTensor{3,1})
+> y
  0.2746  0.9362  0.2546  0.8586  0.6674
  0.8020  0.7246  0.1204  0.3419  0.4385
 [torch.DoubleTensor of dimension 2x5]
@@ -1299,17 +1252,18 @@ t7> =y
 Copies the elements of `tensor` into itself by selecting the indices in the order defined by the order given in `index`.
 
 ```lua
-t7> =x
+> x
  0.8020  0.7246  0.1204  0.3419  0.4385
  0.0369  0.4158  0.0985  0.3024  0.8186
  0.2746  0.9362  0.2546  0.8586  0.6674
  0.7473  0.9028  0.1046  0.9085  0.6622
  0.1412  0.6784  0.1624  0.8113  0.3949
 [torch.DoubleTensor of dimension 5x5]
-t7> z=torch.Tensor(5,2)
-t7> z:select(2,1):fill(-1)
-t7> z:select(2,2):fill(-2)
-t7> =z
+
+z=torch.Tensor(5,2)
+z:select(2,1):fill(-1)
+z:select(2,2):fill(-2)
+> z
 -1 -2
 -1 -2
 -1 -2
@@ -1317,8 +1271,8 @@ t7> =z
 -1 -2
 [torch.DoubleTensor of dimension 5x2]
 
-t7> x:indexCopy(2,torch.LongTensor{5,1},z)
-t7> =x
+x:indexCopy(2,torch.LongTensor{5,1},z)
+> x
 -2.0000  0.7246  0.1204  0.3419 -1.0000
 -2.0000  0.4158  0.0985  0.3024 -1.0000
 -2.0000  0.9362  0.2546  0.8586 -1.0000
@@ -1334,8 +1288,8 @@ t7> =x
 Fills the elements of itself with value `val` by selecting the indices in the order defined by the order given in `index`.
 
 ```lua
-t7> x=torch.rand(5,5)
-t7> =x
+x=torch.rand(5,5)
+> x
  0.8414  0.4121  0.3934  0.5600  0.5403
  0.3029  0.2040  0.7893  0.6079  0.6334
  0.3743  0.1389  0.1573  0.1357  0.8460
@@ -1343,8 +1297,8 @@ t7> =x
  0.8739  0.6887  0.4271  0.0385  0.9116
 [torch.DoubleTensor of dimension 5x5]
 
-t7> x:indexFill(2,torch.LongTensor{4,2},-10)
-t7> =x
+x:indexFill(2,torch.LongTensor{4,2},-10)
+> x
   0.8414 -10.0000   0.3934 -10.0000   0.5403
   0.3029 -10.0000   0.7893 -10.0000   0.6334
   0.3743 -10.0000   0.1573 -10.0000   0.8460
@@ -1363,21 +1317,21 @@ Returns a new Tensor which contains all elements aligned to a `1` in the corresp
 be a 1D tensor of the same type as `Tensor` having size `mask:sum()`.
 
 ```lua
-t7> x = torch.range(1,12):double():resize(3,4)
-t7> =x
+x = torch.range(1,12):double():resize(3,4)
+> x
   1   2   3   4
   5   6   7   8
   9  10  11  12
 [torch.DoubleTensor of dimension 3x4]
 
-t7> mask = torch.DoubleTensor():rand(12):mul(2):floor():byte():resize(2,6)
-t7> =mask 
+mask = torch.DoubleTensor():rand(12):mul(2):floor():byte():resize(2,6)
+> mask 
  1  0  1  0  0  0
  1  1  0  0  0  1
 [torch.ByteTensor of dimension 2x6]
 
-t7> y = x:maskedSelect(mask)
-t7> =y
+y = x:maskedSelect(mask)
+> y
   1
   3
   7
@@ -1385,9 +1339,9 @@ t7> =y
  12
 [torch.DoubleTensor of dimension 5]
 
-t7> z = torch.DoubleTensor()
-t7> z:maskedSelect(x, mask)
-t7> =z
+z = torch.DoubleTensor()
+z:maskedSelect(x, mask)
+> z
   1
   3
   7
@@ -1407,25 +1361,25 @@ corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor`
 of zeros and ones. The `mask`, `tensor` and `Tensor` must have the same number of elements.
 
 ```lua
-t7> x = torch.range(1,8):double():resize(2,4)
-t7> =x
+x = torch.range(1,8):double():resize(2,4)
+> x
  1  2  3  4
  5  6  7  8
 [torch.DoubleTensor of dimension 2x4]
 
-t7> mask = torch.DoubleTensor():rand(8):mul(2):floor():byte():resize(1,8)
-t7> =mask
+mask = torch.DoubleTensor():rand(8):mul(2):floor():byte():resize(1,8)
+> mask
  1  0  0  1  1  0  0  1
 [torch.ByteTensor of dimension 1x8]
 
-t7> y = x:clone():fill(-1)
-t7> =y
+y = x:clone():fill(-1)
+> y
 -1 -1 -1 -1
 -1 -1 -1 -1
 [torch.DoubleTensor of dimension 2x4]
 
-t7> y:maskedCopy(mask, x)
-t7> =y
+y:maskedCopy(mask, x)
+> y
  1 -1 -1  2
  3 -1 -1  4
 [torch.DoubleTensor of dimension 2x4]
@@ -1442,19 +1396,19 @@ corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor`
 of zeros and ones. The `mask` and `Tensor` must have the same number of elements.
 
 ```lua
-t7> x = torch.range(1,4):double():resize(1,4)
-t7> =x
+x = torch.range(1,4):double():resize(1,4)
+> x
  1  2  3  4
 [torch.DoubleTensor of dimension 1x4]
 
-t7> mask = torch.DoubleTensor():rand(4):mul(2):floor():byte():resize(2,2)
-t7> =mask
+mask = torch.DoubleTensor():rand(4):mul(2):floor():byte():resize(2,2)
+> mask
  0  0
  1  1
 [torch.ByteTensor of dimension 2x2]
 
-t7> x:maskedFill(mask, -1)
-t7> =x
+x:maskedFill(mask, -1)
+> x
  1  2 -1 -1
 [torch.DoubleTensor of dimension 1x4]
 
@@ -1476,8 +1430,8 @@ singleton dimensions can be expanded to multiple ones by setting the `stride` to
 Any dimension that is 1 can be expanded to arbitrary value without any new memory allocation.
 
 ```lua
-t7> x=torch.rand(10,1)
-t7> =x
+x = torch.rand(10,1)
+> x
  0.3837
  0.5966
  0.0763
@@ -1490,8 +1444,8 @@ t7> =x
  0.2239
 [torch.DoubleTensor of dimension 10x1]
 
-t7> y=torch.expand(x,10,2)
-t7> =y
+y = torch.expand(x,10,2)
+> y
  0.3837  0.3837
  0.5966  0.5966
  0.0763  0.0763
@@ -1504,8 +1458,8 @@ t7> =y
  0.2239  0.2239
 [torch.DoubleTensor of dimension 10x2]
 
-t7> y:fill(1)
-t7> =y
+y:fill(1)
+> y
  1  1
  1  1
  1  1
@@ -1518,7 +1472,7 @@ t7> =y
  1  1
 [torch.DoubleTensor of dimension 10x2]
 
-t7> =x
+> x
  1
  1
  1
@@ -1531,8 +1485,8 @@ t7> =x
  1
 [torch.DoubleTensor of dimension 10x1]
 
-t7> i=0; y:apply(function() i=i+1;return i end)
-t7> =y
+i=0; y:apply(function() i=i+1;return i end)
+> y
   2   2
   4   4
   6   6
@@ -1545,7 +1499,7 @@ t7> =y
  20  20
 [torch.DoubleTensor of dimension 10x2]
 
-t7> =x
+> x
   2
   4
   6
@@ -1573,8 +1527,8 @@ This is equivalent to self:expand(tensor:size())
  resized. `sizes` specify the number of times the tensor is repeated in each dimension.
 
  ```lua
-t7> x=torch.rand(5)
-t7> =x
+x = torch.rand(5)
+> x
  0.7160
  0.6514
  0.0704
@@ -1582,13 +1536,13 @@ t7> =x
  0.7452
 [torch.DoubleTensor of dimension 5]
 
-t7> =torch.repeatTensor(x,3,2)
+> torch.repeatTensor(x,3,2)
  0.7160  0.6514  0.0704  0.7856  0.7452  0.7160  0.6514  0.0704  0.7856  0.7452
  0.7160  0.6514  0.0704  0.7856  0.7452  0.7160  0.6514  0.0704  0.7856  0.7452
  0.7160  0.6514  0.0704  0.7856  0.7452  0.7160  0.6514  0.0704  0.7856  0.7452
 [torch.DoubleTensor of dimension 3x10]
 
-t7> return torch.repeatTensor(x,3,2,1)
+> torch.repeatTensor(x,3,2,1)
 (1,.,.) = 
   0.7160  0.6514  0.0704  0.7856  0.7452
   0.7160  0.6514  0.0704  0.7856  0.7452
@@ -1611,9 +1565,9 @@ Removes all singleton dimensions of the tensor.
 If `dim` is given, squeezes only that particular dimension of the tensor.
 
  ```lua
- t7> x=torch.rand(2,1,2,1,2)
-t7> =x
- (1,1,1,.,.) =
+x=torch.rand(2,1,2,1,2)
+> x
+(1,1,1,.,.) =
   0.6020  0.8897
 
 (2,1,1,.,.) =
@@ -1626,7 +1580,7 @@ t7> =x
   0.5467  0.8648
 [torch.DoubleTensor of dimension 2x1x2x1x2]
 
-t7> =torch.squeeze(x)
+> torch.squeeze(x)
 (1,.,.) =
   0.6020  0.8897
   0.4441  0.9792
@@ -1636,7 +1590,7 @@ t7> =torch.squeeze(x)
   0.5467  0.8648
 [torch.DoubleTensor of dimension 2x2x2] 
 
-t7> =torch.squeeze(x, 2)
+> torch.squeeze(x,2)
 (1,1,.,.) =
   0.6020  0.8897
 
@@ -1672,27 +1626,27 @@ is -1, the size of that dimension is inferred from the rest of the elements.
 
 
 ```lua
-> x = torch.zeros(4)
-> print(x:view(2,2))
-0 0
-0 0
+x = torch.zeros(4)
+> x:view(2,2)
+ 0 0
+ 0 0
 [torch.DoubleTensor of dimension 2x2]
 
-> print(x:view(2,-1))
-0 0
-0 0
+> x:view(2,-1)
+ 0 0
+ 0 0
 [torch.DoubleTensor of dimension 2x2]
 
-> print(x:view(torch.LongStorage{2,2}))
-0 0
-0 0
+> x:view(torch.LongStorage{2,2})
+ 0 0
+ 0 0
 [torch.DoubleTensor of dimension 2x2]
 
-> print(x)
-0
-0
-0
-0
+> x
+ 0
+ 0
+ 0
+ 0
 [torch.DoubleTensor of dimension 4]
 ```
 
@@ -1705,11 +1659,11 @@ made to point to storage of `tensor`.
 
 
 ```lua
-> x = torch.zeros(4)
-> y = torch.Tensor(2,2)
-> print(x:viewAs(y))
-0 0
-0 0
+x = torch.zeros(4)
+y = torch.Tensor(2,2)
+> x:viewAs(y)
+ 0 0
+ 0 0
 [torch.DoubleTensor of dimension 2x2]
 ```
 
@@ -1720,35 +1674,31 @@ made to point to storage of `tensor`.
 Returns a tensor where dimensions `dim1` and `dim2` have been swapped. For 2D tensors,
 the convenience method of [t()](#torch.Tensor.t) is available.
 ```lua
-> x = torch.Tensor(3,4):zero()                  
-> x:select(2,3):fill(7) -- fill column 3 with 7
-> print(x)
-
+x = torch.Tensor(3,4):zero()                  
+x:select(2,3):fill(7) -- fill column 3 with 7
+> x
  0  0  7  0
  0  0  7  0
  0  0  7  0
 [torch.DoubleTensor of dimension 3x4]
 
-> y = x:transpose(1,2) -- swap dimension 1 and 2
-> print(y)
-
+y = x:transpose(1,2) -- swap dimension 1 and 2
+> y
  0  0  0
  0  0  0
  7  7  7
  0  0  0
 [torch.DoubleTensor of dimension 4x3]
 
-> y:select(2, 3):fill(8) -- fill column 3 with 8
-> print(y)
-
+y:select(2, 3):fill(8) -- fill column 3 with 8
+> y
  0  0  8
  0  0  8
  7  7  8
  0  0  8
 [torch.DoubleTensor of dimension 4x3]
 
-> print(x) -- contents of x have changed as well
-
+> x -- contents of x have changed as well
  0  0  7  0
  0  0  7  0
  8  8  8  8
@@ -1762,19 +1712,17 @@ the convenience method of [t()](#torch.Tensor.t) is available.
 Convenience method of [transpose()](#torch.Tensor.transpose) for 2D
 tensors. The given tensor must be 2 dimensional. Swap dimensions 1 and 2.
 ```lua
-> x = torch.Tensor(3,4):zero()
-> x:select(2,3):fill(7)
-> y = x:t()
-> print(y)
-
+x = torch.Tensor(3,4):zero()
+x:select(2,3):fill(7)
+y = x:t()
+> y
  0  0  0
  0  0  0
  7  7  7
  0  0  0
 [torch.DoubleTensor of dimension 4x3]
 
-> print(x)
-
+> x
  0  0  7  0
  0  0  7  0
  0  0  7  0
@@ -1791,18 +1739,16 @@ Returns a tensor where the dimensions were permuted according to the permutation
 given by (dim1, dim2, ... , dimn). The permutation must be specified fully, i.e.
 there must be as many parameters as the tensor has dimensions.
 ```lua
-> x = torch.Tensor(3,4,2,5)
-> print(x:size())
-
+x = torch.Tensor(3,4,2,5)
+> x:size()
  3
  4
  2
  5
 [torch.LongStorage of size 4]
 
-t7> y = x:permute(2,3,1,4) -- equivalent to y = x:transpose(1,3):transpose(1,2)
-t7> print(y:size())
-
+y = x:permute(2,3,1,4) -- equivalent to y = x:transpose(1,3):transpose(1,2)
+> y:size()
  4
  2
  3
@@ -1824,10 +1770,9 @@ If `sizedim` is the original size of dimension `dim`, the size of dimension
 An additional dimension of size `size` is appended in the returned tensor.
 
 ```lua
-> x = torch.Tensor(7)
-> for i=1,7 do x[i] = i end
-> print(x)
-
+x = torch.Tensor(7)
+for i=1,7 do x[i] = i end
+> x
  1
  2
  3
@@ -1837,8 +1782,7 @@ An additional dimension of size `size` is appended in the returned tensor.
  7
 [torch.DoubleTensor of dimension 7]
 
-> return  x:unfold(1, 2, 1)
-
+> x:unfold(1, 2, 1)
  1  2
  2  3
  3  4
@@ -1847,8 +1791,7 @@ An additional dimension of size `size` is appended in the returned tensor.
  6  7
 [torch.DoubleTensor of dimension 6x2]
 
-> return  x:unfold(1, 2, 2)
-
+> x:unfold(1, 2, 2)
  1  2
  3  4
  5  6
@@ -1872,34 +1815,33 @@ a number, in which case it will be stored in self.
 
 Examples:
 ```lua
-> i = 0
-> z = torch.Tensor(3,3)
-> z:apply(function(x)
->> i = i + 1
->> return i
->> end) -- fill up the tensor
-> = z
-
+i = 0
+z = torch.Tensor(3,3)
+z:apply(function(x)
+  i = i + 1
+  return i
+end) -- fill up the tensor
+> z
  1  2  3
  4  5  6
  7  8  9
 [torch.DoubleTensor of dimension 3x3]
 
-> z:apply(math.sin) -- apply the sin function
-> = z
-
+z:apply(math.sin) -- apply the sin function
+> z
  0.8415  0.9093  0.1411
 -0.7568 -0.9589 -0.2794
  0.6570  0.9894  0.4121
 [torch.DoubleTensor of dimension 3x3]
 
-> sum = 0
-> z:apply(function(x)
->> sum = sum + x
->> end) -- compute the sum of the elements
-> = sum
+sum = 0
+z:apply(function(x)
+  sum = sum + x
+end) -- compute the sum of the elements
+> sum
 1.9552094821074
-> = z:sum() -- it is indeed correct!
+
+> z:sum() -- it is indeed correct!
 1.9552094821074
 ```
 
@@ -1914,21 +1856,19 @@ a number, in which case it will be stored in self.
 
 Example:
 ```lua
-> x = torch.Tensor(3,3)
-> y = torch.Tensor(9)
-> i = 0
-> x:apply(function() i = i + 1; return i end) -- fill-up x
-> i = 0
-> y:apply(function() i = i + 1; return i end) -- fill-up y
-> = x
-
+x = torch.Tensor(3,3)
+y = torch.Tensor(9)
+i = 0
+x:apply(function() i = i + 1; return i end) -- fill-up x
+i = 0
+y:apply(function() i = i + 1; return i end) -- fill-up y
+> x
  1  2  3
  4  5  6
  7  8  9
 [torch.DoubleTensor of dimension 3x3]
 
-> = y
-
+> y
  1
  2
  3
@@ -1940,9 +1880,8 @@ Example:
  9
 [torch.DoubleTensor of dimension 9]
 
-> x:map(y, function(xx, yy) return xx*yy end) -- element-wise multiplication
-> = x
-
+x:map(y, function(xx, yy) return xx*yy end) -- element-wise multiplication
+> x
   1   4   9
  16  25  36
  49  64  81
@@ -1960,23 +1899,21 @@ a number, in which case it will be stored in self.
 
 Example:
 ```lua
-> x = torch.Tensor(3,3)
-> y = torch.Tensor(9)
-> z = torch.Tensor(3,3)
-> 
-> i = 0; x:apply(function() i = i + 1; return math.cos(i)*math.cos(i) end)
-> i = 0; y:apply(function() i = i + 1; return i end)
-> i = 0; z:apply(function() i = i + 1; return i end)
-> 
-> print(x)
+x = torch.Tensor(3,3)
+y = torch.Tensor(9)
+z = torch.Tensor(3,3)
 
+i = 0; x:apply(function() i = i + 1; return math.cos(i)*math.cos(i) end)
+i = 0; y:apply(function() i = i + 1; return i end)
+i = 0; z:apply(function() i = i + 1; return i end)
+
+> x
  0.2919  0.1732  0.9801
  0.4272  0.0805  0.9219
  0.5684  0.0212  0.8302
 [torch.DoubleTensor of dimension 3x3]
 
-> print(y)
-
+> y
  1
  2
  3
@@ -1988,18 +1925,14 @@ Example:
  9
 [torch.DoubleTensor of dimension 9]
 
-> print(z)
-
+> z
  1  2  3
  4  5  6
  7  8  9
 [torch.DoubleTensor of dimension 3x3]
 
-> 
-> x:map2(y, z, function(xx, yy, zz) return xx+yy*zz end)
-> 
-> print(x)
-
+x:map2(y, z, function(xx, yy, zz) return xx+yy*zz end)
+> x
   1.2919   4.1732   9.9801
  16.4272  25.0805  36.9219
  49.5684  64.0212  81.8302
@@ -2026,7 +1959,7 @@ is emptied and reused.
 
 Example:
 ```lua
-> x = torch.randn(3,4,5)
+x = torch.randn(3,4,5)
 
 > x:split(2,1)
 {
@@ -2063,7 +1996,7 @@ torch.split(result, tensor, math.ceil(tensor:size(dim)/n), dim)
 
 Example:
 ```lua
-> x = torch.randn(3,4,5)
+x = torch.randn(3,4,5)
 
 > x:chunk(2,1)
 {
@@ -2100,19 +2033,19 @@ almost as fast as C in lots of cases.
 
 Example:
 ```lua
-> t = torch.randn(3,2)
-> print(t)
+t = torch.randn(3,2)
+> t
  0.8008 -0.6103
  0.6473 -0.1870
 -0.0023 -0.4902
 [torch.DoubleTensor of dimension 3x2]
 
-> t_data = torch.data(t)
-> for i = 0,t:nElement()-1 do t_data[i] = 0 end
-> print(t)
-0 0
-0 0
-0 0
+t_data = torch.data(t)
+for i = 0,t:nElement()-1 do t_data[i] = 0 end
+> t
+ 0 0
+ 0 0
+ 0 0
 [torch.DoubleTensor of dimension 3x2]
 ```
 
@@ -2120,16 +2053,14 @@ WARNING: bear in mind that accessing the raw data like this is dangerous, and sh
 only be done on contiguous tensors (if a tensor is not contiguous, then you have to
 use it size and stride information). Making sure a tensor is contiguous is easy: 
 ```lua
-> t = torch.randn(3,2)
-> t_noncontiguous = t:transpose(1,2)
+t = torch.randn(3,2)
+t_noncontiguous = t:transpose(1,2)
 
 -- it would be unsafe to work with torch.data(t_noncontiguous)
-
-> t_transposed_and_contiguous = t_noncontiguous:contiguous()
+t_transposed_and_contiguous = t_noncontiguous:contiguous()
 
 -- it is now safe to work with the raw pointer
-
-> data = torch.data(t_transposed_and_contiguous)
+data = torch.data(t_transposed_and_contiguous)
 ```
 
 Last, the pointer can be returned as a plain Lua number. This can be useful
@@ -2138,10 +2069,10 @@ tensor doesn't increment the reference counter on the storage. If the first tens
 gets freed, then the second points to nothing):
 
 ```lua
-> t = torch.randn(10)
-> p = torch.data(t,true)
-> s = torch.Storage(10, p)
-> tt = torch.Tensor(s)
+t = torch.randn(10)
+p = torch.data(t,true)
+s = torch.Storage(10, p)
+tt = torch.Tensor(s)
 -- tt and t are a view on the same data. 
 ```
 


### PR DESCRIPTION
As it seems to be ok, I continue what I started in #177 while reading the doc.
Here is an update of `tensor.md` esepcially focused on code blocks.

 * Use '> ' as prompt when the returned value is displayed
 * Use no prompt when there is no returned value
 * Do not use print or return to display a value (it introduces extra parenthesis and noisy characters)
 * Skip a line after displayed value, but not before
 * (In tensor.md only)