### PR TITLE
Fix argument checks

### DIFF
--- a/lib/TH/generic/THTensor.c
+++ b/lib/TH/generic/THTensor.c
@@ -93,12 +93,12 @@ THTensor *THTensor_(newWithTensor)(THTensor *tensor)
 
 /* Storage init */
 THTensor *THTensor_(newWithStorage)(THStorage *storage, long storageOffset, THLongStorage *size, THLongStorage *stride)
-{  
+{
   THTensor *self = THAlloc(sizeof(THTensor));
   if(size && stride)
     THArgCheck(size->size == stride->size, 4, "inconsistent size");
 
-  THTensor_(rawInit)(self);  
+  THTensor_(rawInit)(self);
   THTensor_(rawSet)(self,
                     storage,
                     storageOffset,
@@ -139,7 +139,7 @@ THTensor *THTensor_(newWithStorage4d)(THStorage *storage, long storageOffset,
   long stride[4] = {stride0, stride1, stride2, stride3};
 
   THTensor *self = THAlloc(sizeof(THTensor));
-  THTensor_(rawInit)(self);  
+  THTensor_(rawInit)(self);
   THTensor_(rawSet)(self, storage, storageOffset, 4, size, stride);
 
   return self;
@@ -170,7 +170,7 @@ THTensor *THTensor_(newWithSize4d)(long size0, long size1, long size2, long size
   long size[4] = {size0, size1, size2, size3};
 
   THTensor *self = THAlloc(sizeof(THTensor));
-  THTensor_(rawInit)(self);  
+  THTensor_(rawInit)(self);
   THTensor_(rawResize)(self, 4, size, NULL);
 
   return self;
@@ -298,8 +298,8 @@ void THTensor_(setStorage)(THTensor *self, THStorage *storage_, long storageOffs
 {
   if(size_ && stride_)
     THArgCheck(size_->size == stride_->size, 5, "inconsistent size/stride sizes");
-  
-  THTensor_(rawSet)(self, 
+
+  THTensor_(rawSet)(self,
                     storage_,
                     storageOffset_,
                     (size_ ? size_->size : (stride_ ? stride_->size : 0)),
@@ -350,7 +350,7 @@ void THTensor_(setStorage4d)(THTensor *self, THStorage *storage_, long storageOf
   long size[4] = {size0_, size1_, size2_, size3_};
   long stride[4] = {stride0_, stride1_, stride2_, stride3_};
 
-  THTensor_(rawSet)(self, storage_, storageOffset_, 4, size, stride);  
+  THTensor_(rawSet)(self, storage_, storageOffset_, 4, size, stride);
 }
 
 
@@ -359,15 +359,15 @@ void THTensor_(narrow)(THTensor *self, THTensor *src, int dimension, long firstI
   if(!src)
     src = self;
 
-  THArgCheck( (dimension >= 0) && (dimension < src->nDimension), 3, "out of range");
-  THArgCheck( (firstIndex >= 0) && (firstIndex < src->size[dimension]), 4, "out of range");
-  THArgCheck( (size > 0) && (firstIndex+size <= src->size[dimension]), 5, "out of range");
-  
+  THArgCheck( (dimension >= 0) && (dimension < src->nDimension), 2, "out of range");
+  THArgCheck( (firstIndex >= 0) && (firstIndex < src->size[dimension]), 3, "out of range");
+  THArgCheck( (size > 0) && (firstIndex+size <= src->size[dimension]), 4, "out of range");
+
   THTensor_(set)(self, src);
 
   if(firstIndex > 0)
     self->storageOffset += firstIndex*self->stride[dimension];
-  
+
   self->size[dimension] = size;
 }
 
@@ -379,8 +379,8 @@ void THTensor_(select)(THTensor *self, THTensor *src, int dimension, long sliceI
     src = self;
 
   THArgCheck(src->nDimension > 1, 1, "cannot select on a vector");
-  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 3, "out of range");
-  THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size[dimension]), 4, "out of range");
+  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 2, "out of range");
+  THArgCheck((sliceIndex >= 0) && (sliceIndex < src->size[dimension]), 3, "out of range");
 
   THTensor_(set)(self, src);
   THTensor_(narrow)(self, NULL, dimension, sliceIndex, 1);
@@ -406,7 +406,7 @@ void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1, int dim
 
   if(dimension1 == dimension2)
 	  return;
- 
+
   z = self->stride[dimension1];
   self->stride[dimension1] = self->stride[dimension2];
   self->stride[dimension2] = z;
@@ -425,7 +425,7 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, long size, 
     src = self;
 
   THArgCheck( (src->nDimension > 0), 1, "cannot unfold an empty tensor");
-  THArgCheck(dimension < src->nDimension, 2, "out of range");
+  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 2, "out of range");
   THArgCheck(size <= src->size[dimension], 3, "out of range");
   THArgCheck(step > 0, 4, "invalid step");
 
@@ -499,7 +499,7 @@ void THTensor_(squeeze1d)(THTensor *self, THTensor *src, int dimension)
   if(!src)
     src = self;
 
-  THArgCheck(dimension < src->nDimension, 3, "dimension out of range");
+  THArgCheck((dimension >= 0) && (dimension < src->nDimension), 2, "dimension out of range");
 
   THTensor_(set)(self, src);
 
@@ -613,7 +613,7 @@ static void THTensor_(rawInit)(THTensor *self)
   self->storageOffset = 0;
   self->size = NULL;
   self->stride = NULL;
-  self->nDimension = 0;    
+  self->nDimension = 0;
   self->flag = TH_TENSOR_REFCOUNTED;
 }
 
@@ -681,7 +681,7 @@ static void THTensor_(rawResize)(THTensor *self, int nDimension, long *size, lon
       self->stride = THRealloc(self->stride, sizeof(long)*nDimension);
       self->nDimension = nDimension;
     }
-  
+
     totalSize = 1;
     for(d = self->nDimension-1; d >= 0; d--)
     {
@@ -695,13 +695,13 @@ static void THTensor_(rawResize)(THTensor *self, int nDimension, long *size, lon
         else
           self->stride[d] = self->size[d+1]*self->stride[d+1];
       }
-      totalSize += (self->size[d]-1)*self->stride[d];      
+      totalSize += (self->size[d]-1)*self->stride[d];
     }
 
     if(totalSize+self->storageOffset > 0)
     {
       if(!self->storage)
-        self->storage = THStorage_(new)();    
+        self->storage = THStorage_(new)();
       if(totalSize+self->storageOffset > self->storage->size)
         THStorage_(resize)(self->storage, totalSize+self->storageOffset);
     }


### PR DESCRIPTION
Some of the argument numbers passed to THArgCheck seemed to be off by one, creating confusing error messages. Also, dimension argument wasn't checked to be >= 0, e.g. in THTensor_(squeeze1d) a negative dimension could actually be used leading to segfault.

[ my editor automatically removed trailing whitespace - sorry for the noise ]