### PR TITLE
fixed counter bug in maskedCopy

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -41,6 +41,10 @@ void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src )
 		     cntr++;
 		     if (cntr > nelem)
 		       THError("Number of elements of src != mask");
+		   } else if (*mask_data == 0)
+		   {
+		     src_data++;
+		     cntr++;
 		   });
   if (cntr != nelem)
     THError("Number of elements of src != mask");


### PR DESCRIPTION
maskedCopy was incorrectly not incrementing the counter on mask value == 0