### PR TITLE
fixing torch.random(a,b) for a,b >= 2^31

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -546,13 +546,13 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
    if Tensor == 'ByteTensor' then -- we declare this only once
       interface:print(
          [[
-static int THRandom_random2__(THGenerator *gen, long a, long b)
+static long THRandom_random2__(THGenerator *gen, long a, long b)
 {
   THArgCheck(b >= a, 2, "upper bound must be larger than lower bound");
   return((THRandom_random(gen) % (b+1-a)) + a);
 }
          
-static int THRandom_random1__(THGenerator *gen, long b)
+static long THRandom_random1__(THGenerator *gen, long b)
 {
   THArgCheck(b > 0, 1, "upper bound must be strictly positive");
   return(THRandom_random(gen) % b + 1);


### PR DESCRIPTION
Current implementation casts random number to int :-(. @andresy was this intended?