### PR TITLE
Add C file/line to THError et al. Add THAssert. Improve error messages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ SET(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
   "${CMAKE_MODULE_PATH}")
 
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration -Werror=format")
+
 # Flags
 # When using MSVC
 IF(MSVC)

--- a/Tensor.lua
+++ b/Tensor.lua
@@ -9,6 +9,9 @@ local types = {'Byte', 'Char', 'Short', 'Int', 'Long', 'Float', 'Double'}
 
 -- tostring() functions for Tensor and Storage
 local function Storage__printformat(self)
+   if self:size() == 0 then 
+     return "", nil, 0
+   end
    local intMode = true
    local type = torch.typename(self)
 --   if type == 'torch.FloatStorage' or type == 'torch.DoubleStorage' then

--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -13,7 +13,8 @@ static int torch_Tensor_(size)(lua_State *L)
   if(lua_isnumber(L,2))
   {
     int dim = luaL_checkint(L, 2)-1;
-    luaL_argcheck(L, dim >= 0 && dim < tensor->nDimension, 2, "out of range");
+    THArgCheck(dim >= 0 && dim < tensor->nDimension, 2, "dimension %d out of range of %dD tensor",
+        dim+1, THTensor_(nDimension)(tensor));
     lua_pushnumber(L, tensor->size[dim]);
   }
   else
@@ -36,7 +37,8 @@ static int torch_Tensor_(stride)(lua_State *L)
   if(lua_isnumber(L,2))
   {
     int dim = luaL_checkint(L, 2)-1;
-    luaL_argcheck(L, dim >= 0 && dim < tensor->nDimension, 2, "out of range");
+    THArgCheck(dim >= 0 && dim < tensor->nDimension, 2, "dimension %d out of range of %dD tensor",
+        dim+1, THTensor_(nDimension)(tensor));
     lua_pushnumber(L, tensor->stride[dim]);
   }
   else
@@ -117,7 +119,7 @@ static int torch_Tensor_(new)(lua_State *L)
         THLongStorage_free(size);
         THLongStorage_free(counter);
         THTensor_(free)(tensor);
-        luaL_error(L, "invalid tensor definition");
+        THError("invalid tensor definition");
       }
 
       if(lua_objlen(L, -1) != size->data[size->size-1])
@@ -125,7 +127,7 @@ static int torch_Tensor_(new)(lua_State *L)
         THLongStorage_free(size);
         THLongStorage_free(counter);
         THTensor_(free)(tensor);
-        luaL_error(L, "invalid tensor sizes");
+        THError("invalid tensor sizes");
       }
 
       for(i = 0; i < size->data[size->size-1]; i++)
@@ -136,7 +138,7 @@ static int torch_Tensor_(new)(lua_State *L)
           THLongStorage_free(size);
           THLongStorage_free(counter);
           THTensor_(free)(tensor);
-          luaL_error(L, "invalid element (not a number)");
+          THError("invalid element (not a number)");
         }
         THStorage_(set)(THTensor_(storage)(tensor), si++, (real)lua_tonumber(L, -1));
         lua_pop(L, 1);
@@ -170,14 +172,14 @@ static int torch_Tensor_(new)(lua_State *L)
               THLongStorage_free(size);
               THLongStorage_free(counter);
               THTensor_(free)(tensor);
-              luaL_error(L, "invalid tensor definition");
+              THError("invalid tensor definition");
             }
             if(lua_objlen(L, -1) != size->data[j])
             {
               THLongStorage_free(size);
               THLongStorage_free(counter);
               THTensor_(free)(tensor);
-              luaL_error(L, "invalid tensor sizes");
+              THError("invalid tensor sizes");
             }
             lua_rawgeti(L, -1, counter->data[j]+1);
           }
@@ -295,10 +297,10 @@ static int torch_Tensor_(sub)(lua_State *L)
     d0s += tensor->size[0]+1;
   if(d0e < 0)
     d0e += tensor->size[0]+1;
-  luaL_argcheck(L, tensor->nDimension > 0, 2, "invalid dimension");
-  luaL_argcheck(L, d0s >= 0 && d0s < tensor->size[0], 2, "out of range");
-  luaL_argcheck(L, d0e >= 0 && d0e < tensor->size[0], 3, "out of range");
-  luaL_argcheck(L, d0e >= d0s, 3, "end smaller than beginning");
+  THArgCheck(tensor->nDimension > 0, 2, "invalid dimension");
+  THArgCheck(d0s >= 0 && d0s < tensor->size[0], 2, "out of range");
+  THArgCheck(d0e >= 0 && d0e < tensor->size[0], 3, "out of range");
+  THArgCheck(d0e >= d0s, 3, "end smaller than beginning");
 
   if(!lua_isnone(L, 4))
   {
@@ -308,10 +310,10 @@ static int torch_Tensor_(sub)(lua_State *L)
       d1s += tensor->size[1]+1;
     if(d1e < 0)
       d1e += tensor->size[1]+1;
-    luaL_argcheck(L, tensor->nDimension > 1, 4, "invalid dimension");
-    luaL_argcheck(L, d1s >= 0 && d1s < tensor->size[1], 4, "out of range");
-    luaL_argcheck(L, d1e >= 0 && d1e < tensor->size[1], 5, "out of range");
-    luaL_argcheck(L, d1e >= d1s, 5, "end smaller than beginning");
+    THArgCheck(tensor->nDimension > 1, 4, "invalid dimension");
+    THArgCheck(d1s >= 0 && d1s < tensor->size[1], 4, "out of range");
+    THArgCheck(d1e >= 0 && d1e < tensor->size[1], 5, "out of range");    
+    THArgCheck(d1e >= d1s, 5, "end smaller than beginning");
 
     if(!lua_isnone(L, 6))
     {
@@ -321,10 +323,10 @@ static int torch_Tensor_(sub)(lua_State *L)
         d2s += tensor->size[2]+1;
       if(d2e < 0)
         d2e += tensor->size[2]+1;
-      luaL_argcheck(L, tensor->nDimension > 2, 6, "invalid dimension");
-      luaL_argcheck(L, d2s >= 0 && d2s < tensor->size[2], 6, "out of range");
-      luaL_argcheck(L, d2e >= 0 && d2e < tensor->size[2], 7, "out of range");
-      luaL_argcheck(L, d2e >= d2s, 7, "end smaller than beginning");
+      THArgCheck(tensor->nDimension > 2, 6, "invalid dimension");
+      THArgCheck(d2s >= 0 && d2s < tensor->size[2], 6, "out of range");
+      THArgCheck(d2e >= 0 && d2e < tensor->size[2], 7, "out of range");    
+      THArgCheck(d2e >= d2s, 7, "end smaller than beginning");
 
       if(!lua_isnone(L, 8))
       {
@@ -334,10 +336,10 @@ static int torch_Tensor_(sub)(lua_State *L)
           d3s += tensor->size[3]+1;
         if(d3e < 0)
           d3e += tensor->size[3]+1;
-        luaL_argcheck(L, tensor->nDimension > 3, 8, "invalid dimension");
-        luaL_argcheck(L, d3s >= 0 && d3s < tensor->size[3], 8, "out of range");
-        luaL_argcheck(L, d3e >= 0 && d3e < tensor->size[3], 9, "out of range");
-        luaL_argcheck(L, d3e >= d3s, 9, "end smaller than beginning");
+        THArgCheck(tensor->nDimension > 3, 8, "invalid dimension");
+        THArgCheck(d3s >= 0 && d3s < tensor->size[3], 8, "out of range");
+        THArgCheck(d3e >= 0 && d3e < tensor->size[3], 9, "out of range");    
+        THArgCheck(d3e >= d3s, 9, "end smaller than beginning");
       }
     }
   }
@@ -403,7 +405,7 @@ static int torch_Tensor_(indexSelect)(lua_State *L)
   }
   else
   {
-    luaL_error(L,"Tensor, number, LongTensor | Tensor, Tensor, number, LongTensor expected");
+    THError("Tensor, number, LongTensor | Tensor, Tensor, number, LongTensor expected");
     return 0;
   }
 
@@ -427,7 +429,7 @@ static int torch_Tensor_(indexCopy)(lua_State *L)
   }
   else
   {
-    luaL_error(L,"Tensor, number, LongTensor, Tensor expected");
+    THError("Tensor, number, LongTensor, Tensor expected");
     return 0;
   }
 
@@ -452,7 +454,7 @@ static int torch_Tensor_(indexFill)(lua_State *L)
   }
   else
   {
-    luaL_error(L,"Tensor, number, LongTensor, number expected");
+    THError("Tensor, number, LongTensor, number expected");
     return 0;
   }
 
@@ -482,7 +484,7 @@ static int torch_Tensor_(maskedSelect)(lua_State *L)
   }
   else
   {
-    luaL_error(L,"Tensor, ByteTensor | Tensor, Tensor, ByteTensor expected");
+    THError("Tensor, ByteTensor | Tensor, Tensor, ByteTensor expected");
     return 0;
   }
 
@@ -505,7 +507,7 @@ static int torch_Tensor_(maskedCopy)(lua_State *L)
   }
   else
   {
-    luaL_error(L,"Tensor, ByteTensor, Tensor expected");
+    THError("Tensor, ByteTensor, Tensor expected");
     return 0;
   }
 
@@ -528,7 +530,7 @@ static int torch_Tensor_(maskedFill)(lua_State *L)
   }
   else
   {
-    luaL_error(L,"Tensor, ByteTensor, number expected");
+    THError("Tensor, ByteTensor, number expected");
     return 0;
   }
 
@@ -558,7 +560,7 @@ static int torch_Tensor_(t)(lua_State *L)
 {
   THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
 
-  luaL_argcheck(L, tensor->nDimension == 2, 1, "Tensor must have 2 dimensions");
+  THArgCheck(tensor->nDimension == 2, 1, "Tensor must have 2 dimensions");
 
   tensor = THTensor_(newWithTensor)(tensor);
   THTensor_(transpose)(tensor, NULL, 0, 1);
@@ -652,13 +654,13 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
   {
     void *src;
     long index = luaL_checklong(L,2)-1;
-    luaL_argcheck(L, tensor->nDimension > 0, 1, "empty tensor");
+    THArgCheck(tensor->nDimension > 0, 1, "empty tensor");
     if (index < 0) index = tensor->size[0] + index + 1;
 
     if (lua_isnumber(L,3)) {
       real value = (real)luaL_checknumber(L,3);
       if (tensor->nDimension == 1) {
-        luaL_argcheck(L, index >= 0 && index < tensor->size[0], 2, "out of range");
+        THArgCheck(index >= 0 && index < tensor->size[0], 2, "out of range");
         THStorage_(set)(tensor->storage, tensor->storageOffset+index*tensor->stride[0], value);
       } else {
         tensor = THTensor_(newWithTensor)(tensor);
@@ -717,13 +719,13 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
     real value = (real)luaL_checknumber(L,3);
     int dim;
 
-    luaL_argcheck(L, idx->size == tensor->nDimension, 2, "invalid size");
+    THArgCheck(idx->size == tensor->nDimension, 2, "invalid size");
 
     for(dim = 0; dim < idx->size; dim++)
     {
       long z = idx->data[dim]-1;
       if (z < 0) z = tensor->size[dim] + z + 1;
-      luaL_argcheck(L, (z >= 0) && (z < tensor->size[dim]), 2, "index out of bound");
+      THArgCheck((z >= 0) && (z < tensor->size[dim]), 2, "index out of bound");
       index += z*tensor->stride[dim];
     }
 
@@ -737,7 +739,7 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
     int ndims;
     int done = 0;
     ndims = tensor->nDimension;
-    luaL_argcheck(L, lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
+    THArgCheck(lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
     tensor = THTensor_(newWithTensor)(tensor);
     for(dim = 0; dim < ndims; dim++)
     {
@@ -747,7 +749,7 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
         long z = lua_tonumber(L, -1)-1;
         lua_pop(L, 1);
         if (z < 0) z = tensor->size[cdim] + z + 1;
-        luaL_argcheck(L, (z >= 0) && (z < tensor->size[cdim]), 2, "index out of bound");
+        THArgCheck((z >= 0) && (z < tensor->size[cdim]), 2, "index out of bound");
         if(tensor->nDimension == 1) {
           real value = (real)luaL_checknumber(L,3);
           done = 1;
@@ -767,7 +769,7 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
         }
         lua_pop(L, 1);
         if (start < 0) start = tensor->size[cdim] + start + 1;
-        luaL_argcheck(L, (start >= 0) && (start < tensor->size[cdim]), 2, "start index out of bound");
+        THArgCheck((start >= 0) && (start < tensor->size[cdim]), 2, "start index out of bound");
 
         lua_rawgeti(L, -1, 2);
         if(lua_isnumber(L, -1)) {
@@ -775,9 +777,9 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
         }
         lua_pop(L, 2);
         if (end < 0) end = tensor->size[cdim] + end + 1;
-        luaL_argcheck(L, (end >= 0) && (end < tensor->size[cdim]), 2, "end index out of bound");
+        THArgCheck((end >= 0) && (end < tensor->size[cdim]), 2, "end index out of bound");
 
-        luaL_argcheck(L, (end >= start), 2, "end index must be greater or equal to start index");
+        THArgCheck((end >= start), 2, "end index must be greater or equal to start index");
 
         THTensor_(narrow)(tensor, NULL, cdim++, start, end-start+1);
       }
@@ -827,7 +829,7 @@ static int torch_Tensor_(__newindex__)(lua_State *L)
     }
     else
     {
-      luaL_error(L,"number or tensor expected");
+      THError("number or tensor expected");
     }
   }
   else
@@ -846,9 +848,9 @@ static int torch_Tensor_(__index__)(lua_State *L)
   {
     long index = luaL_checklong(L,2)-1;
 
-    luaL_argcheck(L, tensor->nDimension > 0, 1, "empty tensor");
+    THArgCheck(tensor->nDimension > 0, 1, "empty tensor");
     if (index < 0) index = tensor->size[0] + index + 1;
-    luaL_argcheck(L, index >= 0 && index < tensor->size[0], 2, "out of range");
+    THArgCheck(index >= 0 && index < tensor->size[0], 2, "out of range");
 
     if(tensor->nDimension == 1)
     {
@@ -868,13 +870,13 @@ static int torch_Tensor_(__index__)(lua_State *L)
     long index = THTensor_(storageOffset)(tensor);
     int dim;
 
-    luaL_argcheck(L, idx->size == tensor->nDimension, 2, "invalid size");
-
+    THArgCheck(idx->size == tensor->nDimension, 2, "invalid size");
+    
     for(dim = 0; dim < idx->size; dim++)
     {
       long z = idx->data[dim]-1;
       if (z < 0) z = tensor->size[dim] + z + 1;
-      luaL_argcheck(L, (z >= 0) && (z < tensor->size[dim]), 2, "index out of bound");
+      THArgCheck((z >= 0) && (z < tensor->size[dim]), 2, "index out of bound");
       index += z*tensor->stride[dim];
     }
     lua_pushnumber(L, (double)THStorage_(get)(THTensor_(storage)(tensor), index));
@@ -889,7 +891,7 @@ static int torch_Tensor_(__index__)(lua_State *L)
     int done = 0;
 
     ndims = tensor->nDimension;
-    luaL_argcheck(L, lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
+    THArgCheck(lua_objlen(L, 2) <= ndims, 2, "too many indices provided");
     tensor = THTensor_(newWithTensor)(tensor);
 
     for(dim = 0; dim < ndims; dim++)
@@ -900,7 +902,7 @@ static int torch_Tensor_(__index__)(lua_State *L)
         long z = lua_tonumber(L, -1)-1;
         lua_pop(L, 1);
         if (z < 0) z = tensor->size[cdim] + z + 1;
-        luaL_argcheck(L, (z >= 0) && (z < tensor->size[cdim]), 2, "index out of bound");
+        THArgCheck((z >= 0) && (z < tensor->size[cdim]), 2, "index out of bound");
         if(tensor->nDimension == 1) {
           done = 1;
           lua_pushnumber(L, THStorage_(get)(tensor->storage, tensor->storageOffset+z*tensor->stride[0]));
@@ -919,7 +921,7 @@ static int torch_Tensor_(__index__)(lua_State *L)
         }
         lua_pop(L, 1);
         if (start < 0) start = tensor->size[cdim] + start + 1;
-        luaL_argcheck(L, (start >= 0) && (start < tensor->size[cdim]), 2, "start index out of bound");
+        THArgCheck((start >= 0) && (start < tensor->size[cdim]), 2, "start index out of bound");
 
         lua_rawgeti(L, -1, 2);
         if(lua_isnumber(L, -1)) {
@@ -927,9 +929,9 @@ static int torch_Tensor_(__index__)(lua_State *L)
         }
         lua_pop(L, 2);
         if (end < 0) end = tensor->size[cdim] + end + 1;
-        luaL_argcheck(L, (end >= 0) && (end < tensor->size[cdim]), 2, "end index out of bound");
+        THArgCheck((end >= 0) && (end < tensor->size[cdim]), 2, "end index out of bound");
 
-        luaL_argcheck(L, (end >= start), 2, "end index must be greater or equal to start index");
+        THArgCheck((end >= start), 2, "end index must be greater or equal to start index");
 
         THTensor_(narrow)(tensor, NULL, cdim++, start, end-start+1);
       }
@@ -986,9 +988,9 @@ static void torch_Tensor_(c_readSizeStride)(lua_State *L, int index, int allowSt
     if(!lua_isnoneornil(L, index+1))
     {
       if( (stride = luaT_toudata(L, index+1, "torch.LongStorage")) )
-        luaL_argcheck(L, stride->size == size->size, index+1, "provided stride and size are inconsistent");
+        THArgCheck(stride->size == size->size, index+1, "provided stride and size are inconsistent");
       else
-        luaL_argcheck(L, 0, index+1, "torch.LongStorage expected");
+        THArgCheck(0, index+1, "torch.LongStorage expected");
     }
     THLongStorage_retain(size);
     if(stride)
@@ -1084,13 +1086,13 @@ static void torch_Tensor_(c_readTensorStorageSizeStride)(lua_State *L, int index
   *storageOffset_ = 0;
 
   if(allowTensor && allowStorage)
-      luaL_argcheck(L, 0, index, "expecting number or Tensor or Storage");
+      THArgCheck(0, index, "expecting number or Tensor or Storage");
   else if(allowTensor)
-      luaL_argcheck(L, 0, index, "expecting number or Tensor");
+      THArgCheck(0, index, "expecting number or Tensor");
   else if(allowStorage)
-      luaL_argcheck(L, 0, index, "expecting number or Storage");
+      THArgCheck(0, index, "expecting number or Storage");
   else
-      luaL_argcheck(L, 0, index, "expecting number");
+      THArgCheck(0, index, "expecting number");
 }
 
 static int torch_Tensor_(apply)(lua_State *L)
@@ -1111,7 +1113,7 @@ static int torch_Tensor_(apply)(lua_State *L)
                   else if(lua_isnil(L, 3))
                     lua_pop(L, 1);
                   else
-                    luaL_error(L, "given function should return a number or nil"););
+                    THError("given function should return a number or nil"););
 
   lua_settop(L, 1);
   return 1;
@@ -1137,7 +1139,7 @@ static int torch_Tensor_(map)(lua_State *L)
                   else if(lua_isnil(L, 4))
                     lua_pop(L, 1);
                   else
-                    luaL_error(L, "given function should return a number or nil"););
+                    THError("given function should return a number or nil"););
 
   lua_settop(L, 1);
   return 1;
@@ -1165,7 +1167,7 @@ static int torch_Tensor_(map2)(lua_State *L)
                   else if(lua_isnil(L, 5))
                     lua_pop(L, 1);
                   else
-                    luaL_error(L, "given function should return a number or nothing"););
+                    THError("given function should return a number or nothing"););
 
   lua_settop(L, 1);
   return 1;

--- a/generic/TensorOperator.c
+++ b/generic/TensorOperator.c
@@ -142,7 +142,7 @@ static int torch_TensorOperator_(__div__)(lua_State *L)
   THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
   THTensor *r;
 
-  luaL_argcheck(L, lua_isnumber(L,2), 2, "number expected");
+  THArgCheck(lua_isnumber(L,2), 2, "number expected");
 
   r = THTensor_(new)();
   luaT_pushudata(L, r, torch_Tensor);

--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -13,18 +13,31 @@ static void defaultTorchErrorHandlerFunction(const char *msg, void *data)
 static __thread void (*torchErrorHandlerFunction)(const char *msg, void *data) = defaultTorchErrorHandlerFunction;
 static __thread void *torchErrorHandlerData;
 
-void THError(const char *fmt, ...)
+void _THError(const char *file, const int line, const char *fmt, ...)
 {
-  char msg[1024];
+  char msg[2048];
   va_list args;
 
   /* vasprintf not standard */
   /* vsnprintf: how to handle if does not exists? */
   va_start(args, fmt);
-  vsnprintf(msg, 1024, fmt, args);
+  int n = vsnprintf(msg, 2048, fmt, args);
   va_end(args);
 
+  if(n < 2048) {
+    snprintf(msg + n, 2048 - n, " at %s:%d", file, line);
+  }
+
   (*torchErrorHandlerFunction)(msg, torchErrorHandlerData);
+}
+
+void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...) {
+  char msg[1024];
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(msg, 1024, fmt, args);
+  va_end(args);
+  _THError(file, line, "Assertion `%s' failed. %s", exp, msg);
 }
 
 void THSetErrorHandler( void (*torchErrorHandlerFunction_)(const char *msg, void *data), void *data )
@@ -49,10 +62,24 @@ static void defaultTorchArgErrorHandlerFunction(int argNumber, const char *msg, 
 static __thread void (*torchArgErrorHandlerFunction)(int argNumber, const char *msg, void *data) = defaultTorchArgErrorHandlerFunction;
 static __thread void *torchArgErrorHandlerData;
 
-void THArgCheck(int condition, int argNumber, const char *msg)
+void _THArgCheck(const char *file, int line, int condition, int argNumber, const char *fmt, ...)
 {
-  if(!condition)
+  if(!condition) {
+    char msg[2048];
+    va_list args;
+
+    /* vasprintf not standard */
+    /* vsnprintf: how to handle if does not exists? */
+    va_start(args, fmt);
+    int n = vsnprintf(msg, 2048, fmt, args);
+    va_end(args);
+
+    if(n < 2048) {
+      snprintf(msg + n, 2048 - n, " at %s:%d", file, line);
+    }
+
     (*torchArgErrorHandlerFunction)(argNumber, msg, torchArgErrorHandlerData);
+  }
 }
 
 void THSetArgErrorHandler( void (*torchArgErrorHandlerFunction_)(int argNumber, const char *msg, void *data), void *data )

--- a/lib/TH/THGeneral.h.in
+++ b/lib/TH/THGeneral.h.in
@@ -44,13 +44,29 @@
 #endif
 
 TH_API double THLog1p(const double x);
-TH_API void THError(const char *fmt, ...);
+TH_API void _THError(const char *file, const int line, const char *fmt, ...);
+TH_API void _THAssertionFailed(const char *file, const int line, const char *exp, const char *fmt, ...);
 TH_API void THSetErrorHandler( void (*torchErrorHandlerFunction)(const char *msg, void *data), void *data );
-TH_API void THArgCheck(int condition, int argNumber, const char *msg);
+TH_API void _THArgCheck(const char *file, int line, int condition, int argNumber, const char *fmt, ...);
 TH_API void THSetArgErrorHandler( void (*torchArgErrorHandlerFunction)(int argNumber, const char *msg, void *data), void *data );
 TH_API void* THAlloc(long size);
 TH_API void* THRealloc(void *ptr, long size);
 TH_API void THFree(void *ptr);
+
+#define THError(...) _THError(__FILE__, __LINE__, __VA_ARGS__)
+#define THArgCheck(...) _THArgCheck(__FILE__, __LINE__, __VA_ARGS__)
+#define THAssert(exp)                                                 \
+do {                                                                  \
+  if (!(exp)) {                                                       \
+    _THAssertionFailed(__FILE__, __LINE__, #exp, "");                 \
+  }                                                                   \
+} while(0)
+#define THAssertMsg(exp, ...)                                         \
+do {                                                                  \
+  if (!(exp)) {                                                       \
+    _THAssertionFailed(__FILE__, __LINE__, #exp, __VA_ARGS__);        \
+  }                                                                   \
+} while(0)
 
 #define TH_CONCAT_STRING_2(x,y) TH_CONCAT_STRING_2_EXPAND(x,y)
 #define TH_CONCAT_STRING_2_EXPAND(x,y) #x #y

--- a/lib/TH/THTensor.h
+++ b/lib/TH/THTensor.h
@@ -7,6 +7,11 @@
 #define THTensor          TH_CONCAT_3(TH,Real,Tensor)
 #define THTensor_(NAME)   TH_CONCAT_4(TH,Real,Tensor_,NAME)
 
+#define TH_DESC_BUFF_LEN 64
+typedef struct {
+    char str[TH_DESC_BUFF_LEN];
+} THDescBuff;
+
 /* basics */
 #include "generic/THTensor.h"
 #include "THGenerateAllTypes.h"

--- a/lib/TH/generic/THTensor.h
+++ b/lib/TH/generic/THTensor.h
@@ -122,4 +122,8 @@ TH_API real THTensor_(get2d)(const THTensor *tensor, long x0, long x1);
 TH_API real THTensor_(get3d)(const THTensor *tensor, long x0, long x1, long x2);
 TH_API real THTensor_(get4d)(const THTensor *tensor, long x0, long x1, long x2, long x3);
 
+/* Debug methods */
+TH_API THDescBuff THTensor_(desc)(const THTensor *tensor);
+TH_API THDescBuff THTensor_(sizeDesc)(const THTensor *tensor);
+
 #endif


### PR DESCRIPTION
* Add C file/line to THError and THArgCheck. Add tensor sizeStr() method.
* Add THAssert THAssertMsg functions.
* Add sizeDesc() and desc() functions, which return tensor descriptor
strings for use in error messages. To avoid memory leaks, we have to pass these
strings on the stack within structs, so it's a bit unwieldly.
* Improved a bunch of error messages.

e.g.

```
th> torch.mm(torch.Tensor(4,4), torch.Tensor(5,5))
size mismatch, m1: [4 x 4], m2: [5 x 5] at /home/alerer/git/torch7-2/lib/TH/generic/THTensorMath.c:511
stack traceback:
...
th> torch.Tensor(1):size(4)
[...]:1: bad argument #1 to 'size' (dimension 4 out of range of 1D tensor at /home/alerer/git/torch7-2/generic/Tensor.c:16)
stack traceback:
...
```