### PR TITLE
A typo, 'setp', is corrected to 'step'

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -250,7 +250,7 @@ For more than 4 dimensions, you can use a storage as argument:
 <a name="torch.range"/>
 
 `y=torch.range(x,y)` returns a tensor of size `floor((y - x) / step) + 1` with values
-from `x` to `y` with step `setp` (default to 1).
+from `x` to `y` with step `step` (default to 1).
 
 ```lua
 > print(torch.range(2,5))


### PR DESCRIPTION
This is a very minor correction for the documentation. There is a typo in torch.range section. `step` is misspelled as `setp`.