### PR TITLE
point out htat the dimension-wise operations can also be used matrixwide

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1251,6 +1251,8 @@ a specific dimension `d`, in __descending__ order.
 <a name="torch.matrixwide.dok"/>
 ## Matrix-wide operations  (tensor-wide operations) ##
 
+Note that many of the operations in [dimension-wise operations](#torch.columnwise.dok) can also be used as matrix-wide operations, by just omitting the `dim` parameter.
+
 <a name="torch.norm"/>
 ### torch.norm(x [,p] [,dim]) ###
 


### PR DESCRIPTION
point out htat the dimension-wise operations can also be used matrixwide

I sense from the various '.dok' postfixes that this is generated documentation?  So, this might not be the appropriate place to make this change?
