### PR TITLE
Speed up Tensor:index

### DIFF
--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -101,7 +101,22 @@ void* THAlloc(long size)
   if(size == 0)
     return NULL;
 
-  ptr = malloc(size);
+  if (size > 5120)
+  {
+#if defined(__unix) || defined(__APPLE__)
+    if (posix_memalign(&ptr, 64, size) != 0)
+      ptr = NULL;
+#elif defined(_WIN32)
+    ptr = _aligned_malloc(size, 64);
+#else
+    ptr = malloc(size);
+#endif
+  }
+  else
+  {
+    ptr = malloc(size);
+  }
+
   if(!ptr)
     THError("$ Torch: not enough memory: you tried to allocate %dGB. Buy new RAM!", size/1073741824);
 


### PR DESCRIPTION
This contains two commits to speed up LookupTable operations:

1) Speed up Tensor:index (indexSelect) for contiguous tensors. This speeds up the forward pass of LookupTable by ~90x for large (e.g. 20K) inputs and by 3x for small (e.g. 10) inputs.

2) Align allocated memory on 64 byte boundaries (i.e. cache lines) for allocations larger than 5KB. This speeds up the backwards pass of LookupTable by up to 30% for some sizes and has no effect on others. (It helps when the # of dimensions is a multiple of 64) We only do this for large enough allocations to avoid wasting space.