### PR TITLE
More flexible torch.cat

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -164,6 +164,12 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                 return string.format("TH%s_nDimension(%s)", Tensor, arg.args[argn]:carg())
              end
    end
+
+   local function lastdimarray(argn)
+      return function(arg)
+                return string.format("TH%s_nDimension(arg%d_data[0])", Tensor, arg.args[argn].i)
+             end
+   end
    
    wrap("zero",
         cname("zero"),
@@ -553,7 +559,11 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name=Tensor},
-         {name="index", default=lastdim(2)}})
+         {name="index", default=lastdim(2)}},
+        cname("catArray"),
+        {{name=Tensor, default=true, returned=true},
+         {name=Tensor .. "Array"},
+         {name="index", default=lastdimarray(2)}})
    
    if Tensor == 'ByteTensor' then -- we declare this only once
       interface:print(

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -64,12 +64,15 @@ end
 
 <a name="torch.cat"></a>
 ### [res] torch.cat( [res,] x_1, x_2, [dimension] ) ###
+### [res] torch.cat( [res,] {x_1, x_2, ...}, [dimension] ) ###
 <a name="torch.cat"></a>
 `x=torch.cat(x_1,x_2,[dimension])` returns a tensor `x` which is the concatenation of tensors `x_1` and `x_2` along dimension `dimension`.
 
 If `dimension` is not specified it is the last dimension.
 
 The other dimensions of `x_1` and `x_2` have to be equal.
+
+Also supports arrays with arbitrary numbers of tensors as inputs.
 
 Examples:
 ```lua
@@ -107,6 +110,18 @@ Examples:
 
 
 > print(torch.cat(torch.cat(torch.ones(2,2),torch.zeros(2,2),1),torch.rand(3,2),1))
+
+ 1.0000  1.0000
+ 1.0000  1.0000
+ 0.0000  0.0000
+ 0.0000  0.0000
+ 0.3227  0.0493
+ 0.9161  0.1086
+ 0.2206  0.7449
+[torch.DoubleTensor of dimension 7x2]
+
+
+> print(torch.cat({torch.ones(2,2), torch.zeros(2,2), torch.rand(3,2)},1))
 
  1.0000  1.0000
  1.0000  1.0000

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -78,6 +78,7 @@ TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int d
 TH_API void THTensor_(tril)(THTensor *r_, THTensor *t, long k);
 TH_API void THTensor_(triu)(THTensor *r_, THTensor *t, long k);
 TH_API void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension);
+TH_API void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int dimension);
 
 TH_API void THTensor_(ltValue)(THByteTensor *r_, THTensor* t, real value);
 TH_API void THTensor_(leValue)(THByteTensor *r_, THTensor* t, real value);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1354,12 +1354,33 @@ function torchtest.triu()
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.tril value')
 end
 function torchtest.cat()
-   local x = torch.rand(13,msize,msize)
-   local y = torch.rand(17,msize,msize)
-   local mx = torch.cat(x,y,1)
-   local mxx = torch.Tensor()
-   torch.cat(mxx,x,y,1)
-   mytester:asserteq(maxdiff(mx,mxx),0,'torch.cat value')
+   for dim = 1, 3 do
+      local x = torch.rand(13, msize, msize):transpose(1, dim)
+      local y = torch.rand(17, msize, msize):transpose(1, dim)
+      local mx = torch.cat(x, y, dim)
+      mytester:assertTensorEq(mx:narrow(dim, 1, 13), x, 0, 'torch.cat value')
+      mytester:assertTensorEq(mx:narrow(dim, 14, 17), y, 0, 'torch.cat value')
+
+      local mxx = torch.Tensor()
+      torch.cat(mxx, x, y, dim)
+      mytester:assertTensorEq(mx, mxx, 0, 'torch.cat value')
+   end
+end
+function torchtest.catArray()
+   for dim = 1, 3 do
+      local x = torch.rand(13, msize, msize):transpose(1, dim)
+      local y = torch.rand(17, msize, msize):transpose(1, dim)
+      local z = torch.rand(19, msize, msize):transpose(1, dim)
+
+      local mx = torch.cat({x, y, z}, dim)
+      mytester:assertTensorEq(mx:narrow(dim, 1, 13), x, 0, 'torch.cat value')
+      mytester:assertTensorEq(mx:narrow(dim, 14, 17), y, 0, 'torch.cat value')
+      mytester:assertTensorEq(mx:narrow(dim, 31, 19), z, 0, 'torch.cat value')
+
+      local mxx = torch.Tensor()
+      torch.cat(mxx, {x, y, z}, dim)
+      mytester:assertTensorEq(mx, mxx, 0, 'torch.cat value')
+   end
 end
 function torchtest.sin()
    local x = torch.rand(msize,msize,msize)


### PR DESCRIPTION
Adds a version of torch.cat that takes an array of tensors as inputs.

Adds TensorArray type to cwrap that reads an array of tensors from Lua
and creates a C array of tensor pointers that are passed to the C
function.