### PR TITLE
MSVC corrections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,10 @@ SET(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
   "${CMAKE_MODULE_PATH}")
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration -Werror=format")
+IF (NOT MSVC)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration -Werror=format")
+ENDIF(NOT MSVC)
+
 
 # Flags
 # When using MSVC

--- a/lib/TH/generic/THTensorConv.c
+++ b/lib/TH/generic/THTensorConv.c
@@ -5,7 +5,7 @@
 /*
   2D Input, 2D kernel  : convolve given image with the given kernel.
 */
-TH_API void THTensor_(validXCorr2Dptr)(real *r_,
+void THTensor_(validXCorr2Dptr)(real *r_,
                                        real alpha,
                                        real *t_, long ir, long ic,
                                        real *k_, long kr, long kc,
@@ -58,7 +58,7 @@ TH_API void THTensor_(validXCorr2Dptr)(real *r_,
 /*
   2D Input, 2D kernel  : convolve given image with the given kernel.
 */
-TH_API void THTensor_(validConv2Dptr)(real *r_,
+void THTensor_(validConv2Dptr)(real *r_,
                                       real alpha,
                                       real *t_, long ir, long ic,
                                       real *k_, long kr, long kc,
@@ -111,7 +111,7 @@ TH_API void THTensor_(validConv2Dptr)(real *r_,
 /*
   2D Input, 2D kernel  : convolve given image with the given kernel, full convolution.
 */
-TH_API void THTensor_(fullConv2Dptr)(real *r_,
+void THTensor_(fullConv2Dptr)(real *r_,
                                      real alpha,
                                      real *t_, long ir, long ic,
                                      real *k_, long kr, long kc,
@@ -163,7 +163,7 @@ TH_API void THTensor_(fullConv2Dptr)(real *r_,
 /*
   2D Input, 2D kernel  : convolve given image with the given kernel, full convolution.
 */
-TH_API void THTensor_(fullXCorr2Dptr)(real *r_,
+void THTensor_(fullXCorr2Dptr)(real *r_,
                                       real alpha,
                                       real *t_, long ir, long ic,
                                       real *k_, long kr, long kc,
@@ -218,7 +218,7 @@ TH_API void THTensor_(fullXCorr2Dptr)(real *r_,
   for sr,sc=1 this is equivalent to validXCorr2Dptr, but otherwise it is useful for
   calculating derivatives wrt a kernel that is applied with stride sr,sc != 1
 */
-TH_API void THTensor_(validXCorr2DRevptr)(real *r_,
+void THTensor_(validXCorr2DRevptr)(real *r_,
                                           real alpha,
                                           real *t_, long ir, long ic,
                                           real *k_, long kr, long kc,
@@ -266,7 +266,7 @@ TH_API void THTensor_(validXCorr2DRevptr)(real *r_,
 /*
   3D Input, 3D kernel  : convolve given volume with the given kernel.
 */
-TH_API void THTensor_(validXCorr3Dptr)(real *r_,
+void THTensor_(validXCorr3Dptr)(real *r_,
                                        real alpha,
                                        real *t_, long it, long ir, long ic,
                                        real *k_, long kt, long kr, long kc,
@@ -311,7 +311,7 @@ TH_API void THTensor_(validXCorr3Dptr)(real *r_,
 /*
   3D Input, 3D kernel  : convolve given volume with the given kernel.
 */
-TH_API void THTensor_(validConv3Dptr)(real *r_,
+void THTensor_(validConv3Dptr)(real *r_,
                                       real alpha,
                                       real *t_, long it, long ir, long ic,
                                       real *k_, long kt, long kr, long kc,
@@ -357,7 +357,7 @@ TH_API void THTensor_(validConv3Dptr)(real *r_,
 /*
   3D Input, 3D kernel  : convolve given volume with the given kernel, full convolution.
 */
-TH_API void THTensor_(fullConv3Dptr)(real *r_,
+void THTensor_(fullConv3Dptr)(real *r_,
                                      real alpha,
                                      real *t_, long it, long ir, long ic,
                                      real *k_, long kt, long kr, long kc,
@@ -405,7 +405,7 @@ TH_API void THTensor_(fullConv3Dptr)(real *r_,
 /*
   3D Input, 3D kernel  : convolve given volume with the given kernel, full convolution.
 */
-TH_API void THTensor_(fullXCorr3Dptr)(real *r_,
+void THTensor_(fullXCorr3Dptr)(real *r_,
                                       real alpha,
                                       real *t_, long it, long ir, long ic,
                                       real *k_, long kt, long kr, long kc,
@@ -450,7 +450,7 @@ TH_API void THTensor_(fullXCorr3Dptr)(real *r_,
   for sr,sc=1 this is equivalent to validXCorr3Dptr, but otherwise it is useful for
   calculating derivatives wrt a kernel that is applied with stride sr,sc != 1
 */
-TH_API void THTensor_(validXCorr3DRevptr)(real *r_,
+void THTensor_(validXCorr3DRevptr)(real *r_,
                                           real alpha,
                                           real *t_, long it, long ir, long ic,
                                           real *k_, long kt, long kr, long kc,

--- a/lib/TH/generic/THTensorLapack.c
+++ b/lib/TH/generic/THTensorLapack.c
@@ -40,7 +40,7 @@ static int THTensor_(lapackClone)(THTensor *r_, THTensor *m, int forced)
   return THTensor_(lapackCloneNrows)(r_, m, forced, m->size[0]);
 }
 
-TH_API void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
+void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
 {
   int n, nrhs, lda, ldb, info;
   THIntTensor *ipiv;
@@ -123,7 +123,7 @@ TH_API void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor 
   THIntTensor_free(ipiv);
 }
 
-TH_API void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
+void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
 {
   // Note that a = NULL is interpreted as a = ra_, and b = NULL as b = rb_.
   int m, n, nrhs, lda, ldb, info, lwork;
@@ -217,7 +217,7 @@ TH_API void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor 
   THTensor_(free)(work);
 }
 
-TH_API void THTensor_(geev)(THTensor *re_, THTensor *rv_, THTensor *a_, const char *jobvr)
+void THTensor_(geev)(THTensor *re_, THTensor *rv_, THTensor *a_, const char *jobvr)
 {
   int n, lda, lwork, info, ldvr;
   THTensor *work, *wi, *wr, *a;
@@ -288,7 +288,7 @@ TH_API void THTensor_(geev)(THTensor *re_, THTensor *rv_, THTensor *a_, const ch
   THTensor_(free)(work);
 }
 
-TH_API void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const char *jobz, const char *uplo)
+void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const char *jobz, const char *uplo)
 {
   int n, lda, lwork, info;
   THTensor *work;
@@ -347,14 +347,14 @@ TH_API void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const cha
   THTensor_(free)(work);
 }
 
-TH_API void THTensor_(gesvd)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *a, const char* jobu)
+void THTensor_(gesvd)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *a, const char* jobu)
 {
   THTensor *ra_ = THTensor_(new)();
   THTensor_(gesvd2)(ru_, rs_, rv_,  ra_, a, jobu);
   THTensor_(free)(ra_);
 }
 
-TH_API void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra_, THTensor *a, const char* jobu)
+void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra_, THTensor *a, const char* jobu)
 {
   int k,m, n, lda, ldu, ldvt, lwork, info;
   THTensor *work;
@@ -438,7 +438,7 @@ TH_API void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTen
   THTensor_(free)(work);
 }
 
-TH_API void THTensor_(getri)(THTensor *ra_, THTensor *a)
+void THTensor_(getri)(THTensor *ra_, THTensor *a)
 {
   int m, n, lda, info, lwork;
   real wkopt;
@@ -507,7 +507,7 @@ TH_API void THTensor_(getri)(THTensor *ra_, THTensor *a)
   THIntTensor_free(ipiv);
 }
 
-TH_API void THTensor_(potrf)(THTensor *ra_, THTensor *a)
+void THTensor_(potrf)(THTensor *ra_, THTensor *a)
 {
   int n, lda, info;
   char uplo = 'U';
@@ -567,7 +567,7 @@ TH_API void THTensor_(potrf)(THTensor *ra_, THTensor *a)
   }
 }
 
-TH_API void THTensor_(potri)(THTensor *ra_, THTensor *a)
+void THTensor_(potri)(THTensor *ra_, THTensor *a)
 {
   int n, lda, info;
   char uplo = 'U';
@@ -653,7 +653,7 @@ TH_API void THTensor_(potri)(THTensor *ra_, THTensor *a)
   * `a`   - input Tensor; the matrix to decompose.
 
 */
-TH_API void THTensor_(qr)(THTensor *rq_, THTensor *rr_, THTensor *a)
+void THTensor_(qr)(THTensor *rq_, THTensor *rr_, THTensor *a)
 {
   int m = a->size[0];
   int n = a->size[1];
@@ -690,7 +690,7 @@ TH_API void THTensor_(qr)(THTensor *rq_, THTensor *rr_, THTensor *a)
   For further details, please see the LAPACK documentation.
 
 */
-TH_API void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
+void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
 {
   /* Prepare the input for LAPACK, making a copy if necessary. */
   THTensor *ra__;
@@ -768,7 +768,7 @@ TH_API void THTensor_(geqrf)(THTensor *ra_, THTensor *rtau_, THTensor *a)
   For further details, please see the LAPACK documentation.
 
 */
-TH_API void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
+void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
 {
   /* Prepare the input for LAPACK, making a copy if necessary. */
   THTensor *ra__;

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -2,7 +2,7 @@
 #define TH_GENERIC_FILE "generic/THTensorRandom.c"
 #else
 
-TH_API void THTensor_(random)(THTensor *self, THGenerator *_generator)
+void THTensor_(random)(THTensor *self, THGenerator *_generator)
 {
 #if defined(TH_REAL_IS_BYTE)
   TH_TENSOR_APPLY(real, self, *self_data = (unsigned char)(THRandom_random(_generator) % (UCHAR_MAX+1)););
@@ -23,44 +23,44 @@ TH_API void THTensor_(random)(THTensor *self, THGenerator *_generator)
 #endif
 }
 
-TH_API void THTensor_(geometric)(THTensor *self, THGenerator *_generator, double p)
+void THTensor_(geometric)(THTensor *self, THGenerator *_generator, double p)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_geometric(_generator, p););
 }
 
-TH_API void THTensor_(bernoulli)(THTensor *self, THGenerator *_generator, double p)
+void THTensor_(bernoulli)(THTensor *self, THGenerator *_generator, double p)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_bernoulli(_generator, p););
 }
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
-TH_API void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b)
+void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_uniform(_generator, a, b););
 }
 
-TH_API void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, double stdv)
+void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, double stdv)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_normal(_generator, mean, stdv););
 }
 
-TH_API void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lambda)
+void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lambda)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_exponential(_generator, lambda););
 }
 
-TH_API void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma)
+void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_cauchy(_generator, median, sigma););
 }
 
-TH_API void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, double stdv)
+void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, double stdv)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_logNormal(_generator, mean, stdv););
 }
 
-TH_API void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement)
+void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement)
 {
   int start_dim = THTensor_(nDimension)(prob_dist);
   long n_dist;
@@ -211,7 +211,7 @@ TH_API void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, 
 #endif
 
 #if defined(TH_REAL_IS_BYTE)
-TH_API void THTensor_(getRNGState)(THGenerator *_generator, THTensor *self)
+void THTensor_(getRNGState)(THGenerator *_generator, THTensor *self)
 {
   static const size_t size = sizeof(THGenerator);
   THGenerator *rng_state;
@@ -222,7 +222,7 @@ TH_API void THTensor_(getRNGState)(THGenerator *_generator, THTensor *self)
   THGenerator_copy(rng_state, _generator);
 }
 
-TH_API void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
+void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
 {
   static const size_t size = sizeof(THGenerator);
   THGenerator *rng_state;


### PR DESCRIPTION
Some corrections that allow for compilation in MSVC:
- do not set -Werror compilation flag that MSVC does not understand
- remove TH_API from function definitions for static library compilation
