### PR TITLE
Change lua_isstring check in torch_random

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -58,7 +58,7 @@ static int torch_NAME(lua_State *L)
   else if(narg >= 2 && (tname = torch_istensortype(L, luaT_typename(L, 2)))) /* second? */
   {
   }
-  else if(narg >= 1 && lua_isstring(L, narg)
+  else if(narg >= 1 && lua_type(L, narg) == LUA_TSTRING
 	  && (tname = torch_istensortype(L, lua_tostring(L, narg)))) /* do we have a valid tensor type string then? */
   {
     lua_remove(L, -2);


### PR DESCRIPTION
lua_isstring returns true for a lua_Number. Then lua_tostring was called which led to a re-formatting (#281) that generated a loss of precision for doubles who need more than 14 digits of precision.
Also avoids two useless conversions.  
Replaced by the exclusive (lua_type(L, narg) == LUA_TSTRING) check.