### PR TITLE
Clarify that `torch.random` result is unsigned

### DIFF
--- a/doc/random.md
+++ b/doc/random.md
@@ -60,7 +60,7 @@ Returns the initial seed used to initialize the random generator.
 <a name="torch.random"></a>
 ### [number] random() ###
 
-Returns a 32 bit integer random number.
+Returns an unsigned 32 bit integer random number.
 
 <a name="torch.uniform"></a>
 ### [number] uniform([a],[b]) ###


### PR DESCRIPTION
Minor clarification to the doc in that the result of `torch.random` is always unsigned.