### PR TITLE
Minor refactoring of RNG code

### DIFF
--- a/doc/random.md
+++ b/doc/random.md
@@ -8,10 +8,9 @@ random number generator.
 <a name=":torch.seed.dok"/>
 ## Seed Handling ##
 
-The random number generator is provided with a random seed via 
-[seed()](#torch.seed) when torch is being initialised. It can be 
-reinitialized using
-[seed()](#torch.seed) or [manualSeed()](#torch.manualSeed). 
+The random number generator is provided with a random seed via
+[seed()](#torch.seed) when torch is being initialised. It can be
+reinitialized using [seed()](#torch.seed) or [manualSeed()](#torch.manualSeed).
 
 Initial seed can be obtained using [initialSeed()](#torch.initialSeed).
 
@@ -104,4 +103,3 @@ Returns a random integer number according to a geometric distribution
 
 Returns `1` with probability `p` and `0` with probability `1-p`. `p` must satisfy `0 <= p <= 1`.
 By default `p` is equal to `0.5`.
-

--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -40,6 +40,15 @@ void THGenerator_free(THGenerator *self)
   THFree(self);
 }
 
+int THGenerator_isValid(THGenerator *_generator)
+{
+  if ((_generator->seeded == 1) &&
+    (_generator->left > 0 && _generator->left <= n) && (_generator->next <= n))
+    return 1;
+
+  return 0;
+}
+
 #ifndef _WIN32
 static unsigned long readURandomLong()
 {
@@ -174,16 +183,6 @@ void THRandom_nextState(THGenerator *_generator)
   *p = p[m-n] ^ TWIST(p[0], _generator->state[0]);
 }
 
-int THRandom_isValidState(THGenerator *_generator)
-{
-  if ((_generator->seeded == 1) &&
-    (_generator->left > 0 && _generator->left <= n) &&
-    (_generator->next >= 0 && _generator->next <= n))
-    return 1;
-
-  return 0;
-}
-
 unsigned long THRandom_random(THGenerator *_generator)
 {
   unsigned long y;
@@ -204,20 +203,8 @@ unsigned long THRandom_random(THGenerator *_generator)
 /* generates a random number on [0,1)-double-interval */
 static double __uniform__(THGenerator *_generator)
 {
-  unsigned long y;
-
-  if (--(_generator->left) == 0)
-    THRandom_nextState(_generator);
-  y = *(_generator->state + (_generator->next)++);
-
-  /* Tempering */
-  y ^= (y >> 11);
-  y ^= (y << 7) & 0x9d2c5680UL;
-  y ^= (y << 15) & 0xefc60000UL;
-  y ^= (y >> 18);
-
-  return (double)y * (1.0/4294967296.0);
   /* divided by 2^32 */
+  return (double)THRandom_random(_generator) * (1.0/4294967296.0);
 }
 
 /*********************************************************

--- a/lib/TH/THRandom.h
+++ b/lib/TH/THRandom.h
@@ -29,6 +29,9 @@ TH_API THGenerator * THGenerator_new();
 TH_API THGenerator * THGenerator_copy(THGenerator *self, THGenerator *from);
 TH_API void THGenerator_free(THGenerator *gen);
 
+/* Checks if given generator is valid */
+TH_API int THGenerator_isValid(THGenerator *_generator);
+
 /* Initializes the random number generator from /dev/urandom (or on Windows
 platforms with the current time (granularity: seconds)) and returns the seed. */
 TH_API unsigned long THRandom_seed(THGenerator *_generator);
@@ -75,10 +78,4 @@ TH_API int THRandom_geometric(THGenerator *_generator, double p);
 
 /* Returns true with probability $p$ and false with probability $1-p$ (p > 0). */
 TH_API int THRandom_bernoulli(THGenerator *_generator, double p);
-
-/* returns the random number state */
-TH_API void THRandom_getState(THGenerator *_generator, unsigned long *state, long *offset, long *_left);
-
-/* sets the random number state */
-TH_API void THRandom_setState(THGenerator *_generator, unsigned long *state, long offset, long _left);
 #endif

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -229,7 +229,7 @@ TH_API void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
   THArgCheck(THTensor_(nElement)(self) == size, 1, "RNG state is wrong size");
   THArgCheck(THTensor_(isContiguous)(self), 1, "RNG state needs to be contiguous");
   rng_state = (THGenerator *)THTensor_(data)(self);
-  THArgCheck(THRandom_isValidState(rng_state), 1, "Invalid RNG state");
+  THArgCheck(THGenerator_isValid(rng_state), 1, "Invalid RNG state");
   THGenerator_copy(_generator, rng_state);
 }
 #endif


### PR DESCRIPTION
Cleaned up some bits of RNG code:
* removed obsolete declarations of no longer existent functions  THRandom_getState/setState
* replaced THRandom_isValidState by THGenerator_isValid
* changed \_\_uniform\_\_ to use THRandom_random (code was practically identical) , which removes a brittleness in how the nextState has to be generated (tricky, error-prone 3 lines of code which were reused in two places previously)