### PR TITLE
Matlab-like find function

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -65,7 +65,7 @@ static int torch_NAME(lua_State *L)
   }
   else if(!(tname = torch_istensortype(L, torch_getdefaulttensortype(L))))
     luaL_error(L, "internal error: the default tensor type does not seem to be an actual tensor");
-  
+
   lua_pushstring(L, "NAME");
   lua_rawget(L, -2);
   if(lua_isfunction(L, -1))
@@ -91,7 +91,7 @@ function interface:dispatchregister(name)
    end
    table.insert(txt, '{NULL, NULL}')
    table.insert(txt, '};')
-   table.insert(txt, '')   
+   table.insert(txt, '')
    self.dispatchregistry = {}
 end
 
@@ -163,11 +163,11 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                 return string.format("TH%s_nDimension(%s)", Tensor, arg.args[argn]:carg())
              end
    end
-   
+
    wrap("zero",
         cname("zero"),
         {{name=Tensor, returned=true}})
-   
+
    wrap("fill",
         cname("fill"),
         {{name=Tensor, returned=true},
@@ -223,7 +223,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor},
          {name=Tensor},
          {name=accreal, creturned=true}})
-   
+
    wrap("add",
         cname("add"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -234,7 +234,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name=Tensor, method={default=1}},
          {name=real, default=1},
          {name=Tensor}})
-   
+
    wrap("mul",
         cname("mul"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -246,7 +246,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
          {name=Tensor, method={default=1}},
          {name=real}})
-  
+
    wrap("clamp",
         cname("clamp"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -443,7 +443,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name="index"}})
-   
+
    for _,name in ipairs({"min", "max"}) do
       wrap(name,
            cname(name .. "all"),
@@ -460,26 +460,26 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         cname("trace"),
         {{name=Tensor},
          {name=accreal, creturned=true}})
-   
+
    wrap("cross",
         cname("cross"),
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name=Tensor},
          {name="index", default=0}})
-   
+
    wrap("diag",
         cname("diag"),
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name="long", default=0}})
-   
+
    wrap("eye",
         cname("eye"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
          {name="long"},
          {name="long", default=0}})
-   
+
    wrap("range",
         cname("range"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -541,7 +541,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name=Tensor},
          {name=Tensor},
          {name="index", default=lastdim(2)}})
-   
+
    if Tensor == 'ByteTensor' then -- we declare this only once
       interface:print(
          [[
@@ -550,7 +550,7 @@ static int THRandom_random2__(THGenerator *gen, long a, long b)
   THArgCheck(b >= a, 2, "upper bound must be larger than lower bound");
   return((THRandom_random(gen) % (b+1-a)) + a);
 }
-         
+
 static int THRandom_random1__(THGenerator *gen, long b)
 {
   THArgCheck(b > 0, 1, "upper bound must be strictly positive");
@@ -602,7 +602,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
 
    for _,f in ipairs({{name='geometric'},
                       {name='bernoulli', a=0.5}}) do
-      
+
       wrap(f.name,
            string.format("THRandom_%s", f.name),
            {{name='Generator', default=true},
@@ -810,6 +810,27 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=Tensor}})
    end
 
+   wrap("find",
+     cname("find"),
+     {{name="IndexTensor", default=true, returned=true},
+       {name=Tensor}})
+
+   if Tensor == 'LongTensor' then
+     wrap("ind2sub",
+       cname("ind2sub"),
+       {{name="IndexTensor", default=true, returned=true},
+        {name="IndexTensor", returned=true},
+        {name="LongArg"}})
+
+     wrap("sub2ind",
+       cname("sub2ind"),
+       {{name="IndexTensor", default=true, returned=true},
+         {name="IndexTensor", returned=true},
+         {name="LongArg"}})
+
+
+   end
+
    if Tensor == 'ByteTensor' then
      -- Logical accumulators only apply to ByteTensor
       for _,name in ipairs({'all', 'any'}) do
@@ -818,6 +839,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
              {{name=Tensor},
 		{name="boolean", creturned=true}})
       end
+
    end
 
    if Tensor == 'IntTensor' then
@@ -848,7 +870,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
            {{name=Tensor, default=true, returned=true},
             {name=Tensor},
             {name="index"}})
-      
+
       for _,name in ipairs({"var", "std"}) do
          wrap(name,
               cname(name .. "all"),
@@ -878,7 +900,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=Tensor},
             {name=real},
             {name="index"}})
-            
+
       wrap("renorm",
            cname("renorm"),
            {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -886,14 +908,14 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=real},
             {name="index"},
             {name=real}})
-      
+
       wrap("dist",
            cname("dist"),
            {{name=Tensor},
             {name=Tensor},
             {name=real, default=2},
             {name=accreal, creturned=true}})
-      
+
       wrap("linspace",
            cname("linspace"),
            {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -907,7 +929,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=real},
             {name=real},
             {name="long", default=100}})
-      
+
       for _,name in ipairs({"log", "log1p", "exp",
                             "cos", "acos", "cosh",
                             "sin", "asin", "sinh",
@@ -916,14 +938,14 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
                             "round", "ceil", "floor"}) do
                             --"abs"}) do
 
-         wrap(name, 
+         wrap(name,
               cname(name),
               {{name=Tensor, default=true, returned=true, method={default='nil'}},
                {name=Tensor, method={default=1}}},
               name,
               {{name=real},
                {name=real, creturned=true}})
-         
+
       end
          wrap("abs",
               cname("abs"),
@@ -969,20 +991,20 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
            {{name=Tensor, default=true, returned=true, method={default='nil'}},
             {name='Generator', default=true},
             {name="LongArg"}})
-            
+
       wrap("multinomial",
            cname("multinomial"),
            {{name="IndexTensor", default=true, returned=true, method={default='nil'}},
             {name='Generator', default=true},
-            {name=Tensor}, 
-            {name="int"}, 
+            {name=Tensor},
+            {name="int"},
             {name="boolean", default=false}})
-      
+
       for _,f in ipairs({{name='uniform', a=0, b=1},
                          {name='normal', a=0, b=1},
                          {name='cauchy', a=0, b=1},
                          {name='logNormal', a=1, b=2}}) do
-         
+
          wrap(f.name,
               string.format("THRandom_%s", f.name),
               {{name='Generator', default=true},
@@ -997,7 +1019,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
       end
 
       for _,f in ipairs({{name='exponential'}}) do
-         
+
          wrap(f.name,
               string.format("THRandom_%s", f.name),
               {{name='Generator', default=true},
@@ -1008,7 +1030,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
                {name='Generator', default=true},
                {name=real, default=f.a}})
       end
-      
+
       for _,name in ipairs({"gesv","gels"}) do
          interface:wrap(name,
                         cname(name),
@@ -1073,7 +1095,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
                      {{name=Tensor, default=true, returned=true, invisible=true},
                       {name=Tensor}}
                   )
-     
+
       interface:wrap("potri",
                      cname("potri"),
                      {{name=Tensor, returned=true},

--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -5,7 +5,24 @@ The `Tensor` class is probably the most important class in
 `Torch`. Almost every package depends on this class. It is *__the__*
 class for handling numeric data. As with   pretty much anything in
 [Torch7](./../index.md), tensors are
-[serializable](file.md#torch.File.serialization).
+[serializable](file.md#torch.File.serialization). Basic functions for
+manipulating tensors fall into several types of categories:
+
+* [Constructors](#torch.Tensor).
+* [Cloning](#torch.cloning.dok).
+* [Structure querying operations](#torch.construction.dok) such as [size](#torch.Tensor.size) and [dim](#torch.Tensor.dim).
+* [Element querying operations](#torch.__index__).
+* [Referencing operations](#torch.Tensor.set).
+* [Copying operations](#torch.copying.dok) such as [copy](#torch.Tensor.copy), [fill](#torch.fill) and [zero](#torch.zero).
+* [Resizing operations](#torch.resize.dok) such as [resizeAs](#torch.Tensor.resizeAs) and [resize](#torch.resize).
+* [Search and indexing operations](#torch.search.dok) such as [find](#torch.find).
+* [Tensor extraction operations](#torch.extraction.dok) such as [narrow](#torch.Tensor.narrow), [sub](#torch.Tensor.sub), [select](#torch.Tensor.select) and [index](#torch.Tensor.index).
+* [Expanding and squeezing operations](#torch.expand.dok) such as [expand](#torch.expand), [repeatTensor](#torch.repeatTensor) and [squeeze](#torch.squeeze).
+* [Tensor view operations](#torch.view.dok) such as [view](#torch.view), [transpose](#torch.Tensor.transpose), [permute](#torch.Tensor.permute) and [unfold](#torch.Tensor.unfold).
+* [Function applying operations](#torch.apply.dok) such as [apply](#torch.Tensor.apply), [map](#torch.Tensor.map) and [map2](#torch.Tensor.map2).
+* [Conversion operations](#torch.convert.dok) such as [split](#torch.split) and [chunk](#torch.chunk).
+* [FFI operations](#torch.ffi.dok) such as [data](#torch.data).
+
 
 __Multi-dimensional matrix__
 
@@ -122,7 +139,7 @@ FloatTensor -- contains floats
 DoubleTensor -- contains doubles
 ```
 
-Most numeric operations are implemented _only_ for `FloatTensor` and `DoubleTensor`. 
+Most numeric operations are implemented _only_ for `FloatTensor` and `DoubleTensor`.
 Other Tensor types are useful if you want to save memory space.
 
 __Default Tensor type__
@@ -331,6 +348,7 @@ Example:
 [torch.DoubleTensor of dimension 2x4]
 ```
 
+<a name="torch.cloning.dok"/>
 ## Cloning ##
 
 <a name="torch.Tensor.clone"/>
@@ -546,6 +564,7 @@ x = torch.Tensor(3):fill(3.14)
 [torch.IntTensor of dimension 3]
 ```
 
+<a name="torch.structure.dok"/>
 ## Querying the size and structure ##
 
 <a name="torch.nDimension"/>
@@ -895,6 +914,7 @@ This is a "shorcut" for previous method.
 It works up to 4 dimensions. `szi` is the size of the `i`-th dimension of the tensor.
 `sti` is the stride in the `i`-th dimension.
 
+<a name="torch.copying.dok"/>
 ## Copying and initializing ##
 
 <a name="torch.Tensor.copy"/>
@@ -953,7 +973,7 @@ Fill the tensor with zeros.
 ## Resizing ##
 
 __When resizing to a larger size__, the underlying [Storage](storage.md) is resized to fit
-all the elements of the `Tensor`. 
+all the elements of the `Tensor`.
 
 __When resizing to a smaller size__, the underlying [Storage](#Storage) is not resized.
 
@@ -963,7 +983,7 @@ might have been completely changed. In particular, _the elements of the resized 
 <a name="torch.Tensor.resizeAs"/>
 ### [self] resizeAs(tensor) ###
 
-Resize the `tensor` as the given `tensor` (of the same type). 
+Resize the `tensor` as the given `tensor` (of the same type).
 
 <a name="torch.resize"/>
 ### [self] resize(sizes) ###
@@ -975,6 +995,105 @@ Resize the `tensor` according to the given [LongStorage](storage.md) `size`.
 
 Convenience method of the previous method, working for a number of dimensions up to 4.
 
+
+<a name="torch.search.dok"/>
+## Search ##
+
+Each of these methods returns a `LongTensor` corresponding to the indices of the
+given search operation.
+
+<a name="torch.find"/>
+### [LongTensor] find(tensor)
+
+Finds and returns a `LongTensor` corresponding to the linear indices of all
+non-zero elements in `tensor`.
+
+```lua
+x = torch.rand(4, 4):mul(3):floor():int()
+> x
+ 2  0  2  0
+ 0  0  1  2
+ 0  2  2  1
+ 2  1  2  2
+[torch.IntTensor of dimension 4x4]
+
+> torch.find(x)
+ 1  1
+ 1  3
+ 2  3
+ 2  4
+ 3  2
+ 3  3
+ 3  4
+ 4  1
+ 4  2
+ 4  3
+ 4  4
+[torch.LongTensor of dimension 11x2]
+
+> x:find()
+ 1  1
+ 1  3
+ 2  3
+ 2  4
+ 3  2
+ 3  3
+ 3  4
+ 4  1
+ 4  2
+ 4  3
+ 4  4
+[torch.LongTensor of dimension 11x2]
+
+```
+
+<a name="torch.ind2sub"/>
+### [LongTensor] ind2sub([inds,] size)
+
+Accepts a `LongTensor` of size `n` corresponding to linear indices and a
+`LongStorage` of size `m` corresponding to the size of a Tensor. Returns an
+`nxm` `LongTensor` corresponding to subscript indices.
+
+```lua
+inds = torch.LongTensor{2, 7, 8, 26}
+> inds
+  2
+  7
+  8
+ 26
+[torch.LongTensor of dimension 4]
+
+> torch.ind2sub(inds, torch.LongStorage{3, 3, 3})
+ 1  1  2
+ 1  3  1
+ 1  3  2
+ 3  3  2
+[torch.LongTensor of dimension 4x3]
+```
+
+<a name="torch.sub2ind"/>
+### [LongTensor] sub2ind([subs,] size)
+
+Accepts a `LongTensor` of size `nxm` corresponding to subscript indices and a
+`LongStorage` of size `m` corresponding to the size of a Tensor. Returns an
+`n` sized `LongTensor` corresponding to linear indices.
+
+```lua
+subs = torch.LongTensor{{1, 1}, {2, 2}}
+> subs
+ 1  1
+ 2  2
+[torch.LongTensor of dimension 2x2]
+
+
+> torch.sub2ind(subs, torch.LongStorage{2, 2})
+ 1
+ 4
+[torch.LongTensor of dimension 2]
+```
+
+
+<a name="torch.extraction.dok"/>
 ## Extracting sub-tensors ##
 
 Each of these methods returns a `Tensor` which is a sub-tensor of the given
@@ -1037,7 +1156,7 @@ x = torch.Tensor(5, 6):zero()
  0 0 0 0 0 0
 [torch.DoubleTensor of dimension 5x6]
 
-y = x:sub(2,4):fill(1) -- y is sub-tensor of x: 
+y = x:sub(2,4):fill(1) -- y is sub-tensor of x:
 > y                    -- dimension 1 starts at index 2, ends at index 4
  1  1  1  1  1  1
  1  1  1  1  1  1
@@ -1201,9 +1320,9 @@ x[torch.lt(x,0)] = -2 -- sets all negative elements to -2 via a mask
 <a name="torch.Tensor.index"/>
 ### [Tensor] index(dim, index) ###
 
-Returns a new Tensor which indexes the given tensor along dimension `dim` 
-and using the entries in `torch.LongTensor` `index`. 
-The returned tensor has the same number of dimensions as the original tensor. 
+Returns a new Tensor which indexes the given tensor along dimension `dim`
+and using the entries in `torch.LongTensor` `index`.
+The returned tensor has the same number of dimensions as the original tensor.
 The returned tensor does __not__ use the same storage as the original tensor -- see below for storing the result in an existing tensor.
 
 ```lua
@@ -1238,9 +1357,9 @@ y:fill(1)
 
 ```
 
-Note the explicit `index` function is different than the indexing operator `[]`. 
-The indexing operator `[]` is a syntactic shortcut for a series of select and narrow operations, 
-therefore it always returns a new view on the original tensor that shares the same storage. 
+Note the explicit `index` function is different than the indexing operator `[]`.
+The indexing operator `[]` is a syntactic shortcut for a series of select and narrow operations,
+therefore it always returns a new view on the original tensor that shares the same storage.
 However, the explicit `index` function can not use the same storage.
 
 It is possible to store the result into an existing Tensor with `result:index(source, ...)`:
@@ -1384,8 +1503,8 @@ z = torch.zeros(2, 4):scatter(2, torch.LongTensor{{3}, {4}}, 1.23)
 ### [Tensor] maskedSelect(mask) ###
 
 Returns a new Tensor which contains all elements aligned to a `1` in the corresponding
-`mask`. This `mask` is a `torch.ByteTensor` of zeros and ones. The `mask` and 
-`Tensor` must have the same number of elements. The resulting Tensor will 
+`mask`. This `mask` is a `torch.ByteTensor` of zeros and ones. The `mask` and
+`Tensor` must have the same number of elements. The resulting Tensor will
 be a 1D tensor of the same type as `Tensor` having size `mask:sum()`.
 
 ```lua
@@ -1397,7 +1516,7 @@ x = torch.range(1,12):double():resize(3,4)
 [torch.DoubleTensor of dimension 3x4]
 
 mask = torch.ByteTensor(2,6):bernoulli()
-> mask 
+> mask
  1  0  1  0  0  0
  1  1  0  0  0  1
 [torch.ByteTensor of dimension 2x6]
@@ -1428,15 +1547,15 @@ Also note how an existing tensor `z` can be used to store the results.
 <a name="torch.Tensor.maskedCopy"/>
 ### [Tensor] maskedCopy(mask, tensor) ###
 
-Copies the masked elements of `tensor` into itself. The masked elements are those elements having a 
-corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor` 
+Copies the masked elements of `tensor` into itself. The masked elements are those elements having a
+corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor`
 of zeros and ones. The destination `Tensor` and the `mask` Tensor should have the same number of elements.
 The source `tensor` should have atleast as many elements as the number of 1s in the `mask`.
 
 ```lua
 x = torch.range(1,4):double():resize(2,2)
 > x
- 1  2  
+ 1  2
  3  4
 [torch.DoubleTensor of dimension 2x4]
 
@@ -1458,14 +1577,14 @@ y:maskedCopy(mask, x)
 [torch.DoubleTensor of dimension 2x4]
 ```
 
-Note how the dimensions of the above `x`, `mask` and `y' do not match, 
+Note how the dimensions of the above `x`, `mask` and `y' do not match,
 but the number of elements do.
 
 <a name="torch.Tensor.maskedFill"/>
 ### [Tensor] maskedFill(mask, val) ###
 
-Fills the masked elements of itself with value `val`. The masked elements are those elements having a 
-corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor` 
+Fills the masked elements of itself with value `val`. The masked elements are those elements having a
+corresponding `1` in the `mask` Tensor. This `mask` is a `torch.ByteTensor`
 of zeros and ones. The `mask` and `Tensor` must have the same number of elements.
 
 ```lua
@@ -1486,9 +1605,10 @@ x:maskedFill(mask, -1)
 [torch.DoubleTensor of dimension 1x4]
 
 ```
-Note how the dimensions of the above `x` and `mask` do not match, 
+Note how the dimensions of the above `x` and `mask` do not match,
 but the number of elements do.
 
+<a name="torch.expand.dok"/>
 ## Expanding/Replicating/Squeezing Tensors ##
 
 These methods returns a Tensor which is created by replications of the
@@ -1499,7 +1619,7 @@ original tensor.
 
 `sizes` can either be a `torch.LongStorage` or numbers. Expanding a tensor
 does not allocate new memory, but only creates a new view on the existing tensor where
-singleton dimensions can be expanded to multiple ones by setting the `stride` to 0. 
+singleton dimensions can be expanded to multiple ones by setting the `stride` to 0.
 Any dimension that is 1 can be expanded to arbitrary value without any new memory allocation.
 
 ```lua
@@ -1596,7 +1716,7 @@ This is equivalent to self:expand(tensor:size())
 #### [Tensor] repeatTensor([result,] sizes) ####
 
 `sizes` can either be a `torch.LongStorage` or numbers. Repeating a tensor allocates
- new memory, unless `result` is provided, in which case its memory is 
+ new memory, unless `result` is provided, in which case its memory is
  resized. `sizes` specify the number of times the tensor is repeated in each dimension.
 
  ```lua
@@ -1616,21 +1736,21 @@ x = torch.rand(5)
 [torch.DoubleTensor of dimension 3x10]
 
 > torch.repeatTensor(x,3,2,1)
-(1,.,.) = 
+(1,.,.) =
   0.7160  0.6514  0.0704  0.7856  0.7452
   0.7160  0.6514  0.0704  0.7856  0.7452
 
-(2,.,.) = 
+(2,.,.) =
   0.7160  0.6514  0.0704  0.7856  0.7452
   0.7160  0.6514  0.0704  0.7856  0.7452
 
-(3,.,.) = 
+(3,.,.) =
   0.7160  0.6514  0.0704  0.7856  0.7452
   0.7160  0.6514  0.0704  0.7856  0.7452
 [torch.DoubleTensor of dimension 3x2x5]
 
  ```
- 
+
 <a name="torch.squeeze"/>
 #### [Tensor] squeeze([dim]) ####
 
@@ -1661,7 +1781,7 @@ x=torch.rand(2,1,2,1,2)
 (2,.,.) =
   0.4713  0.2645
   0.5467  0.8648
-[torch.DoubleTensor of dimension 2x2x2] 
+[torch.DoubleTensor of dimension 2x2x2]
 
 > torch.squeeze(x,2)
 (1,1,.,.) =
@@ -1679,6 +1799,7 @@ x=torch.rand(2,1,2,1,2)
 
  ```
 
+<a name="torch.view.dok"/>
 ## Manipulating the tensor view ##
 
 Each of these methods returns a `Tensor` which is another way of viewing
@@ -1691,7 +1812,7 @@ These methods are very fast, are they do not involve any memory copy.
 ### [result] view([result,] tensor, sizes) ###
 
 Creates a view with different dimensions of the storage associated with `tensor`.
-If `result` is not passed, then a new tensor is returned, otherwise its storage is 
+If `result` is not passed, then a new tensor is returned, otherwise its storage is
 made to point to storage of `tensor`.
 
 `sizes` can either be a `torch.LongStorage` or numbers. If one of the dimensions
@@ -1726,8 +1847,8 @@ x = torch.zeros(4)
 <a name="torch.viewAs"/>
 ### [result] viewAs([result,] tensor, template) ###
 
-Creates a view with with the same dimensions as `template` of the storage associated 
-with `tensor`. If `result` is not passed, then a new tensor is returned, otherwise its storage is 
+Creates a view with with the same dimensions as `template` of the storage associated
+with `tensor`. If `result` is not passed, then a new tensor is returned, otherwise its storage is
 made to point to storage of `tensor`.
 
 
@@ -1747,7 +1868,7 @@ y = torch.Tensor(2,2)
 Returns a tensor where dimensions `dim1` and `dim2` have been swapped. For 2D tensors,
 the convenience method of [t()](#torch.Tensor.t) is available.
 ```lua
-x = torch.Tensor(3,4):zero()                  
+x = torch.Tensor(3,4):zero()
 x:select(2,3):fill(7) -- fill column 3 with 7
 > x
  0  0  7  0
@@ -1871,6 +1992,7 @@ for i=1,7 do x[i] = i end
 [torch.DoubleTensor of dimension 3x2]
 ```
 
+<a name="torch.apply.dok"/>
 ## Applying a function to a tensor ##
 
 These functions apply a function to each element of the tensor on which the
@@ -2012,7 +2134,7 @@ x:map2(y, z, function(xx, yy, zz) return xx+yy*zz end)
 [torch.DoubleTensor of dimension 3x3]
 ```
 
-
+<a name="torch.convert.dok"/>
 ## Converting Tensors to tables of Tensors ##
 
 These functions divide a Tensor into a table of Tensors.
@@ -2020,15 +2142,15 @@ These functions divide a Tensor into a table of Tensors.
 <a name="torch.split"/>
 ### [result] split([result,] tensor, size, [dim]) ###
 
-Splits Tensor `tensor` along dimension `dim` 
+Splits Tensor `tensor` along dimension `dim`
 into a `result` table of Tensors of size `size` (a number)
 or less (in the case of the last Tensor). The sizes of the non-`dim`
-dimensions remain unchanged. Internally, a series of 
-[narrows](#torch.Tensor.narrow) are performed along 
+dimensions remain unchanged. Internally, a series of
+[narrows](#torch.Tensor.narrow) are performed along
 dimensions `dim`. Argument `dim` defaults to 1.
 
-If `result` is not passed, then a new table is returned, otherwise it 
-is emptied and reused. 
+If `result` is not passed, then a new table is returned, otherwise it
+is emptied and reused.
 
 Example:
 ```lua
@@ -2058,14 +2180,14 @@ x = torch.randn(3,4,5)
 <a name="torch.chunk"/>
 ### [result] chunk([result,] tensor, n, [dim]) ###
 
-Splits Tensor `tensor` into `n` chunks of approximately equal size along 
+Splits Tensor `tensor` into `n` chunks of approximately equal size along
 dimensions `dim` and returns these as a `result` table of Tensors.
 Argument `dim` defaults to 1.
- 
+
 This function uses [split](#torch.split) internally:
 ```lua
 torch.split(result, tensor, math.ceil(tensor:size(dim)/n), dim)
-``` 
+```
 
 Example:
 ```lua
@@ -2090,9 +2212,10 @@ x = torch.randn(3,4,5)
 }
 ```
 
+<a name="torch.ffi.dok"/>
 ## LuaJIT FFI access ##
 These functions expose Torch's Tensor and Storage data structures, through
-[LuaJIT FFI](http://luajit.org/ext_ffi_api.html). 
+[LuaJIT FFI](http://luajit.org/ext_ffi_api.html).
 This allows extremely fast access to Tensors and Storages, all from Lua.
 
 <a name="torch.data"/>
@@ -2124,7 +2247,7 @@ for i = 0,t:nElement()-1 do t_data[i] = 0 end
 
 WARNING: bear in mind that accessing the raw data like this is dangerous, and should
 only be done on contiguous tensors (if a tensor is not contiguous, then you have to
-use it size and stride information). Making sure a tensor is contiguous is easy: 
+use it size and stride information). Making sure a tensor is contiguous is easy:
 ```lua
 t = torch.randn(3,2)
 t_noncontiguous = t:transpose(1,2)
@@ -2146,14 +2269,14 @@ t = torch.randn(10)
 p = torch.data(t,true)
 s = torch.Storage(10, p)
 tt = torch.Tensor(s)
--- tt and t are a view on the same data. 
+-- tt and t are a view on the same data.
 ```
 
 <a name="torch.cdata"/>
 ### [result] cdata(tensor, [asnumber]) ###
 
 Returns a LuaJIT FFI pointer to the C structure of the tensor.
-Use this with caution, and look at [FFI.lua](https://github.com/torch/torch7/blob/master/FFI.lua) 
+Use this with caution, and look at [FFI.lua](https://github.com/torch/torch7/blob/master/FFI.lua)
 for the members of the tensor
 
 ## Reference counting ##

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -6,13 +6,13 @@
 
 void THTensor_(fill)(THTensor *r_, real value)
 {
-  TH_TENSOR_APPLY(real, r_, 
+  TH_TENSOR_APPLY(real, r_,
                   THVector_(fill)(r__data, value, r__size); break;);
 }
 
 void THTensor_(zero)(THTensor *r_)
 {
-  TH_TENSOR_APPLY(real, r_, 
+  TH_TENSOR_APPLY(real, r_,
                   THVector_(fill)(r__data, 0, r__size); break;);
 }
 
@@ -67,6 +67,127 @@ void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask
                      tensor_data++;
                    });
 }
+
+// Finds non-zero elements of a tensor and returns their subscripts
+void THTensor_(find)(THLongTensor *subscript, THTensor *tensor)
+{
+  long numel = 0;
+  long *subscript_data;
+  long i = 0;
+  long dim;
+  long sub = 0;
+  long div = 1;
+
+  /* First Pass to determine size of subscripts */
+  TH_TENSOR_APPLY(real, tensor,
+                  if (*tensor_data != 0)
+                  {
+                    ++numel;
+                  });
+  THLongTensor_resize2d(subscript, numel, tensor->nDimension);
+
+  /* Second pass populates subscripts */
+  // The funky pointer arithmetic is as a result of the torch's last dimension
+  // being the fastest changing. Another valid strategy would be to fill in the
+  // subscript tensor backwards which would save some addition operations
+  // (2*num_non_zero_elems). However this method gives a result in numerical
+  // order which is more satisfying.
+  subscript_data = THLongTensor_data(subscript);
+  TH_TENSOR_APPLY(real, tensor,
+                  if (*tensor_data != 0)
+                  {
+                    subscript_data += tensor->nDimension - 1;
+
+                    *subscript_data = i % tensor->size[tensor->nDimension - 1];
+                    sub = *subscript_data;
+                    div = tensor->size[tensor->nDimension - 1];
+                    --subscript_data;
+
+                    for (dim = tensor->nDimension - 2; dim >= 0; dim--) {
+                      *subscript_data = ((i - sub)/div) % tensor->size[dim];
+                      sub += *subscript_data;
+                      div *= tensor->size[dim];
+                      --subscript_data;
+                    }
+
+                    subscript_data += tensor->nDimension + 1;
+                  }
+                  ++i;);
+}
+
+#if defined(TH_REAL_IS_LONG)
+// Converts linear indices to subscripts
+void THTensor_(ind2sub)(THTensor *subscript, THLongTensor *index, THLongStorage *size)
+{
+  long numel = 1;
+  long *subscript_data;
+  long *size_data;
+  long dim;
+  long dims;
+  long sub = 0;
+  long div = 1;
+
+  /* First Pass to determine size of index */
+  size_data = THLongStorage_data(size);
+  dims = size->size;
+  numel = THLongTensor_nElement(index);
+  THLongTensor_resize2d(subscript, numel, dims);
+
+  /* Second pass populates index */
+  // The funky pointer arithmetic is as a result of the torch's last dimension
+  // being the fastest changing. Another valid strategy would be to fill in the
+  // index tensor backwards which would save some addition operations
+  // (2*num_non_zero_elems). However, this method gives a result in a sensible
+  // order.
+  subscript_data = THLongTensor_data(subscript);
+  TH_TENSOR_APPLY(long, index,
+                  subscript_data += dims - 1;
+
+                  *subscript_data = *index_data % size_data[dims - 1];
+                  sub = *subscript_data;
+                  div = size_data[dims - 1];
+                  --subscript_data;
+
+                  for (dim = dims - 2; dim >= 0; dim--) {
+                     *subscript_data = ((*index_data - sub)/div) % size_data[dim];
+                     sub += *subscript_data;
+                     div *= size_data[dim];
+                     --subscript_data;
+                  }
+
+                  subscript_data += dims + 1;
+                 );
+}
+
+// Converts subscripts to linear indices
+void THTensor_(sub2ind)(THTensor *index, THLongTensor *subscript, THLongStorage *size)
+{
+  long *subscript_data;
+  long *size_data;
+  long dim;
+  long dims;
+
+  /* Initialise */
+  size_data = THLongStorage_data(size);
+  dims = size->size;
+  THLongTensor_resize1d(index, subscript->size[0]);
+
+  /* Second pass populates index */
+  subscript_data = THLongTensor_data(subscript);
+  TH_TENSOR_APPLY(real, index,
+
+                  *index_data = *subscript_data;
+                  ++subscript_data;
+
+                  for (dim = 1; dim < dims; dim++) {
+                     *index_data *= size_data[dim];
+                     *index_data += *subscript_data;
+                     ++subscript_data;
+                  }
+
+                 );
+}
+#endif
 
 void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index)
 {
@@ -141,27 +262,27 @@ void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTens
   long i, numel;
   THTensor *tSlice, *sSlice;
   long *index_data;
-  
+
   numel = THLongTensor_nElement(index);
   THArgCheck(index->nDimension == 1, 3, "Index is supposed to be a vector");
   THArgCheck(dim < src->nDimension, 4,"Indexing dim %d is out of bounds of tensor", dim+1);
   THArgCheck(numel == src->size[dim],4,"Number of indices should be equal to source:size(dim)");
-  
+
   index = THLongTensor_newContiguous(index);
   index_data = THLongTensor_data(index);
-  
+
   if (tensor->nDimension > 1 )
   {
     tSlice = THTensor_(new)();
     sSlice = THTensor_(new)();
-    
+
     for (i=0; i<numel; i++)
     {
       THTensor_(select)(tSlice, tensor, dim, index_data[i]-1);
       THTensor_(select)(sSlice, src, dim, i);
       THTensor_(copy)(tSlice, sSlice);
     }
-    
+
     THTensor_(free)(tSlice);
     THTensor_(free)(sSlice);
   }
@@ -187,7 +308,7 @@ void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, real v
 
   index = THLongTensor_newContiguous(index);
   index_data = THLongTensor_data(index);
-  
+
   for (i=0; i<numel; i++)
   {
     if (tensor->nDimension > 1 )
@@ -276,9 +397,9 @@ accreal THTensor_(dot)(THTensor *tensor, THTensor *src)
                    tensor_i += sz;
                    src_i += sz;
                    tensor_data += sz*tensor_stride;
-                   src_data += sz*src_stride; 
+                   src_data += sz*src_stride;
                    break;);
-  return sum; 
+  return sum;
 }
 
 real THTensor_(minall)(THTensor *tensor)
@@ -287,7 +408,7 @@ real THTensor_(minall)(THTensor *tensor)
   THArgCheck(tensor->nDimension > 0, 1, "tensor must have one dimension");
   theMin = THTensor_(data)(tensor)[0];
   TH_TENSOR_APPLY(real, tensor, if(*tensor_data < theMin) theMin = *tensor_data;);
-  return theMin; 
+  return theMin;
 }
 
 real THTensor_(maxall)(THTensor *tensor)
@@ -296,7 +417,7 @@ real THTensor_(maxall)(THTensor *tensor)
   THArgCheck(tensor->nDimension > 0, 1, "tensor must have one dimension");
   theMax = THTensor_(data)(tensor)[0];
   TH_TENSOR_APPLY(real, tensor, if(*tensor_data > theMax) theMax = *tensor_data;);
-  return theMax; 
+  return theMax;
 }
 
 accreal THTensor_(sumall)(THTensor *tensor)
@@ -492,18 +613,18 @@ void THTensor_(addcdiv)(THTensor *r_, THTensor *t, real value, THTensor *src1, T
 void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *mat, THTensor *vec)
 {
   if( (mat->nDimension != 2) || (vec->nDimension != 1) )
-    THError("matrix and vector expected, got %dD, %dD", 
+    THError("matrix and vector expected, got %dD, %dD",
       mat->nDimension, vec->nDimension);
- 
+
   if( mat->size[1] != vec->size[0] ) {
     THDescBuff bm = THTensor_(sizeDesc)(mat);
     THDescBuff bv = THTensor_(sizeDesc)(vec);
     THError("size mismatch, %s, %s", bm.str, bv.str);
   }
 
-  if(t->nDimension != 1) 
+  if(t->nDimension != 1)
     THError("vector expected, got t: %dD", t->nDimension);
-    
+
   if(t->size[0] != mat->size[0]) {
     THDescBuff bt = THTensor_(sizeDesc)(t);
     THDescBuff bm = THTensor_(sizeDesc)(mat);
@@ -554,13 +675,13 @@ void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain)
   long i;
 
   THTensor_(resize2d)(r_, N1, N2);
-  
+
   m1 = THTensor_(newContiguous)(m1);
   m2 = THTensor_(newContiguous)(m2);
 
   THTensor_(resize2d)(m1, N1, THTensor_(nElement)(m1) / N1);
   THTensor_(resize2d)(m2, N2, THTensor_(nElement)(m2) / N2);
-    
+
   dim = m1->size[1];
   THArgCheck(m1->size[1] == m2->size[1], 3, "m1 and m2 must have the same inner vector dim");
 
@@ -586,7 +707,7 @@ void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain)
 }
 
 void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *m1, THTensor *m2)
-{ 
+{
   char transpose_r, transpose_m1, transpose_m2;
   THTensor *r__, *m1_, *m2_;
 
@@ -634,7 +755,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   else
   {
     transpose_r = 'n';
-    
+
     r__ = THTensor_(newWithSize2d)(r_->size[1], r_->size[0]);
     THTensor_(copy)(r__, r_);
     THTensor_(transpose)(r__, NULL, 0, 1);
@@ -698,7 +819,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 
   if(r__ != r_)
     THTensor_(freeCopyTo)(r__, r_);
-} 
+}
 
 void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *vec1, THTensor *vec2)
 {
@@ -708,7 +829,7 @@ void THTensor_(addr)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor 
 
   if(t->nDimension != 2)
     THError("expected matrix, got %dD tensor for t", t->nDimension);
-    
+
   if( (t->size[0] != vec1->size[0]) || (t->size[1] != vec2->size[0]) ) {
     THDescBuff bt  = THTensor_(sizeDesc)(t);
     THDescBuff bv1 = THTensor_(sizeDesc)(vec1);
@@ -762,7 +883,7 @@ void THTensor_(addbmm)(THTensor *result, real beta, THTensor *t, real alpha, THT
              "equal number of batches expected, got %d, %d",
              THTensor_(size)(batch1, 0), THTensor_(size)(batch2, 0));
   THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
-             "wrong matrix size, batch1: %dx%d, batch2: %dx%d", 
+             "wrong matrix size, batch1: %dx%d, batch2: %dx%d",
              THTensor_(size)(batch1, 1), THTensor_(size)(batch1,2),
              THTensor_(size)(batch2, 1), THTensor_(size)(batch2,2));
 
@@ -801,7 +922,7 @@ void THTensor_(baddbmm)(THTensor *result, real beta, THTensor *t, real alpha, TH
              "equal number of batches expected, got %d, %d",
              THTensor_(size)(batch1, 0), THTensor_(size)(batch2, 0));
   THArgCheck(THTensor_(size)(batch1, 2) == THTensor_(size)(batch2, 1), 2,
-             "wrong matrix size, batch1: %dx%d, batch2: %dx%d", 
+             "wrong matrix size, batch1: %dx%d, batch2: %dx%d",
              THTensor_(size)(batch1, 1), THTensor_(size)(batch1, 2),
              THTensor_(size)(batch2, 1), THTensor_(size)(batch2, 2));
 
@@ -865,7 +986,7 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
                          }
                        }
                        *indices__data = theIndex;
-                       *values__data = theMax;);  
+                       *values__data = theMax;);
 
 }
 
@@ -895,7 +1016,7 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
                          }
                        }
                        *indices__data = theIndex;
-                       *values__data = theMin;);  
+                       *values__data = theMin;);
 
 }
 
@@ -906,7 +1027,7 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension)
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
       dimension+1);
-  
+
   dim = THTensor_(newSizeOf)(t);
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
@@ -931,7 +1052,7 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension)
   THLongStorage_set(dim, dimension, 1);
   THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
-  
+
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
                        accreal prod = 1;
                        long i;
@@ -945,7 +1066,7 @@ void THTensor_(cumsum)(THTensor *r_, THTensor *t, int dimension)
 {
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
       dimension+1);
-  
+
   THTensor_(resizeAs)(r_, t);
 
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
@@ -962,7 +1083,7 @@ void THTensor_(cumprod)(THTensor *r_, THTensor *t, int dimension)
 {
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
       dimension+1);
-  
+
   THTensor_(resizeAs)(r_, t);
 
   TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
@@ -981,11 +1102,11 @@ void THTensor_(sign)(THTensor *r_, THTensor *t)
   THTensor_(resizeAs)(r_, t);
 
 #if defined (TH_REAL_IS_BYTE)
-  TH_TENSOR_APPLY2(real, r_, real, t, 
+  TH_TENSOR_APPLY2(real, r_, real, t,
 		   if (*t_data > 0) *r__data = 1;
 		   else *r__data = 0;);
 #else
-  TH_TENSOR_APPLY2(real, r_, real, t, 
+  TH_TENSOR_APPLY2(real, r_, real, t,
 		   if (*t_data > 0) *r__data = 1;
 		   else if (*t_data < 0) *r__data = -1;
 		   else *r__data = 0;);
@@ -1019,9 +1140,10 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
   int i;
 
   if(THTensor_(nDimension)(a) != THTensor_(nDimension)(b))
+
     THError("inconsistent tensor dimension %dD, %dD",
         THTensor_(nDimension)(a), THTensor_(nDimension)(b));
-  
+
   for(i = 0; i < THTensor_(nDimension)(a); i++)
   {
     if(THTensor_(size)(a, i) != THTensor_(size)(b, i)) {
@@ -1030,7 +1152,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
         THError("inconsistent tensor sizes %s, %s", ba.str, bb.str);
     }
   }
-  
+
   if(dimension < 0)
   {
     for(i = 0; i < THTensor_(nDimension)(a); i++)
@@ -1047,7 +1169,7 @@ void THTensor_(cross)(THTensor *r_, THTensor *a, THTensor *b, int dimension)
     }
   }
 
-  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(a), 3, "dimension %d out of range", 
+  THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(a), 3, "dimension %d out of range",
       dimension+1);
   THArgCheck(THTensor_(size)(a, dimension) == 3, 3, "dimension %d does not have size 3",
       dimension+1);
@@ -1087,7 +1209,7 @@ void THTensor_(diag)(THTensor *r_, THTensor *t, int k)
     long r__stride_1;
     long i;
 
-    THTensor_(resize2d)(r_, sz, sz);    
+    THTensor_(resize2d)(r_, sz, sz);
     THTensor_(zero)(r_);
     r__data = THTensor_(data)(r_);
     r__stride_0 = THTensor_(stride)(r_, 0);
@@ -1152,7 +1274,7 @@ void THTensor_(range)(THTensor *r_, real xmin, real xmax, real step)
               , 2, "upper bound and larger bound incoherent with step sign");
 
   size = (long)((xmax-xmin)/step+1);
-  
+
   THTensor_(resize1d)(r_, size);
 
   TH_TENSOR_APPLY(real, r_, *r__data = xmin + (i++)*step;);
@@ -1174,7 +1296,7 @@ void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, long n)
     r__data[i*r__stride_0] = (real)(i);
 
   for(i = 0; i < n-1; i++)
-  {    
+  {
     long z = THRandom_random(_generator) % (n-i);
     real sav = r__data[i*r__stride_0];
     r__data[i*r__stride_0] = r__data[(z+i)*r__stride_0];
@@ -1192,7 +1314,7 @@ void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
    Sedgewick's 1978 "Implementing Quicksort Programs" article
    http://www.csie.ntu.edu.tw/~b93076/p847-sedgewick.pdf
 
-   It is the state of the art existing implementation. The macros 
+   It is the state of the art existing implementation. The macros
    are here to make as close a match as possible to the pseudocode of
    Program 2 p.851
 
@@ -1412,7 +1534,7 @@ void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimensio
 
   if(descendingOrder)
   {
-    TH_TENSOR_DIM_APPLY2(real, rt_, long, ri_, dimension, 
+    TH_TENSOR_DIM_APPLY2(real, rt_, long, ri_, dimension,
                          long i;
                          for(i = 0; i < ri__size; i++)
                            ri__data[i*ri__stride] = i;
@@ -1879,7 +2001,7 @@ void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension)
 }
 
 accreal THTensor_(normall)(THTensor *tensor, real value)
-{ 
+{
   accreal sum = 0;
   if(value == 0) {
     TH_TENSOR_APPLY(real, tensor, sum += *tensor_data != 0.0;);
@@ -1900,23 +2022,23 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, 
 {
   int i;
   THTensor *rowR, *rowS;
-  
+
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(src), 3, "invalid dimension %d",
       dimension+1);
   THArgCheck(value > 0, 2, "non-positive-norm not supported");
   THArgCheck(THTensor_(nDimension)(src) > 1, 1, "need at least 2 dimensions, got %d dimensions",
       THTensor_(nDimension)(src));
-  
+
   rowR = THTensor_(new)();
   rowS = THTensor_(new)();
-  
+
   THTensor_(resizeAs)(res, src);
-   
+
   for (i=0; i<src->size[dimension]; i++)
   {
     real norm = 0;
     real new_norm;
-    
+
     THTensor_(select)(rowS, src, dimension, i);
     THTensor_(select)(rowR, res, dimension, i);
     if (value == 1) {
@@ -1932,36 +2054,36 @@ void THTensor_(renorm)(THTensor *res, THTensor *src, real value, int dimension, 
     if (norm > maxnorm)
     {
       new_norm = maxnorm / (norm + 1e-7);
-      
+
       TH_TENSOR_APPLY2(
-        real, rowR, real, rowS, 
+        real, rowR, real, rowS,
         *rowR_data = (*rowS_data) * new_norm;
       )
     }
     else
       THTensor_(copy)(rowR, rowS);
   }
-  
+
   THTensor_(free)(rowR);
   THTensor_(free)(rowS);
 }
 
 accreal THTensor_(dist)(THTensor *tensor, THTensor *src, real value)
-{ 
+{
   real sum = 0;
-  TH_TENSOR_APPLY2(real, tensor, real, src, 
+  TH_TENSOR_APPLY2(real, tensor, real, src,
 	sum += pow(fabs(*tensor_data - *src_data), value);)
   return pow(sum, 1.0/value);
 }
 
 accreal THTensor_(meanall)(THTensor *tensor)
-{ 
+{
   THArgCheck(tensor->nDimension > 0, 1, "empty Tensor");
   return THTensor_(sumall)(tensor)/THTensor_(nElement)(tensor);
-}  
+}
 
 accreal THTensor_(varall)(THTensor *tensor)
-{ 
+{
   accreal mean = THTensor_(meanall)(tensor);
   accreal sum = 0;
   TH_TENSOR_APPLY(real, tensor, sum += (*tensor_data - mean)*(*tensor_data - mean););
@@ -1970,7 +2092,7 @@ accreal THTensor_(varall)(THTensor *tensor)
 }
 
 accreal THTensor_(stdall)(THTensor *tensor)
-{ 
+{
   return sqrt(THTensor_(varall)(tensor));
 }
 
@@ -1980,7 +2102,7 @@ void THTensor_(linspace)(THTensor *r_, real a, real b, long n)
 
   THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
   THArgCheck(a <= b, 2, "end range should be greater than start range");
-  
+
   THTensor_(resize1d)(r_, n);
 
   if(n == 1) {
@@ -2002,7 +2124,7 @@ void THTensor_(logspace)(THTensor *r_, real a, real b, long n)
 
   THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
   THArgCheck(a <= b, 2, "end range should be greater than start range");
-  
+
   THTensor_(resize1d)(r_, n);
   if(n == 1) {
     TH_TENSOR_APPLY(real, r_,
@@ -2041,7 +2163,7 @@ void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalu
   THTensor_(zero)(hist);
   minval = minvalue;
   maxval = maxvalue;
-  if (minval == maxval) 
+  if (minval == maxval)
   {
     minval = THTensor_(minall)(tensor);
     maxval = THTensor_(maxall)(tensor);
@@ -2053,7 +2175,7 @@ void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalu
   }
   bins = (real)(nbins)-1e-6;
 
-  
+
   clone = THTensor_(newWithSize1d)(THTensor_(nElement)(tensor));
   THTensor_(copy)(clone,tensor);
   THTensor_(add)(clone, clone, -minval);
@@ -2061,7 +2183,7 @@ void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalu
   THTensor_(mul)(clone, clone, bins);
   THTensor_(floor)(clone, clone);
   THTensor_(add)(clone, clone, 1);
-  
+
   h_data = THTensor_(data)(hist);
 
   TH_TENSOR_APPLY(real, clone,                                         \

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -9,6 +9,10 @@ TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, real val
 TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
 TH_API void THTensor_(maskedSelect)(THTensor *tensor, THTensor* src, THByteTensor *mask);
 
+TH_API void THTensor_(find)(THLongTensor *subscript, THTensor *tensor);
+TH_API void THTensor_(ind2sub)(THTensor *subscript, THLongTensor *index, THLongStorage *size);
+TH_API void THTensor_(sub2ind)(THTensor *index, THLongTensor *subscript, THLongStorage *size);
+
 TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, real val);


### PR DESCRIPTION
Apologies for github commenting confusion and stripped trailing white-space diff.

Adds a find function similar to to the one found in MatLab. Copied from doc:

### [LongTensor] find(tensor)

Finds and returns a `LongTensor` corresponding to the linear indices of all
non-zero elements in `tensor`.

```lua
x = torch.rand(4, 4):mul(3):floor():int()
> x
  1  0  2  0
  2  0  2  2
  2  1  2  1
  0  1  1  2
[torch.IntTensor of dimension 4x4]

> torch.find(x)
  1
  3
  5
  7
  8
  9
 10
 11
 12
 14
 15
 16
[torch.LongTensor of dimension 12]

> x:find()
  1
  3
  5
  7
  8
  9
 10
 11
 12
 14
 15
 16
[torch.LongTensor of dimension 12]

```