### PR TITLE
Fix bug in split while reusing the result table.

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -492,15 +492,14 @@ function Tensor.split(result, tensor, splitSize, dim)
       end
    end
    dim = dim or 1
-   local splits = {}
    local start = 1
    while start <= tensor:size(dim) do
       local size = math.min(splitSize, tensor:size(dim) - start + 1)
       local split = tensor:narrow(dim, start, size)
-      table.insert(splits, split)
+      table.insert(result, split)
       start = start + size
    end
-   return splits
+   return result
 end
 torch.split = Tensor.split
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -3,6 +3,7 @@
 local mytester
 local torchtest = {}
 local msize = 100
+local precision
 
 local function maxdiff(x,y)
    local d = x-y
@@ -2010,6 +2011,10 @@ function torchtest.split()
       mytester:assertTableEq(split:size():totable(), targetSize[i], 'Result size error in split '..i)
       mytester:assertTensorEq(tensor:narrow(dim, start, targetSize[i][dim]), split, 0.000001, 'Result content error in split '..i)
       start = start + targetSize[i][dim]
+   end
+   mytester:asserteq(#splits,#result, 0, 'Non-consistent output size from split')
+   for i, split in ipairs(splits) do
+      mytester:assertTensorEq(split,result[i], 0, 'Non-consistent outputs from split')
    end
 end
 


### PR DESCRIPTION
There was a small bug in `split` when the `result` table was given as input to be reused, as explained in the documentation. Instead of putting the output in `result`, it was only emptying it. It passed the tests because the size of `results` was 0, so it didn't check the assertions.
Added a few more test cases to compare both outputs.
Additionally, I set the `precision` variable to be local in `test.lua`