### PR TITLE
do not use _aligned_malloc in WIN32: it requires _aligned_[free|realloc]

### DIFF
--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -106,8 +106,10 @@ void* THAlloc(long size)
 #if (defined(__unix) || defined(__APPLE__)) && (!defined(DISABLE_POSIX_MEMALIGN))
     if (posix_memalign(&ptr, 64, size) != 0)
       ptr = NULL;
+/*
 #elif defined(_WIN32)
     ptr = _aligned_malloc(size, 64);
+*/
 #else
     ptr = malloc(size);
 #endif


### PR DESCRIPTION
Sam Gross in
9ad68c82f6d5a11db05ec667cbd78d8909c120d2
used _aligned_malloc 
but _aligned_malloc in Win32 requires _alinged_free in all other places (and in those places we do not know if we allocated with malloc - or with _aligned_malloc) - and resulted in crashes in garbage collector


