### PR TITLE
Fix lua GC to support allocations across multiple threads

### DIFF
--- a/init.c
+++ b/init.c
@@ -47,19 +47,12 @@ static void luaTorchArgErrorHandlerFunction(int argNumber, const char *msg, void
   luaL_argcheck(L, 0, argNumber, msg);
 }
 
-static void luaTorchGCFunction(void *data)
-{
-  lua_State *L = data;
-  lua_gc(L, LUA_GCCOLLECT, 0);
-}
-
 LUA_EXTERNC DLL_EXPORT int luaopen_libtorch(lua_State *L);
 
 int luaopen_libtorch(lua_State *L)
 {
   THSetErrorHandler(luaTorchErrorHandlerFunction, L);
   THSetArgErrorHandler(luaTorchArgErrorHandlerFunction, L);
-  THSetGCHandler(luaTorchGCFunction, L);
 
   lua_newtable(L);
   lua_pushvalue(L, -1);

--- a/lib/TH/THAtomic.c
+++ b/lib/TH/THAtomic.c
@@ -101,3 +101,61 @@ int THAtomicCompareAndSwap(int volatile *a, int oldvalue, int newvalue)
     return 0;
 #endif
 }
+
+long THAtomicGetLong(long volatile *a)
+{
+#if defined(USE_C11_ATOMICS)
+  return atomic_load(a);
+#else
+  long value;
+  do {
+    value = *a;
+  } while (!THAtomicCompareAndSwapLong(a, value, value));
+  return value;
+#endif
+}
+
+long THAtomicAddLong(long volatile *a, long value)
+{
+#if defined(USE_C11_ATOMICS)
+  return atomic_fetch_add(a, value);
+#elif defined(USE_MSC_ATOMICS)
+  return _InterlockedExchangeAdd(a, value);
+#elif defined(USE_GCC_ATOMICS)
+  return __sync_fetch_and_add(a, value);
+#else
+  long oldvalue;
+  do {
+    oldvalue = *a;
+  } while (!THAtomicCompareAndSwapLong(a, oldvalue, (oldvalue + value)));
+  return oldvalue;
+#endif
+}
+
+long THAtomicCompareAndSwapLong(long volatile *a, long oldvalue, long newvalue)
+{
+#if defined(USE_C11_ATOMICS)
+  return atomic_compare_exchange_strong(a, &oldvalue, newvalue);
+#elif defined(USE_MSC_ATOMICS)
+  return (_InterlockedCompareExchange(a, newvalue, oldvalue) == oldvalue);
+#elif defined(USE_GCC_ATOMICS)
+  return __sync_bool_compare_and_swap(a, oldvalue, newvalue);
+#elif defined(USE_PTHREAD_ATOMICS)
+  long ret = 0;
+  pthread_mutex_lock(&ptm);
+  if(*a == oldvalue) {
+    *a = newvalue;
+    ret = 1;
+  }
+  pthread_mutex_unlock(&ptm);
+  return ret;
+#else
+#warning THAtomic is not thread safe
+  if(*a == oldvalue) {
+    *a = newvalue;
+    return 1;
+  }
+  else
+    return 0;
+#endif
+}

--- a/lib/TH/THAtomic.h
+++ b/lib/TH/THAtomic.h
@@ -57,4 +57,28 @@ TH_API void THAtomicIncrementRef(int volatile *a);
 */
 TH_API int THAtomicDecrementRef(int volatile *a);
 
+
+
+/******************************************************************************
+ * functions for long type
+ ******************************************************************************/
+
+/*
+ * return *a
+*/
+TH_API long THAtomicGetLong(long volatile *a);
+
+/*
+ * *a += value,
+ * return previous *a
+*/
+TH_API long THAtomicAddLong(long volatile *a, long value);
+
+/*
+ * check if (*a == oldvalue)
+ * if true: set *a to newvalue, return 1
+ * if false: return 0
+*/
+TH_API long THAtomicCompareAndSwapLong(long volatile *a, long oldvalue, long newvalue);
+
 #endif

--- a/test/test.lua
+++ b/test/test.lua
@@ -2588,6 +2588,7 @@ function torchtest.storageview()
 end
 
 function torch.test(tests)
+   torch.setheaptracking(true)
    math.randomseed(os.time())
    if torch.getdefaulttensortype() == 'torch.FloatTensor' then
       precision = 1e-4

--- a/utils.c
+++ b/utils.c
@@ -188,6 +188,23 @@ static int torch_getnumcores(lua_State *L)
   return 1;
 }
 
+static void luaTorchGCFunction(void *data)
+{
+  lua_State *L = data;
+  lua_gc(L, LUA_GCCOLLECT, 0);
+}
+
+static int torch_setheaptracking(lua_State *L)
+{
+  int enabled = luaT_checkboolean(L,1);
+  if(enabled) {
+    THSetGCHandler(luaTorchGCFunction, L);
+  } else {
+    THSetGCHandler(NULL, NULL);
+  }
+  return 0;
+}
+
 static const struct luaL_Reg torch_utils__ [] = {
   {"getdefaulttensortype", torch_lua_getdefaulttensortype},
   {"isatty", torch_isatty},
@@ -209,6 +226,7 @@ static const struct luaL_Reg torch_utils__ [] = {
   {"pushudata", luaT_lua_pushudata},
   {"version", luaT_lua_version},
   {"pointer", luaT_lua_pointer},
+  {"setheaptracking", torch_setheaptracking},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
With torch/threads, Tensors can be allocated in one thread and deallocated in another, so `heapSize` must not be thread-local. Note that I am leaving `heapSoftMax` as thread-local, so each thread will maintain it's own softmax.

Here's an example that this PR fixes:

```lua
```require 'torch'
local Threads = require 'threads'
Threads.serialization('threads.sharedserialize')

local a = torch.Tensor(1e7):zero()
pool = Threads(1, function() require 'torch'; end);
pool:addjob(function() for i = 1,1000 do a:add(1); end; a = nil;  collectgarbage(); end)
a = nil
collectgarbage()
pool:synchronize()
```

If you add an assert that `heapSize >= 0` prior to this PR, it will fail (in the pool thread).
