### PR TITLE
Nonzero function for finding non-zero elements of a tensor

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -823,6 +823,11 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=Tensor}})
    end
 
+   wrap("nonzero",
+        cname("nonzero"),
+        {{name="IndexTensor", default=true, returned=true},
+         {name=Tensor}})
+
    if Tensor == 'ByteTensor' then
      -- Logical accumulators only apply to ByteTensor
       for _,name in ipairs({'all', 'any'}) do

--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -1538,6 +1538,83 @@ x:maskedFill(mask, -1)
 Note how the dimensions of the above `x` and `mask` do not match, 
 but the number of elements do.
 
+## Search ##
+
+Each of these methods returns a `LongTensor` corresponding to the indices of the
+given search operation.
+
+<a name="torch.Tensor.nonzero"/>
+### [LongTensor] nonzero(tensor)
+
+Finds and returns a `LongTensor` corresponding to the *subcript* indices of all
+non-zero elements in `tensor`.
+
+Note that torch uses the first argument on dispatch to determine the return
+type. Since the first argument is any `torch.TensorType`, but the return type
+is always `torch.LongTensor`, the function call
+`torch.nonzero(torch.LongTensor(), tensor)` does not work. However,
+`tensor.nonzero(torch.LongTensor(), tensor)` does work.
+
+```lua
+> x = torch.rand(4, 4):mul(3):floor():int()
+> x
+ 2  0  2  0
+ 0  0  1  2
+ 0  2  2  1
+ 2  1  2  2
+[torch.IntTensor of dimension 4x4]
+
+> torch.nonzero(x)
+ 1  1
+ 1  3
+ 2  3
+ 2  4
+ 3  2
+ 3  3
+ 3  4
+ 4  1
+ 4  2
+ 4  3
+ 4  4
+[torch.LongTensor of dimension 11x2]
+
+> x:nonzero()
+ 1  1
+ 1  3
+ 2  3
+ 2  4
+ 3  2
+ 3  3
+ 3  4
+ 4  1
+ 4  2
+ 4  3
+ 4  4
+[torch.LongTensor of dimension 11x2]
+
+> indices = torch.LongTensor()
+> x.nonzero(indices, x)
+ 1  1
+ 1  3
+ 2  3
+ 2  4
+ 3  2
+ 3  3
+ 3  4
+ 4  1
+ 4  2
+ 4  3
+ 4  4
+[torch.LongTensor of dimension 11x2]
+
+> x:eq(1):nonzero()
+ 2  3
+ 3  4
+ 4  2
+[torch.LongTensor of dimension 3x2]
+
+```
+
 ## Expanding/Replicating/Squeezing Tensors ##
 
 These methods returns a Tensor which is created by replications of the

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -9,6 +9,8 @@ TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, real val
 TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
 TH_API void THTensor_(maskedSelect)(THTensor *tensor, THTensor* src, THByteTensor *mask);
 
+TH_API void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor);
+
 TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, real val);


### PR DESCRIPTION
New branch continuing PR #183.

Changes:
- Renamed from `find` to `nonezero`
- Stripped out `ind2sub` and `sub2ind` functions

### [LongTensor] nonzero(tensor)

Finds and returns a `LongTensor` corresponding to the *subcript* indices of all
non-zero elements in `tensor`.

```lua
> x = torch.rand(4, 4):mul(3):floor():int()
> x
 2  0  2  0
 0  0  1  2
 0  2  2  1
 2  1  2  2
[torch.IntTensor of dimension 4x4]

> torch.nonzero(x)
 1  1
 1  3
 2  3
 2  4
 3  2
 3  3
 3  4
 4  1
 4  2
 4  3
 4  4
[torch.LongTensor of dimension 11x2]

> x:nonzero()
 1  1
 1  3
 2  3
 2  4
 3  2
 3  3
 3  4
 4  1
 4  2
 4  3
 4  4
[torch.LongTensor of dimension 11x2]

> x:eq(1):nonzero()
 2  3
 3  4
 4  2
[torch.LongTensor of dimension 11x2]

```