### PR TITLE
fixing torch.cat for sizes greater than 2^31

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1478,8 +1478,8 @@ void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension)
   size = THLongStorage_newWithSize(ndim);
   for(i = 0; i < ndim; i++)
   {
-    int tadi = (i < ta->nDimension ? ta->size[i] : 1);
-    int tbdi = (i < tb->nDimension ? tb->size[i] : 1);
+    long tadi = (i < ta->nDimension ? ta->size[i] : 1);
+    long tbdi = (i < tb->nDimension ? tb->size[i] : 1);
 
     if(i == dimension)
       size->data[i] = tadi+tbdi;


### PR DESCRIPTION
```lua
a = torch.zeros(2^31-10)
b  = torch.zeros(500)
c= torch.cat(a,b)
```
fails on master, passes now.

Can not add it as a default test case as it is too intensive.