### PR TITLE
Fixed inconsistency in Tensor.__tostring__

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -208,13 +208,13 @@ function Tensor.__tostring__(self)
                table.insert(strt, string.format(format, tensor[i]) .. '\n')
             end
          end
-         table.insert(strt, '[' .. torch.typename(self) .. ' of dimension ' .. tensor:size(1) .. ']\n')
+         table.insert(strt, '[' .. torch.typename(self) .. ' of size ' .. tensor:size(1) .. ']\n')
       elseif tensor:nDimension() == 2 then
          table.insert(strt, Tensor__printMatrix(tensor))
-         table.insert(strt, '[' .. torch.typename(self) .. ' of dimension ' .. tensor:size(1) .. 'x' .. tensor:size(2) .. ']\n')
+         table.insert(strt, '[' .. torch.typename(self) .. ' of size ' .. tensor:size(1) .. 'x' .. tensor:size(2) .. ']\n')
       else
          table.insert(strt, Tensor__printTensor(tensor))
-         table.insert(strt, '[' .. torch.typename(self) .. ' of dimension ')
+         table.insert(strt, '[' .. torch.typename(self) .. ' of size ')
          for i=1,tensor:nDimension() do
             table.insert(strt, tensor:size(i))
             if i ~= tensor:nDimension() then


### PR DESCRIPTION
The string that `Tensor.__tostring__` function returns includes size of different dimensions of the tensor (`tensor:size()`), but not the dimension of the tensor (`tensor:dim()`). For example, the dimension of the `torch.rand(7)`, which is obtained by `torch.rand(7):dim()` is 1, whereas `Tensor.__tostring__` returns
`[torch.DoubleTensor of dimension 7]`,
which is incorrect. This is a tensor of dimension 1, size 7. The same problem exists for Tensors of dimension 2 and beyond. For instance, for `torch.rand(8,5)` the `Tensor.__tostring__` function returns
`[torch.DoubleTensor of dimension 8x5]`
instead of returning `[torch.DoubleTensor of dimension 2]` as expected by `torch.rand(8,5):dim()`.

To fix this issue and make the returned description consistent with the terminology of the Torch package (i.e. `tensor:dim()` and `tensor:size()`), the string `' of dimension '` has been changed to `' of size '` in all three usages.

Here is another example in a screenshot of Trepl:

![small](https://cloud.githubusercontent.com/assets/9168758/7082724/2bc48012-df0d-11e4-873d-663e8bd4b997.png)
