### PR TITLE
FindBLAS.cmake: fix missing stdlib.h include

### DIFF
--- a/lib/TH/cmake/FindBLAS.cmake
+++ b/lib/TH/cmake/FindBLAS.cmake
@@ -243,6 +243,7 @@ endif()
 IF (BLAS_LIBRARIES)
   SET(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
   CHECK_C_SOURCE_RUNS("
+#include <stdlib.h>
 #include <stdio.h>
 float x[4] = { 1, 2, 3, 4 };
 float y[4] = { .1, .01, .001, .0001 };
@@ -255,6 +256,7 @@ int main() {
   exit((float)r != (float).1234);
 }" BLAS_F2C_DOUBLE_WORKS )
   CHECK_C_SOURCE_RUNS("
+#include <stdlib.h>
 #include <stdio.h>
 float x[4] = { 1, 2, 3, 4 };
 float y[4] = { .1, .01, .001, .0001 };

--- a/test/test.lua
+++ b/test/test.lua
@@ -16,19 +16,25 @@ local function maxdiff(x,y)
 end
 
 function torchtest.dot()
-   local v1 = torch.randn(100)
-   local v2 = torch.randn(100)
+   local types = {
+      ['torch.DoubleTensor'] = 1e-8, -- for ddot
+      ['torch.FloatTensor']  = 1e-4, -- for sdot
+   }
+   for tname, prec in pairs(types) do
+      local v1 = torch.randn(100):type(tname)
+      local v2 = torch.randn(100):type(tname)
 
-   local res1 = torch.dot(v1,v2)
+      local res1 = torch.dot(v1,v2)
 
-   local res2 = 0
-   for i = 1,v1:size(1) do
-      res2 = res2 + v1[i] * v2[i]
+      local res2 = 0
+      for i = 1,v1:size(1) do
+         res2 = res2 + v1[i] * v2[i]
+      end
+
+      local err = math.abs(res1-res2)
+
+      mytester:assertlt(err, prec, 'error in torch.dot (' .. tname .. ')')
    end
-
-   local err = math.abs(res1-res2)
-
-   mytester:assertlt(err, precision, 'error in torch.dot')
 end
 
 local genericSingleOpTest = [[


### PR DESCRIPTION
This is to make sure BLAS F2C auto detection does not fail because of compiler warnings:

    error: implicit declaration of function 'exit'

I discovered this problem while re-installing Torch on Mac OS X (10.10.3) with [GCC 5](https://github.com/Homebrew/homebrew-versions/blob/316dddf599f0c34a224374ef1ee6267cea6d1364/gcc5.rb). The dot product between two `float` tensors returned 0.

Looking at cmake outputs I got:

    -- Performing Test BLAS_F2C_DOUBLE_WORKS
    -- Performing Test BLAS_F2C_DOUBLE_WORKS - Failed
    -- Performing Test BLAS_F2C_FLOAT_WORKS
    -- Performing Test BLAS_F2C_FLOAT_WORKS - Failed

And CMakeError.log indicated that these auto detection programs failed because of `some warnings being treated as errors`.

I extended the unit test to make sure there is coverage for `sdot`. This extended test properly fails for my setup (OS X 10.10.3 / GCC 5) prior to this fix.