### PR TITLE
Use torch.typename in isTensor and isStorage

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -127,11 +127,19 @@ function torch.totable(obj)
 end
 
 function torch.isTensor(obj)
-  return type(obj) == 'userdata' and torch.isTypeOf(obj, 'torch.*Tensor')
+   local typename = torch.typename(obj)
+   if typename and typename:find('torch.*Tensor') then
+      return true
+   end
+   return false
 end
 
 function torch.isStorage(obj)
-  return type(obj) == 'userdata' and torch.isTypeOf(obj, 'torch.*Storage')
+   local typename = torch.typename(obj)
+   if typename and typename:find('torch.*Storage') then
+      return true
+   end
+   return false
 end
 -- alias for convenience
 torch.Tensor.isTensor = torch.isTensor


### PR DESCRIPTION
This supports tensor types that are implemented using cdata.
These cdata objects do not have a unique metatable, but their
names are available through torch.typename.

For Tensors and Storages, we do not need the recursive behavior of torch.isTypeOf.