### PR TITLE
Fix problem with NaNs in max and min

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -284,19 +284,39 @@ accreal THTensor_(dot)(THTensor *tensor, THTensor *src)
 real THTensor_(minall)(THTensor *tensor)
 {
   real theMin;
+  real value;
+
   THArgCheck(tensor->nDimension > 0, 1, "tensor must have one dimension");
   theMin = THTensor_(data)(tensor)[0];
-  TH_TENSOR_APPLY(real, tensor, if(*tensor_data < theMin) theMin = *tensor_data;);
-  return theMin; 
+  TH_TENSOR_APPLY(real, tensor,
+                  value = *tensor_data;
+                  /* This is not the same as value<theMin in the case of NaNs */
+                  if(!(value >= theMin))
+                  {
+                    theMin = value;
+                    if (isnan(value))
+                      break;
+                  });
+  return theMin;
 }
 
 real THTensor_(maxall)(THTensor *tensor)
 {
   real theMax;
+  real value;
+
   THArgCheck(tensor->nDimension > 0, 1, "tensor must have one dimension");
   theMax = THTensor_(data)(tensor)[0];
-  TH_TENSOR_APPLY(real, tensor, if(*tensor_data > theMax) theMax = *tensor_data;);
-  return theMax; 
+  TH_TENSOR_APPLY(real, tensor,
+                  value = *tensor_data;
+                  /* This is not the same as value>theMax in the case of NaNs */
+                  if(!(value <= theMax))
+                  {
+                    theMax = value;
+                    if (isnan(value))
+                      break;
+                  });
+  return theMax;
 }
 
 accreal THTensor_(sumall)(THTensor *tensor)
@@ -842,6 +862,9 @@ long THTensor_(numel)(THTensor *t)
 void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension)
 {
   THLongStorage *dim;
+  real theMax;
+  real value;
+  long theIndex;
   long i;
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
@@ -854,24 +877,31 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongStorage_free(dim);
 
   TH_TENSOR_DIM_APPLY3(real, t, real, values_, long, indices_, dimension,
-                       long theIndex = 0;
-                       real theMax = t_data[0];
-                       for(i = 1; i < t_size; i++)
+                       theMax = t_data[0];
+                       theIndex = 0;
+
+                       for(i = 0; i < t_size; i++)
                        {
-                         if(t_data[i*t_stride] > theMax)
+                         value = t_data[i*t_stride];
+                         /* This is not the same as value>theMax in the case of NaNs */
+                         if(!(value <= theMax))
                          {
                            theIndex = i;
-                           theMax = t_data[i*t_stride];
+                           theMax = value;
+                           if (isnan(value))
+                             break;
                          }
                        }
                        *indices__data = theIndex;
-                       *values__data = theMax;);  
-
+                       *values__data = theMax;);
 }
 
 void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension)
 {
   THLongStorage *dim;
+  real theMin;
+  real value;
+  long theIndex;
   long i;
 
   THArgCheck(dimension >= 0 && dimension < THTensor_(nDimension)(t), 2, "dimension %d out of range",
@@ -884,19 +914,23 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   THLongStorage_free(dim);
 
   TH_TENSOR_DIM_APPLY3(real, t, real, values_, long, indices_, dimension,
-                       long theIndex = 0;
-                       real theMin = t_data[0];
-                       for(i = 1; i < t_size; i++)
+                       theMin = t_data[0];
+                       theIndex = 0;
+
+                       for(i = 0; i < t_size; i++)
                        {
-                         if(t_data[i*t_stride] < theMin)
+                         value = t_data[i*t_stride];
+                         /* This is not the same as value<theMin in the case of NaNs */
+                         if(!(value >= theMin))
                          {
                            theIndex = i;
-                           theMin = t_data[i*t_stride];
+                           theMin = value;
+                           if (isnan(value))
+                             break;
                          }
                        }
                        *indices__data = theIndex;
-                       *values__data = theMin;);  
-
+                       *values__data = theMin;);
 }
 
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -284,6 +284,16 @@ function torchtest.max()  -- torch.max([resval, resind,] x [,dim])
       end
    end
    mytester:assertlt(maxerr, precision, 'error in torch.max - non-contiguous')
+   -- NaNs
+   for index in pairs{1, 5, 100} do
+      local m1 = torch.randn(100)
+      m1[index] = 0/0
+      local res1val, res1ind = torch.max(m1, 1)
+      mytester:assert(res1val[1] ~= res1val[1], 'error in torch.max (value) - NaNs')
+      mytester:assert(res1ind[1] == index, 'error in torch.max (index) - NaNs')
+      local res1val = torch.max(m1)
+      mytester:assert(res1val ~= res1val, 'error in torch.max - NaNs')
+   end
 end
 
 function torchtest.min()  -- torch.min([resval, resind,] x [,dim])
@@ -342,6 +352,16 @@ function torchtest.min()  -- torch.min([resval, resind,] x [,dim])
       end
    end
    mytester:assertlt(minerr, precision, 'error in torch.min - non-contiguous')
+   -- NaNs
+   for index in pairs{1, 5, 100} do
+      local m1 = torch.randn(100)
+      m1[index] = 0/0
+      local res1val, res1ind = torch.min(m1, 1)
+      mytester:assert(res1val[1] ~= res1val[1], 'error in torch.min (value) - NaNs')
+      mytester:assert(res1ind[1] == index, 'error in torch.min (index) - NaNs')
+      local res1val = torch.min(m1)
+      mytester:assert(res1val ~= res1val, 'error in torch.min - NaNs')
+   end
 end
 
 for i, v in ipairs{{10}, {5, 5}} do


### PR DESCRIPTION
Now min and max always return NaN when the input contains a NaN.

They only returned NaN before when the first element of the input was NaN and the min or max value excluding NaNs otherwise.