### PR TITLE
Tweak torch.range to be more numerically robust.

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -483,9 +483,9 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
    wrap("range",
         cname("range"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
-         {name=real},
-         {name=real},
-         {name=real, default=1}})
+         {name=accreal},
+         {name=accreal},
+         {name=accreal, default=1}})
 
    wrap("randperm",
         cname("randperm"),

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1142,7 +1142,7 @@ void THTensor_(eye)(THTensor *r_, long n, long m)
 }
 
 
-void THTensor_(range)(THTensor *r_, real xmin, real xmax, real step)
+void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
 {
   long size;
   real i = 0;
@@ -1151,7 +1151,7 @@ void THTensor_(range)(THTensor *r_, real xmin, real xmax, real step)
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound incoherent with step sign");
 
-  size = (long)((xmax-xmin)/step+1);
+  size = (long)((xmax/step - xmin/step)+1);
   
   THTensor_(resize1d)(r_, size);
 

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -63,7 +63,7 @@ TH_API void THTensor_(zeros)(THTensor *r_, THLongStorage *size);
 TH_API void THTensor_(ones)(THTensor *r_, THLongStorage *size);
 TH_API void THTensor_(diag)(THTensor *r_, THTensor *t, int k);
 TH_API void THTensor_(eye)(THTensor *r_, long n, long m);
-TH_API void THTensor_(range)(THTensor *r_, real xmin, real xmax, real step);
+TH_API void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step);
 TH_API void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, long n);
 
 TH_API void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1020,6 +1020,18 @@ function torchtest.rangeequalbounds()
    torch.range(mxx,1,1,1)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.range value for equal bounds step')
 end
+function torchtest.rangefloat()
+   local mx = torch.FloatTensor():range(0.6, 0.9, 0.1)
+   mytester:asserteq(mx:size(1), 4, 'wrong size for FloatTensor range')
+   mx = torch.FloatTensor():range(1, 10, 0.3)
+   mytester:asserteq(mx:size(1), 31, 'wrong size for FloatTensor range')
+end
+function torchtest.rangedouble()
+   local mx = torch.DoubleTensor():range(0.6, 0.9, 0.1)
+   mytester:asserteq(mx:size(1), 4, 'wrong size for DoubleTensor range')
+   mx = torch.DoubleTensor():range(1, 10, 0.3)
+   mytester:asserteq(mx:size(1), 31, 'wrong size for DoubleTensor range')
+end
 function torchtest.randperm()
    local t=os.time()
    torch.manualSeed(t)


### PR DESCRIPTION
Otherwise it can produce mildly surprising behaviour, in the floating-point setting, due to rounding errors.

For example, we get:

    > torch.FloatTensor():range(0.6, 0.9, 0.1)
    0.6000
    0.7000
    0.8000
    [torch.FloatTensor of size 3]

When we'd expect:

     > torch.range(0.6, 0.9, 0.1)
     0.6000
     0.7000
     0.8000
     0.9000
     [torch.FloatTensor of size 4]

This happens because the size for the result tensor is computed as 

    size = (long)((xmax-xmin)/step+1);

and in single-precision this gives 3. We can avoid this by
* changing the input types to accreal, so that the size is computed at double precision even for FloatTensors.
* dividing by step before subtracting xmin from xmax, which seems to be more robust to rounding error.

Both appear to be necessary in my tests...