### PR TITLE
Added kthvalue and median operations, tests, doc

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -478,7 +478,22 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name=Tensor},
          {name="index", default=lastdim(3)},
          {name="boolean", default=0}})
-   
+
+   wrap("kthvalue",
+        cname("kthvalue"),
+        {{name=Tensor, default=true, returned=true},
+         {name="IndexTensor", default=true, returned=true, noreadadd=true},
+         {name=Tensor},
+         {name="index"},
+         {name="index", default=lastdim(3)}})
+
+   wrap("median",
+        cname("median"),
+        {{name=Tensor, default=true, returned=true},
+         {name="IndexTensor", default=true, returned=true, noreadadd=true},
+         {name=Tensor},
+         {name="index", default=lastdim(3)}})
+
    wrap("tril",
         cname("tril"),
         {{name=Tensor, default=true, returned=true},

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1134,7 +1134,7 @@ each column of `x`.
 `y=torch.mean(x,n)` performs the mean operation over the dimension `n`.
 
 <a name="torch.min"/>
-### torch.min([resval, resind,] x) ###
+### torch.min([resval, resind,] x [,dim]) ###
 
 `y=torch.min(x)` returns the single smallest element of `x`.
 
@@ -1145,6 +1145,33 @@ each column of `x`.
 `y,i=torch.min(x,2)` performs the min operation across rows.
 
 `y,i=torch.min(x,n)` performs the min operation over the dimension `n`.
+
+<a name="torch.median"/>
+### torch.median([resval, resind,] x [,dim]) ###
+
+`y=torch.median(x)` returns the median element of `x`
+(one-before-middle in the case of an even number of elements).
+
+`y,i=torch.median(x,1)` returns the median element in each column
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
+`x`.
+
+`y,i=torch.median(x,2)` performs the median operation across rows.
+
+`y,i=torch.median(x,n)` performs the median operation over the dimension `n`.
+
+<a name="torch.kthvalue"/>
+### torch.kthvalue([resval, resind,] x, k [,dim]) ###
+
+`y=torch.kthvalue(x,k)` returns the k-th smallest element of `x`.
+
+`y,i=torch.kthvalue(x,k,1)` returns the k-th smallest element in each column
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
+`x`.
+
+`y,i=torch.kthvalue(x,k,2)` performs the k-th value operation across rows.
+
+`y,i=torch.kthvalue(x,k,n)` performs the median operation over the dimension `n`.
 
 
 <a name="torch.prod"/>

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -45,6 +45,8 @@ TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain
 TH_API long THTensor_(numel)(THTensor *t);
 TH_API void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
+TH_API void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t, long k, int dimension);
+TH_API void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension);
 TH_API void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension);
 TH_API void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1118,6 +1118,82 @@ function torchtest.sortDescending()
    assertIsOrdered('descending', x, mxx, ixx, 'random with duplicate keys')
 end
 
+function torchtest.kthvalue()
+   local x = torch.rand(msize, msize, msize)
+   local x0 = x:clone()
+   do
+      local k = math.random(1, msize)
+      local mx, ix = torch.kthvalue(x, k)
+      local mxx, ixx = torch.sort(x)
+
+      mytester:assertTensorEq(mxx:select(3, k), mx, 0, 'torch.kthvalue value')
+      mytester:assertTensorEq(ixx:select(3, k), ix, 0, 'torch.kthvalue index')
+   end
+   do -- test use of result tensors
+      local k = math.random(1, msize)
+      local mx = torch.Tensor()
+      local ix = torch.LongTensor()
+      torch.kthvalue(mx, ix, x, k)
+      local mxx, ixx = torch.sort(x)
+      mytester:assertTensorEq(mxx:select(3, k), mx, 0, 'torch.kthvalue value')
+      mytester:assertTensorEq(ixx:select(3, k), ix, 0, 'torch.kthvalue index')
+   end
+   do -- test non-default dim
+      local k = math.random(1, msize)
+      local mx, ix = torch.kthvalue(x, k, 1)
+      local mxx, ixx = torch.sort(x, 1)
+      mytester:assertTensorEq(mxx:select(1, k), mx, 0, 'torch.kthvalue value')
+      mytester:assertTensorEq(ixx:select(1, k), ix, 0, 'torch.kthvalue index')
+   end
+   do -- non-contiguous
+      local y = x:narrow(2, 1, 1)
+      local y0 = y:clone()
+      local k = math.random(1, msize)
+      local my, ix = torch.kthvalue(y, k)
+      local my0, ix0 = torch.kthvalue(y0, k)
+      mytester:assertTensorEq(my, my0, 0, 'torch.kthvalue value')
+      mytester:assertTensorEq(ix, ix0, 0, 'torch.kthvalue index')
+   end
+   mytester:assertTensorEq(x, x0, 0, 'torch.kthvalue modified input')
+
+   -- simple test case (with repetitions)
+   local y = torch.Tensor{3,5,4,1,1,5}
+   mytester:assertTensorEq(torch.kthvalue(y, 3), torch.Tensor{3}, 1e-16,
+      'torch.kthvalue simple')
+   mytester:assertTensorEq(torch.kthvalue(y, 2), torch.Tensor{1}, 1e-16,
+      'torch.kthvalue simple')
+end
+
+function torchtest.median()
+   for _, msize in ipairs{155,156} do
+      local x = torch.rand(msize, msize)
+      local x0 = x:clone()
+
+      local mx, ix = torch.median(x)
+      local mxx, ixx = torch.sort(x)
+      local ind = math.floor((msize+1)/2)
+
+      mytester:assertTensorEq(mxx:select(2, ind), mx, 0, 'torch.median value')
+      mytester:assertTensorEq(ixx:select(2, ind), ix, 0, 'torch.median index')
+
+      -- Test use of result tensor
+      local mr = torch.Tensor()
+      local ir = torch.LongTensor()
+      torch.median(mr, ir, x)
+      mytester:assertTensorEq(mr, mx, 0, 'torch.median result tensor value')
+      mytester:assertTensorEq(ir, ix, 0, 'torch.median result tensor index')
+
+      -- Test non-default dim
+      mx, ix = torch.median(x, 1)
+      mxx, ixx = torch.sort(x, 1)
+      mytester:assertTensorEq(mxx:select(1, ind), mx, 0,'torch.median value')
+      mytester:assertTensorEq(ixx:select(1, ind), ix, 0,'torch.median index')
+
+      -- input unchanged
+      mytester:assertTensorEq(x, x0, 0, 'torch.median modified input')
+   end
+end
+
 function torchtest.tril()
    local x = torch.rand(msize,msize)
    local mx = torch.tril(x)


### PR DESCRIPTION
Added kthvalue function, to select k-th smallest value. Interface as close as possible to min/max, i.e. returns values and indices. Based on Quickselect algorithm (i.e. linear time) adapted from [this](http://ndevilla.free.fr/median/median/src/quickselect.c) Public Domain implementation, somewhat changed with tricks from the Quicksort implementation used in Torch.

Also added median function based on same algorithm. Median returns 'middle' element in case of odd-many elements, otherwise one-before-middle element (could also do the other convention to take mean of the two around-the-middle elements, but that would be twice more expensive, so I decided for this one).