### PR TITLE
fixing avx checks

### DIFF
--- a/lib/TH/cmake/FindSSE.cmake
+++ b/lib/TH/cmake/FindSSE.cmake
@@ -62,10 +62,8 @@ SET(AVX_CODE "
 
   int main()
   {
-    if (0) {
-      __m256 a;
-      a = _mm256_set1_ps(0);
-    }
+     __m256 a;
+    a = _mm256_set1_ps(0);
     return 0;
   }
 ")


### PR DESCRIPTION
This was a bug introduced in #241 from @zakattacktwitter . 
It was tracked down and reported by one of our community users "Alex" in the google groups.

The AVX check was disabled with if (0), so people without AVX support were still having TH attempt to compile the AVX code, and was later failing at the assembler level.

Let me know if I missed anything.