### PR TITLE
Add support for compilation on Windows using mingw32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,12 @@ SET(CMAKE_MODULE_PATH
   "${CMAKE_MODULE_PATH}")
 
 IF (NOT MSVC)
+  IF (MINGW)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=format")
+  ELSE()
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration -Werror=format")
+  ENDIF(MINGW)
 ENDIF(NOT MSVC)
-
 
 # Flags
 # When using MSVC

--- a/Timer.c
+++ b/Timer.c
@@ -1,6 +1,6 @@
 #include "general.h"
 
-#ifdef _MSC_VER
+#if (defined(_MSC_VER) || defined(__MINGW32__))
 #include <time.h>
 #else
 #include <sys/time.h>
@@ -19,7 +19,7 @@ typedef struct _Timer
     double startusertime;
     double startsystime;
 
-#ifdef _MSC_VER
+#if (defined(_MSC_VER) || defined(__MINGW32__))
   time_t base_time;
 #endif
 

--- a/general.h
+++ b/general.h
@@ -7,7 +7,7 @@
 #include "luaT.h"
 #include "TH.h"
 
-#ifdef _MSC_VER
+#if (defined(_MSC_VER) || defined(__MINGW32__))
 
 #define snprintf _snprintf
 #define popen _popen

--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -150,7 +150,7 @@ void THFree(void *ptr)
 
 double THLog1p(const double x)
 {
-#ifdef _MSC_VER
+#if (defined(_MSC_VER) || defined(__MINGW32__))
   volatile double y = 1 + x;
   return log(y) - ((y-1)-x)/y ;  /* cancels errors with IEEE arithmetic */
 #else

--- a/lib/TH/THGeneral.h.in
+++ b/lib/TH/THGeneral.h.in
@@ -89,7 +89,7 @@ do {                                                                  \
 #define THMin(X, Y)  ((X) < (Y) ? (X) : (Y))
 #define THMax(X, Y)  ((X) > (Y) ? (X) : (Y))
 
-#ifdef _MSC_VER
+#if (defined(_MSC_VER) || defined(__MINGW32__))
 # define log1p(x) THLog1p(x)
 #define snprintf _snprintf
 #define popen _popen

--- a/lib/luaT/luaT.h
+++ b/lib/luaT/luaT.h
@@ -18,7 +18,7 @@ extern "C" {
 # endif
 #endif
 
-#ifdef _MSC_VER
+#if (defined(_MSC_VER) || defined(__MINGW32__))
 # define DLL_EXPORT __declspec(dllexport)
 # define DLL_IMPORT __declspec(dllimport)
 # ifdef luaT_EXPORTS
@@ -108,7 +108,7 @@ LUAT_API int luaT_lua_pushudata(lua_State *L);
 /* comments show what function (that you should use) they call now */
 #if (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #define LUAT_DEPRECATED  __attribute__((__deprecated__))
-#elif defined(_MSC_VER)
+#elif (defined(_MSC_VER) || defined(__MINGW32__))
 #define LUAT_DEPRECATED __declspec(deprecated)
 #else
 #define LUAT_DEPRECATED


### PR DESCRIPTION
This patch enables Torch7 compilation on Windows using mingw32 (or tdm-gcc with msys/msys2).

The steps needed:

1. Install `torch/cwrap` and `torch/paths`
2. Run the following commands:

```
cmake -E make_directory build
cd build
cmake .. -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DLUALIB=lua51.dll -DLUA_INCDIR="%LUA_INCDIR%" -DLUA_LIBDIR="%LUA_LIBDIR%" -DLUA="%LUA%"
make
```

Related ticket: #150. I've tested this under Windows 8.1 using msys2 and tdm-gcc-4.8, but it should work with other versions and configurations of mingw.