### PR TITLE
Fix for gemm with zero strides plus add unit test for torch.mm

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -624,12 +624,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
 /*  printf("%ldx%ld = %ldx%ld X %ldx%ld\n", r_->size[0], r_->size[1], m1->size[0], m1->size[1], m2->size[0], m2->size[1]); */
 
   /* r_ */
-  if(r_->stride[0] == 1)
+  if(r_->stride[0] == 1 &&
+     r_->stride[1] != 0)
   {
     transpose_r = 'n';
     r__ = r_;
   }
-  else if(r_->stride[1] == 1)
+  else if(r_->stride[1] == 1 &&
+          r_->stride[0] != 0)
   {
     THTensor *swap = m2;
     m2 = m1;
@@ -647,12 +649,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   }
 
   /* m1 */
-  if(m1->stride[(transpose_r == 'n' ? 0 : 1)] == 1)
+  if(m1->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
+     m1->stride[(transpose_r == 'n' ? 1 : 0)] != 0)
   {
     transpose_m1 = 'n';
     m1_ = m1;
   }
-  else if(m1->stride[(transpose_r == 'n' ? 1 : 0)] == 1)
+  else if(m1->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
+          m1->stride[(transpose_r == 'n' ? 0 : 1)] != 0)
   {
     transpose_m1 = 't';
     m1_ = m1;
@@ -664,12 +668,14 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   }
 
   /* m2 */
-  if(m2->stride[(transpose_r == 'n' ? 0 : 1)] == 1)
+  if(m2->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
+     m2->stride[(transpose_r == 'n' ? 1 : 0)] != 0)
   {
     transpose_m2 = 'n';
     m2_ = m2;
   }
-  else if(m2->stride[(transpose_r == 'n' ? 1 : 0)] == 1)
+  else if(m2->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
+          m2->stride[(transpose_r == 'n' ? 0 : 1)] != 0)
   {
     transpose_m2 = 't';
     m2_ = m2;

--- a/test/test.lua
+++ b/test/test.lua
@@ -471,6 +471,72 @@ function torchtest.div()
    mytester:assertlt(err, precision, 'error in torch.div - scalar, non contiguous')
 end
 
+function torchtest.mm()
+   -- helper function
+   local function matrixmultiply(mat1,mat2)
+      local n = mat1:size(1)
+      local m = mat1:size(2)
+      local p = mat2:size(2)
+      local res = torch.zeros(n,p)
+      for i = 1, n do
+         for j = 1, p do
+            local sum = 0
+            for k = 1, m do
+               sum = sum + mat1[i][k]*mat2[k][j]
+            end
+            res[i][j] = sum
+         end
+      end
+      return res
+   end
+
+   -- contiguous case
+   local n, m, p = 10, 10, 5
+   local mat1 = torch.randn(n,m)
+   local mat2 = torch.randn(m,p)
+   local res = torch.mm(mat1,mat2)
+
+   local res2 = matrixmultiply(mat1,mat2)
+   mytester:assertTensorEq(res,res2,precision,'error in torch.mm')
+
+   -- non contiguous case 1
+   local n, m, p = 10, 10, 5
+   local mat1 = torch.randn(n,m)
+   local mat2 = torch.randn(p,m):t()
+   local res = torch.mm(mat1,mat2)
+
+   local res2 = matrixmultiply(mat1,mat2)
+   mytester:assertTensorEq(res,res2,precision,'error in torch.mm, non contiguous')
+
+   -- non contiguous case 2
+   local n, m, p = 10, 10, 5
+   local mat1 = torch.randn(m,n):t()
+   local mat2 = torch.randn(m,p)
+   local res = torch.mm(mat1,mat2)
+
+   local res2 = matrixmultiply(mat1,mat2)
+   mytester:assertTensorEq(res,res2,precision,'error in torch.mm, non contiguous')
+
+   -- non contiguous case 3
+   local n, m, p = 10, 10, 5
+   local mat1 = torch.randn(m,n):t()
+   local mat2 = torch.randn(p,m):t()
+   local res = torch.mm(mat1,mat2)
+
+   local res2 = matrixmultiply(mat1,mat2)
+   mytester:assertTensorEq(res,res2,precision,'error in torch.mm, non contiguous')
+
+   -- test with zero stride
+   local n, m, p = 10, 10, 5
+   local mat1 = torch.randn(n,m)
+   local mat2 = torch.randn(m,1):expand(m,p)
+   local res = torch.mm(mat1,mat2)
+
+   local res2 = matrixmultiply(mat1,mat2)
+   mytester:assertTensorEq(res,res2,precision,'error in torch.mm, non contiguous, zero stride')
+
+end
+
 function torchtest.bmm()
    local num_batches = 10
    local M, N, O = 23, 8, 12


### PR DESCRIPTION
- Solves https://github.com/torch/torch7/issues/58
- Also solves the issue of gemm when the resulting tensor has zero stride (as in https://github.com/torch/torch7/issues/289)
- Adds unit test for `torch.mm`, which was missing