### PR TITLE
Tests and documentation for transpositions in LAPACK functions

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -64,7 +64,7 @@ end
 <a name="torch.cat"/>
 ### [res] torch.cat( [res,] x_1, x_2, [dimension] ) ###
 <a name="torch.cat"/>
-`x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors `x_1` and `x_2` along dimension `dimension`. 
+`x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors `x_1` and `x_2` along dimension `dimension`.
 
 If `dimension` is not specified it is the last dimension.
 
@@ -129,7 +129,7 @@ Examples:
 with elements constructed from the diagonal of `x`.
 
 `y=torch.diag(x,k)` returns the k-th diagonal of `x`,
-where `k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0` 
+where `k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0`
 is below the main diagonal.
 
 <a name="torch.eye"/>
@@ -177,21 +177,21 @@ range.
 <a name="torch.multinomial"/>
 
 `y=torch.multinomial(p,n)` returns a tensor `y` where each row contains
-`n` indices sampled from the 
+`n` indices sampled from the
 [multinomial probability distribution](http://en.wikipedia.org/wiki/Multinomial_distribution)
-located in the corresponding row of tensor `p`. 
+located in the corresponding row of tensor `p`.
 
-The rows of `p` do not need to sum to one (in which case we use the values as weights), 
-but must be non-negative and have a non-zero sum. 
-Indices are ordered from left to right according to 
-when each was sampled (first samples are placed in first column). 
+The rows of `p` do not need to sum to one (in which case we use the values as weights),
+but must be non-negative and have a non-zero sum.
+Indices are ordered from left to right according to
+when each was sampled (first samples are placed in first column).
 
 If `p` is a vector, `y` is a vector size `n`.
 
 If `p` is a m-rows matrix, `y` is an `m x n` matrix.
 
-If `replacement` is `true`, samples are drawn __with replacement__. 
-If not, they are drawn __without replacement__, which means that when a sample index is drawn for a row, it 
+If `replacement` is `true`, samples are drawn __with replacement__.
+If not, they are drawn __without replacement__, which means that when a sample index is drawn for a row, it
 cannot be drawn again for that row. This implies the constraint that `n` must be lower than `p` length (or number of columns of `p` if it is a matrix).
 
 The default value for `replacement` is `false`.
@@ -206,10 +206,10 @@ a = torch.multinomial(p, 10000, true)
 [torch.LongTensor of dimension 10000]
 
 > for i=1,4 do print(a:eq(i):sum()) end
-3967  
-4016  
-2017  
-0 
+3967
+4016
+2017
+0
 ```
 
 <a name="torch.ones"/>
@@ -289,8 +289,8 @@ For more than 4 dimensions, you can use a storage:
 
 `y=torch.tril(x)` returns the lower triangular part of `x`, the other elements of `y` are set to 0.
 
-`torch.tril(x,k)` returns the elements on and below the k-th diagonal of `x` as non-zero. 
-`k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0` 
+`torch.tril(x,k)` returns the elements on and below the k-th diagonal of `x` as non-zero.
+`k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0`
 is below the main diagonal.
 
 <a name="torch.triu"/>
@@ -300,8 +300,8 @@ is below the main diagonal.
 `y=torch.triu(x)` returns the upper triangular part of `x`,
 the other elements of `y` are set to 0.
 
-`torch.triu(x,k)` returns the elements on and above the k-th diagonal of `x` as non-zero. 
-`k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0` 
+`torch.triu(x,k)` returns the elements on and above the k-th diagonal of `x` as non-zero.
+`k = 0` is the main diagonal, `k > 0` is above the main diagonal and `k < 0`
 is below the main diagonal.
 
 <a name="torch.zeros"/>
@@ -673,7 +673,7 @@ number of elements must match, but sizes do not matter.
 
 ```lua
 > x = torch.Tensor(2,2):fill(1)
-> y = torch.Tensor(4)        
+> y = torch.Tensor(4)
 > for i=1,4 do y[i] = i end
 > x:cdiv(y)
 > = x
@@ -695,8 +695,8 @@ number of elements must match, but sizes do not matter.
 ### [res] torch.addcdiv([res,] x [,value], tensor1, tensor2) ###
 <a name="torch.addcdiv"/>
 
-Performs the element-wise division of `tensor1` by `tensor1`, 
-multiply the result by the scalar `value` and add it to `x`. 
+Performs the element-wise division of `tensor1` by `tensor1`,
+multiply the result by the scalar `value` and add it to `x`.
 The number of elements must match, but sizes do not matter.
 
 ```lua
@@ -742,7 +742,7 @@ elements must match: both tensors are seen as a 1D vector.
 Performs a matrix-vector multiplication between `mat` (2D tensor)
 and `vec2` (1D tensor) and add it to `vec1`.
 
-Optional values `v1` and `v2` are scalars that multiply 
+Optional values `v1` and `v2` are scalars that multiply
 `vec1` and `vec2` respectively.
 
 Optional value `beta` is  a scalar that scales the result tensor, before accumulating the result into the tensor. Defaults to 1.0.
@@ -787,7 +787,7 @@ be a vector of size `n`.
 
 Performs the outer-product between `vec1` (1D tensor) and `vec2` (1D tensor).
 
-Optional values `v1` and `v2` are scalars that multiply 
+Optional values `v1` and `v2` are scalars that multiply
 `M` and `vec1 [out] vec2` respectively.
 
 In other words,
@@ -796,11 +796,11 @@ In other words,
 res_ij = v1 * mat_ij + v2 * vec1_i * vec2_j
 ```
 
-If `vec1` is a vector of size `n` and `vec2` is a vector of size `m`, 
+If `vec1` is a vector of size `n` and `vec2` is a vector of size `m`,
 then mat must be a matrix of size `n x m`.
 
 ```lua
-> x = torch.Tensor(3)        
+> x = torch.Tensor(3)
 > y = torch.Tensor(2)
 > for i=1,3 do x[i] = i end
 > for i=1,2 do y[i] = i end
@@ -831,7 +831,7 @@ then mat must be a matrix of size `n x m`.
 Performs a matrix-matrix multiplication between `mat1` (2D tensor)
 and `mat2` (2D tensor).
 
-Optional values `v1` and `v2` are scalars that multiply 
+Optional values `v1` and `v2` are scalars that multiply
 `M` and `mat1 * mat2` respectively.
 
 Optional value `beta` is  a scalar that scales the result tensor, before accumulating the result into the tensor. Defaults to 1.0.
@@ -842,7 +842,7 @@ In other words,
 res = res * beta + v1 * M + v2 * mat1*mat2
 ```
 
-If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix, 
+If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
 `M` must be a `n x p` matrix.
 
 `torch.addmm(M,mat1,mat2)` returns the result in a new tensor.
@@ -858,7 +858,7 @@ If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
 ### [res] torch.addbmm([res,] [v1,] M [v2,] batch1, batch2) ###
 <a name="torch.addbmm"/>
 
-Batch matrix matrix product of matrices stored in `batch1` and `batch2`, 
+Batch matrix matrix product of matrices stored in `batch1` and `batch2`,
 with a reduced add step (all matrix multiplications get accumulated in a
 single place).
 
@@ -905,8 +905,8 @@ res_i = v1 * M_i + v2 * batch1_i * batch2_i
 ### [res] torch.mv([res,] mat, vec) ###
 <a name="torch.mv"/>
 
-Matrix vector product of `mat` and `vec`. Sizes must respect 
-the matrix-multiplication operation: if `mat` is a `n x m` matrix, 
+Matrix vector product of `mat` and `vec`. Sizes must respect
+the matrix-multiplication operation: if `mat` is a `n x m` matrix,
 `vec` must be vector of size `m` and res must be a vector of size `n`.
 
 `torch.mv(x,y)` puts the result in a new tensor.
@@ -919,8 +919,8 @@ the matrix-multiplication operation: if `mat` is a `n x m` matrix,
 ### [res] torch.mm([res,] mat1, mat2) ###
 <a name="torch.mm"/>
 
-Matrix matrix product of `mat1` and `mat2`. If `mat1` is a 
-`n x m` matrix, `mat2` a `m x p` matrix, res must be a 
+Matrix matrix product of `mat1` and `mat2`. If `mat1` is a
+`n x m` matrix, `mat2` a `m x p` matrix, res must be a
 `n x p` matrix.
 
 
@@ -950,8 +950,8 @@ tensor, res will be a `b x n x p` tensor.
 ### [res] torch.ger([res,] vec1, vec2) ###
 <a name="torch.ger"/>
 
-Outer product of `vec1` and `vec2`. If `vec1` is a vector of 
-size `n` and `vec2` is a vector of size `m`, then res must 
+Outer product of `vec1` and `vec2`. If `vec1` is a vector of
+size `n` and `vec2` is a vector of size `m`, then res must
 be a matrix of size `n x m`.
 
 
@@ -1126,7 +1126,7 @@ of `x`, performing the operation over dimension `n`.
 
 `y=torch.mean(x)` returns the mean of all elements of `x`.
 
-`y=torch.mean(x,1)` returns a tensor `y` of the mean of the elements in 
+`y=torch.mean(x,1)` returns a tensor `y` of the mean of the elements in
 each column of `x`.
 
 `y=torch.mean(x,2)` performs the mean operation for each row.
@@ -1261,24 +1261,24 @@ in `a` and `v`.
 <a name="torch.prod"/>
 ### [res] torch.prod([res,] x [,n]) ###
 
-`y=torch.prod(x)` returns the product of all elements in `x`. 
+`y=torch.prod(x)` returns the product of all elements in `x`.
 
 `y=torch.prod(x,n)` returns a tensor `y` whom size in dimension `n` is 1 and where elements are the product of elements of `x` with respect to dimension `n`.
 
 ```lua
 > a = torch.Tensor{{{1,2},{3,4}}, {{5,6},{7,8}}}
 > a
-(1,.,.) = 
+(1,.,.) =
   1  2
   3  4
 
-(2,.,.) = 
+(2,.,.) =
   5  6
   7  8
 [torch.DoubleTensor of dimension 2x2x2]
 
 > torch.prod(a, 1)
-(1,.,.) = 
+(1,.,.) =
    5  12
   21  32
 [torch.DoubleTensor of dimension 1x2x2]
@@ -1340,9 +1340,9 @@ Note that many of the operations in [dimension-wise operations](#torch.columnwis
 <a name="torch.norm"/>
 ### torch.norm(x [,p] [,dim]) ###
 
-`y=torch.norm(x)` returns the 2-norm of the tensor `x`. 
+`y=torch.norm(x)` returns the 2-norm of the tensor `x`.
 
-`y=torch.norm(x,p)` returns the `p`-norm of the tensor `x`. 
+`y=torch.norm(x,p)` returns the `p`-norm of the tensor `x`.
 
 `y=torch.norm(x,p,dim)` returns the `p`-norms of the tensor `x` computed over the dimension `dim`.
 
@@ -1350,9 +1350,9 @@ Note that many of the operations in [dimension-wise operations](#torch.columnwis
 ### torch.renorm([res], x, p, dim, maxnorm) ###
 Renormalizes the sub-tensors along dimension `dim` such that they do not exceed norm `maxnorm`.
 
-`y=torch.renorm(x,p,dim,maxnorm)` returns a version of `x` with `p`-norms lower than `maxnorm` over non-`dim` dimensions. 
-The `dim` argument is not to be confused with the argument of the same name in function [norm](#torch.norm). 
-In this case, the `p`-norm is measured for each `i`-th sub-tensor `x:select(dim, i)`. This function is 
+`y=torch.renorm(x,p,dim,maxnorm)` returns a version of `x` with `p`-norms lower than `maxnorm` over non-`dim` dimensions.
+The `dim` argument is not to be confused with the argument of the same name in function [norm](#torch.norm).
+In this case, the `p`-norm is measured for each `i`-th sub-tensor `x:select(dim, i)`. This function is
 equivalent to (but faster than) the following:
 
 ```lua
@@ -1378,9 +1378,9 @@ Note: this function is particularly useful as a regularizer for constraining the
 <a name="torch.dist"/>
 ### torch.dist(x,y) ###
 
-`y=torch.dist(x,y)` returns the 2-norm of `x-y`. 
+`y=torch.dist(x,y)` returns the 2-norm of `x-y`.
 
-`y=torch.dist(x,y,p)` returns the `p`-norm of `x-y`. 
+`y=torch.dist(x,y,p)` returns the `p`-norm of `x-y`.
 
 <a name="torch.numel"/>
 ### torch.numel(x) ###
@@ -1390,7 +1390,7 @@ Note: this function is particularly useful as a regularizer for constraining the
 <a name="torch.trace"/>
 ### torch.trace(x) ###
 
-`y=torch.trace(x)` returns the trace (sum of the diagonal elements) 
+`y=torch.trace(x)` returns the trace (sum of the diagonal elements)
 of a matrix `x`. This is  equal  to the sum of the eigenvalues of `x`.
 The returned value `y` is a number, not a tensor.
 
@@ -1486,25 +1486,28 @@ cross-correlation of the input with the kernel `k`.
 <a name="torch.linalg.dok"/>
 ## Eigenvalues, SVD, Linear System Solution ##
 
-Functions in this section are implemented with an interface to 
-[LAPACK](https://en.wikipedia.org/wiki/LAPACK) libraries. 
+Functions in this section are implemented with an interface to
+[LAPACK](https://en.wikipedia.org/wiki/LAPACK) libraries.
 If LAPACK libraries are not found during compilation step,
 then these functions will not be available.
 
 <a name="torch.gesv"/>
-### [x,lu] torch.gesv([res1, res2,] b,a) ###
+### [x,lu] torch.gesv([resb, resa,] b, a) ###
 
-`X,LU=torch.gesv(B,A)` returns the solution of `AX=B` and `LU` contains 
+`X,LU=torch.gesv(B,A)` returns the solution of `AX=B` and `LU` contains
 `L` and `U` factors for `LU` factorization of `A`.
 
 `A` has to be a square and non-singular matrix (2D tensor).
 `A` and `LU` are `m x m`, `X` is `m x k` and `B` is `m x k`.
 
-If `res1` and `res2` are given, then they will be used for
+If `resb` and `resa` are given, then they will be used for
 temporary storage and returning the result.
 
   * `resa` will contain `L` and `U` factors for `LU` factorization of `A`.
   * `resb` will contain the solution `X`.
+
+Note: Irrespective of the original strides, the returned matrices `resb` and
+`resa` will be transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
 a = torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
@@ -1549,7 +1552,7 @@ x = torch.gesv(b,a)
 ```
 
 <a name="torch.gels"/>
-### torch.gels([resb, resa,] b,a) ###
+### torch.gels([resb, resa,] b, a) ###
 
 Solution of least squares and least norm problems for a full rank `m x n` matrix `A`.
 
@@ -1560,6 +1563,9 @@ On return, first `n` rows of `x` matrix contains the solution
 and the rest contains residual information. Square root of sum squares
 of elements of each column of `x` starting at row `n + 1` is
 the residual for corresponding column.
+
+Note: Irrespective of the original strides, the returned matrices `resb` and
+`resa` will be transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
 
@@ -1590,8 +1596,8 @@ b = torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
 [torch.DoubleTensor of dimension 6x2]
 
 x = torch.gels(b,a)
-> x 
- -0.4506   0.2497 
+> x
+ -0.4506   0.2497
  -0.8492  -0.9020
   0.7066   0.6323
   0.1289   0.1351
@@ -1610,22 +1616,24 @@ x = torch.gels(b,a)
 <a name="torch.symeig"/>
 ### torch.symeig([rese, resv,] a [, 'N' or 'V'] [, 'U' or 'L']) ###
 
-`e,V=torch.symeig(A)` returns eigen values and eigen vectors of a 
+`e,V=torch.symeig(A)` returns eigenvalues and eigenvectors of a
 symmetric real matrix `A`.
 
 `A` and `V` are `m x m` matrices and `e` is a `m` dimensional vector.
 
-This function calculates all eigenvalues (and vectors) of `A` such 
+This function calculates all eigenvalues (and vectors) of `A` such
 that `A = V' diag(e) V`.
 
 Third argument defines computation of eigenvectors or eigenvalues
 only. If it is `'N'`, only eignevalues are computed. If it is `'V'`, both
 eigenvalues and eigenvectors are computed.
 
-Since the input matrix `A` is supposed to be symmetric, only upper 
-triangular portion is used by default. If the 4th argument is `'L'`, 
+Since the input matrix `A` is supposed to be symmetric, only upper
+triangular portion is used by default. If the 4th argument is `'L'`,
 then lower triangular portion is used.
 
+Note: Irrespective of the original strides, the returned matrix `V` will be
+transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
 a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
@@ -1685,21 +1693,24 @@ e,v = torch.symeig(a,'V')
 ### torch.eig([rese, resv,] a [, 'N' or 'V']) ###
 
 
-`e,V=torch.eig(A)` returns eigen values and eigen vectors of a 
+`e,V=torch.eig(A)` returns eigenvalues and eigenvectors of a
 general real square matrix `A`.
 
 `A` and `V` are `m x m` matrices and `e` is a `m` dimensional vector.
 
-This function calculates all right eigenvalues (and vectors) of `A` such 
+This function calculates all right eigenvalues (and vectors) of `A` such
 that `A = V' diag(e) V`.
 
 Third argument defines computation of eigenvectors or eigenvalues
 only. If it is `'N'`, only eignevalues are computed. If it is `'V'`, both
 eigenvalues and eigenvectors are computed.
 
-The eigen values returned follow 
-[LAPACK convention](https://software.intel.com/sites/products/documentation/hpc/mkl/mklman/GUID-16EB5901-5644-4DA6-A332-A052309010C4.htm) 
+The eigen values returned follow
+[LAPACK convention](https://software.intel.com/sites/products/documentation/hpc/mkl/mklman/GUID-16EB5901-5644-4DA6-A332-A052309010C4.htm)
 and are returned as complex (real/imaginary) pairs of numbers (`2*m` dimensional tensor).
+
+Note: Irrespective of the original strides, the returned matrix `V` will be
+transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
 a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
@@ -1766,7 +1777,7 @@ e,v = torch.eig(b,'V')
 ```
 
 <a name="torch.svd"/>
-### torch.svd([resu, ress, resv] a [, 'S' or 'A']) ###
+### torch.svd([resu, ress, resv,] a [, 'S' or 'A']) ###
 
 `U,S,V=torch.svd(A)` returns the singular value decomposition of a real matrix `A` of size `n x m`
 such that `A = USV'*`.
@@ -1775,6 +1786,9 @@ such that `A = USV'*`.
 
 The last argument, if it is string, represents the number of singular
 values to be computed. `'S'` stands for *some* and `'A'` stands for *all*.
+
+Note: Irrespective of the original strides, the returned matrix `U` will be
+transposed, i.e. with strides `1,n` instead of `n,1`.
 
 ```lua
 a = torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
@@ -1840,6 +1854,9 @@ Computes the inverse of square matrix `x`.
 
 `torch.inverse(y,x)` puts the result in `y`.
 
+Note: Irrespective of the original strides, the returned matrix `y` will be
+transposed, i.e. with strides `1,m` instead of `m,1`.
+
 ```lua
 x = torch.rand(10,10)
 y = torch.inverse(x)
@@ -1878,6 +1895,9 @@ large.
 Note also that, while it should always give you a valid decomposition, it may
 not give you the same one across platforms - it will depend on your LAPACK
 implementation.
+
+Note: Irrespective of the original strides, the returned matrix `q` will be
+transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
 > a = torch.Tensor{{12, -51, 4}, {6, 167, -68}, {-4, 24, -41}}

--- a/test/test.lua
+++ b/test/test.lua
@@ -1425,6 +1425,24 @@ function torchtest.gesv()
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.gesv value out1')
    mytester:asserteq(maxdiff(mx,mxxx),0,'torch.gesv value out2')
 end
+function torchtest.gesv_reuse()
+   if not torch.gesv then return end
+   local a=torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
+                         {-6.05, -3.30,  5.36, -4.44,  1.08},
+                         {-0.45,  2.58, -2.70,  0.27,  9.04},
+                         {8.32,  2.71,  4.35, -7.17,  2.14},
+                         {-9.67, -5.14, -7.26,  6.08, -6.87}}):t()
+   local b=torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
+                         {-1.56,  4.00, -8.67,  1.75,  2.86},
+                         {9.81, -4.09, -4.57, -8.61,  8.99}}):t()
+   local mx = torch.gesv(b,a)
+   local ta = torch.Tensor()
+   local tb = torch.Tensor()
+   torch.gesv(tb,ta,b,a)
+   mytester:asserteq(maxdiff(mx,tb),0,'torch.gesv value temp')
+   torch.gesv(tb,ta,b,a)
+   mytester:asserteq(maxdiff(mx,tb),0,'torch.gesv value reuse')
+end
 function torchtest.gels_uniquely_determined()
    if not torch.gels then return end
    local expectedNorm = 0
@@ -1454,6 +1472,24 @@ function torchtest.gels_uniquely_determined()
    mytester:asserteq(maxdiff(mx,b),0,'torch.gels value flag')
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.gels value out1')
    mytester:asserteq(maxdiff(mx,mxxx),0,'torch.gels value out2')
+end
+function torchtest.gels_reuse()
+   if not torch.gels then return end
+   local expectedNorm = 0
+   local a=torch.Tensor({{ 1.44, -9.96, -7.55,  8.34},
+                         {-7.84, -0.28,  3.24,  8.09},
+                         {-4.39, -3.24,  6.27,  5.28},
+                         {4.53,  3.83, -6.64,  2.06}}):t()
+   local b=torch.Tensor({{8.58,  8.26,  8.48, -5.28},
+                         {9.35, -4.43, -0.70, -0.26}}):t()
+   local ta = torch.Tensor()
+   local tb = torch.Tensor()
+   torch.gels(tb,ta,b,a)
+   mytester:assertalmosteq((torch.mm(a,tb)-b):norm(), expectedNorm, 1e-8, 'torch.gels wrong answer')
+   torch.gels(tb,ta,b,a)
+   mytester:assertalmosteq((torch.mm(a,tb)-b):norm(), expectedNorm, 1e-8, 'torch.gels wrong answer')
+   torch.gels(tb,ta,b,a)
+   mytester:assertalmosteq((torch.mm(a,tb)-b):norm(), expectedNorm, 1e-8, 'torch.gels wrong answer')
 end
 function torchtest.gels_overdetermined()
    if not torch.gels then return end
@@ -1535,6 +1571,7 @@ function torchtest.eig()
    mytester:assertlt(maxdiff(vv,tv),1e-12,'torch.eig value')
 end
 function torchtest.eig_reuse()
+   if not torch.eig then return end
    local X = torch.randn(4,4)
    X = X:t()*X
    local e, v = torch.zeros(4,2), torch.zeros(4,4)
@@ -1545,10 +1582,11 @@ function torchtest.eig_reuse()
 
    torch.eig(e, v, X, 'V')
    local Xhat = torch.mm(v, torch.mm(e:select(2,1):diag(), v:t()))
-   mytester:assertTensorEq(X, Xhat, 1e-8, 'USV\' wrong')
+   mytester:assertTensorEq(X, Xhat, 1e-8, 'VeV\' wrong')
    mytester:assert(not v:isContiguous(), 'V is contiguous')
 end
 function torchtest.eig_noncontig()
+   if not torch.eig then return end
    local X = torch.randn(4,4)
    X = X:t()*X
    local e = torch.zeros(4,2,2)[{ {}, 2, {} }]
@@ -1560,6 +1598,7 @@ function torchtest.eig_noncontig()
    mytester:assertTensorEq(X, Xhat, 1e-8, 'VeV\' wrong')
 end
 function torchtest.test_symeig()
+  if not torch.symeig then return end
   local xval = torch.rand(100,3)
   local cov = torch.mm(xval:t(), xval)
   local rese = torch.zeros(3)
@@ -1569,15 +1608,16 @@ function torchtest.test_symeig()
   mytester:assert(resv:isContiguous(), 'resv is not contiguous') -- PASS
   torch.symeig(rese, resv, cov:clone(), 'V')
   local ahat = resv*torch.diag(rese)*resv:t()
-  mytester:assertTensorEq(cov, ahat, 1e-8, 'USV\' wrong') -- PASS
+  mytester:assertTensorEq(cov, ahat, 1e-8, 'VeV\' wrong') -- PASS
 
   -- Second call to symeig
   mytester:assert(not resv:isContiguous(), 'resv is contiguous') -- FAIL
   torch.symeig(rese, resv, cov:clone(), 'V')
   local ahat = torch.mm(torch.mm(resv, torch.diag(rese)), resv:t())
-  mytester:assertTensorEq(cov, ahat, 1e-8, 'USV\' wrong') -- FAIL
+  mytester:assertTensorEq(cov, ahat, 1e-8, 'VeV\' wrong') -- FAIL
 end
 function  torchtest.symeig_noncontig()
+  if not torch.symeig then return end
    local X = torch.rand(5,5)
    X = X:t()*X
    local e = torch.zeros(4,2):select(2,2)
@@ -1608,6 +1648,7 @@ function torchtest.svd()
    mytester:asserteq(maxdiff(v,vvv),0,'torch.svd')
 end
 function torchtest.svd_reuse()
+   if not torch.svd then return end
    local X = torch.randn(4,4)
    local U, S, V = torch.svd(X)
    local Xhat = torch.mm(U, torch.mm(S:diag(), V:t()))
@@ -1619,6 +1660,7 @@ function torchtest.svd_reuse()
    mytester:assertTensorEq(X, Xhat, 1e-8, 'USV\' wrong')
 end
 function torchtest.svd_noncontig()
+   if not torch.svd then return end
    local X = torch.randn(5,5)
    local U = torch.zeros(5,2,5)[{ {}, 2, {} }]
    local S = torch.zeros(5,2)[{ {}, 2 }]
@@ -1630,6 +1672,24 @@ function torchtest.svd_noncontig()
    torch.svd(U, S, V, X)
    local Xhat = torch.mm(U, torch.mm(S:diag(), V:t()))
    mytester:assertTensorEq(X, Xhat, 1e-8, 'USV\' wrong')
+end
+function torchtest.inverse()
+   if not torch.inverse then return end
+   local M = torch.randn(5,5)
+   local MI = torch.inverse(M)
+   local E = torch.eye(5)
+   mytester:assert(not MI:isContiguous(), 'MI is contiguous')
+   mytester:assertalmosteq(maxdiff(E,torch.mm(M,MI)), 0, 1e-8, 'inverse value')
+   mytester:assertalmosteq(maxdiff(E,torch.mm(MI,M)), 0, 1e-8, 'inverse value')
+
+   local MII = torch.Tensor(5,5)
+   torch.inverse(MII, M)
+   mytester:assert(not MII:isContiguous(), 'MII is contiguous')
+   mytester:asserteq(maxdiff(MII, MI), 0, 'inverse value in-place')
+   -- second call, now that MII is transposed
+   torch.inverse(MII, M)
+   mytester:assert(not MII:isContiguous(), 'MII is contiguous')
+   mytester:asserteq(maxdiff(MII, MI), 0, 'inverse value in-place')
 end
 function torchtest.conv2()
    local x = torch.rand(math.floor(torch.uniform(50,100)),math.floor(torch.uniform(50,100)))


### PR DESCRIPTION
Added some tests for the previously failing cases of wrong transpositions for in-place LAPACK functions. Added comments to the documentation regarding the fact that return values have non-standard strides.

[ My editor clearly dislikes trailing whitespace, sorry for the noise ]