### PR TITLE
Adding elementType to complement elementSize.

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -287,3 +287,21 @@ Increment the reference counter of the storage.
 
 Decrement the reference counter of the storage. Free the storage if the
 counter is at 0.
+
+<a name="torch.Storage.elementSize"/>
+### [number] elementSize() ###
+
+Returns the size in bytes of an element in the storage. This is platform
+dependent and is not guaranteed to be the same everywhere.
+
+<a name="torch.Storage.elementType"/>
+### [number] elementType() ###
+
+Returns a string describing the type of element in the storage. This
+is the closest thing to RTTI for storage instantiations.
+
+```lua
+> x = torch.CharStorage()
+> print(x:elementType())
+Char
+```

--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -2179,3 +2179,21 @@ Increment the reference counter of the tensor.
 
 Decrement the reference counter of the tensor. Free the tensor if the
 counter is at 0.
+
+<a name="torch.Storage.elementSize"/>
+### [number] elementSize() ###
+
+Returns the size in bytes of an element in the storage. This is platform
+dependent and is not guaranteed to be the same everywhere.
+
+<a name="torch.Storage.elementType"/>
+### [number] elementType() ###
+
+Returns a string describing the type of element in the storage. This
+is the closest thing to RTTI for storage instantiations.
+
+```lua
+> x = torch.CharStorage()
+> print(x:elementType())
+Char
+```

--- a/generic/Storage.c
+++ b/generic/Storage.c
@@ -146,6 +146,12 @@ static int torch_Storage_(elementSize)(lua_State *L)
   return 1;
 }
 
+static int torch_Storage_(elementType)(lua_State *L)
+{
+  lua_pushstring(L, THStorage_(elementType)());
+  return 1;
+}
+
 static int torch_Storage_(__len__)(lua_State *L)
 {
   THStorage *storage = luaT_checkudata(L, 1, torch_Storage);
@@ -254,6 +260,7 @@ static const struct luaL_Reg torch_Storage_(_) [] = {
   {"free", torch_Storage_(free)},
   {"size", torch_Storage_(__len__)},
   {"elementSize", torch_Storage_(elementSize)},
+  {"elementType", torch_Storage_(elementType)},
   {"__len__", torch_Storage_(__len__)},
   {"__newindex__", torch_Storage_(__newindex__)},
   {"__index__", torch_Storage_(__index__)},

--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -31,6 +31,12 @@ static int torch_Tensor_(elementSize)(lua_State *L)
   return 1;
 }
 
+static int torch_Tensor_(elementType)(lua_State *L)
+{
+  lua_pushstring(L, THStorage_(elementType)());
+  return 1;
+}
+
 static int torch_Tensor_(stride)(lua_State *L)
 {
   THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
@@ -312,7 +318,7 @@ static int torch_Tensor_(sub)(lua_State *L)
       d1e += tensor->size[1]+1;
     THArgCheck(tensor->nDimension > 1, 4, "invalid dimension");
     THArgCheck(d1s >= 0 && d1s < tensor->size[1], 4, "out of range");
-    THArgCheck(d1e >= 0 && d1e < tensor->size[1], 5, "out of range");    
+    THArgCheck(d1e >= 0 && d1e < tensor->size[1], 5, "out of range");
     THArgCheck(d1e >= d1s, 5, "end smaller than beginning");
 
     if(!lua_isnone(L, 6))
@@ -325,7 +331,7 @@ static int torch_Tensor_(sub)(lua_State *L)
         d2e += tensor->size[2]+1;
       THArgCheck(tensor->nDimension > 2, 6, "invalid dimension");
       THArgCheck(d2s >= 0 && d2s < tensor->size[2], 6, "out of range");
-      THArgCheck(d2e >= 0 && d2e < tensor->size[2], 7, "out of range");    
+      THArgCheck(d2e >= 0 && d2e < tensor->size[2], 7, "out of range");
       THArgCheck(d2e >= d2s, 7, "end smaller than beginning");
 
       if(!lua_isnone(L, 8))
@@ -338,7 +344,7 @@ static int torch_Tensor_(sub)(lua_State *L)
           d3e += tensor->size[3]+1;
         THArgCheck(tensor->nDimension > 3, 8, "invalid dimension");
         THArgCheck(d3s >= 0 && d3s < tensor->size[3], 8, "out of range");
-        THArgCheck(d3e >= 0 && d3e < tensor->size[3], 9, "out of range");    
+        THArgCheck(d3e >= 0 && d3e < tensor->size[3], 9, "out of range");
         THArgCheck(d3e >= d3s, 9, "end smaller than beginning");
       }
     }
@@ -871,7 +877,7 @@ static int torch_Tensor_(__index__)(lua_State *L)
     int dim;
 
     THArgCheck(idx->size == tensor->nDimension, 2, "invalid size");
-    
+
     for(dim = 0; dim < idx->size; dim++)
     {
       long z = idx->data[dim]-1;
@@ -1236,6 +1242,7 @@ static const struct luaL_Reg torch_Tensor_(_) [] = {
   {"contiguous", torch_Tensor_(contiguous)},
   {"size", torch_Tensor_(size)},
   {"elementSize", torch_Tensor_(elementSize)},
+  {"elementType", torch_Tensor_(elementType)},
   {"__len__", torch_Tensor_(size)},
   {"stride", torch_Tensor_(stride)},
   {"dim", torch_Tensor_(nDimension)},

--- a/lib/TH/generic/THStorage.c
+++ b/lib/TH/generic/THStorage.c
@@ -17,6 +17,31 @@ int THStorage_(elementSize)()
   return sizeof(real);
 }
 
+const char* THStorage_(elementType)()
+{
+  #ifdef TH_REAL_IS_BYTE
+    return "Byte";
+  #endif
+  #ifdef TH_REAL_IS_CHAR
+    return "Char";
+  #endif
+  #ifdef TH_REAL_IS_SHORT
+    return "Short";
+  #endif
+  #ifdef TH_REAL_IS_INT
+    return "Int";
+  #endif
+  #ifdef TH_REAL_IS_LONG
+    return "Long";
+  #endif
+  #ifdef TH_REAL_IS_FLOAT
+    return "Float";
+  #endif
+  #ifdef TH_REAL_IS_DOUBLE
+    return "Double";
+  #endif
+}
+
 THStorage* THStorage_(new)(void)
 {
   return THStorage_(newWithSize)(0);

--- a/lib/TH/generic/THStorage.h
+++ b/lib/TH/generic/THStorage.h
@@ -35,6 +35,7 @@ typedef struct THStorage
 TH_API real* THStorage_(data)(const THStorage*);
 TH_API long THStorage_(size)(const THStorage*);
 TH_API int THStorage_(elementSize)();
+TH_API const char* THStorage_(elementType)();
 
 /* slow access -- checks everything */
 TH_API void THStorage_(set)(THStorage*, long, real);

--- a/test/test.lua
+++ b/test/test.lua
@@ -2135,6 +2135,32 @@ function torchtest.elementSize()
   mytester:assert(double >= float)
 end
 
+function torchtest.elementType()
+  local byte = torch.ByteStorage():elementType()
+  local char = torch.CharStorage():elementType()
+  local short = torch.ShortStorage():elementType()
+  local int = torch.IntStorage():elementType()
+  local long = torch.LongStorage():elementType()
+  local float = torch.FloatStorage():elementType()
+  local double = torch.DoubleStorage():elementType()
+
+  mytester:assert(byte == torch.ByteTensor():elementType(), "Expected Byte")
+  mytester:assert(char == torch.CharTensor():elementType(), "Expected Char")
+  mytester:assert(short == torch.ShortTensor():elementType(), "Expected Short")
+  mytester:assert(int == torch.IntTensor():elementType(), "Expected Int")
+  mytester:assert(long == torch.LongTensor():elementType(), "Expected Long")
+  mytester:assert(float == torch.FloatTensor():elementType(), "Expected Float")
+  mytester:assert(double == torch.DoubleTensor():elementType(), "Expected Double")
+
+  mytester:assert(byte == "Byte", "Expected Byte")
+  mytester:assert(char == "Char", "Expected Char")
+  mytester:assert(short == "Short", "Expected Short")
+  mytester:assert(int == "Int", "Expected Int")
+  mytester:assert(long == "Long", "Expected Long")
+  mytester:assert(float == "Float", "Expected Float")
+  mytester:assert(double == "Double", "Expected Double")
+end
+
 function torchtest.split()
    local result = {}
    local tensor = torch.rand(7,4)


### PR DESCRIPTION
This is a very simple version of RTTI for Tensor/Storage, it is very useful when interfacing with other systems, in particular where we need to marshal storage data in a type safe way.