### PR TITLE
Allowing usage of posix_memalign to be disabled through a new flag, DISABLE_POSIX_MEMALIGN

### DIFF
--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -103,7 +103,7 @@ void* THAlloc(long size)
 
   if (size > 5120)
   {
-#if defined(__unix) || defined(__APPLE__)
+#if (defined(__unix) || defined(__APPLE__)) && (!defined(DISABLE_POSIX_MEMALIGN))
     if (posix_memalign(&ptr, 64, size) != 0)
       ptr = NULL;
 #elif defined(_WIN32)


### PR DESCRIPTION
The usage of posix_memalign causes us problems with tcmalloc. I am adding a flag to disable its usage.