### PR TITLE
Track and print the serialization 'stack trace' on failure

### DIFF
--- a/test/test_writeObject.lua
+++ b/test/test_writeObject.lua
@@ -77,5 +77,31 @@ function tests.test_empty_table()
    file:writeObject({})
 end
 
+function tests.test_error_msg()
+   local torch = torch
+   local inner = {
+       baz = function(a) torch.somefunc() end
+   }
+   local outer = {
+       theinner = inner
+   }
+   local function evil_func()
+      outer.prop = 1
+      image.compress(1)
+   end
+   local ok, msg = pcall(torch.save, 'saved.t7', evil_func)
+   myTester:assert(not ok)
+   myTester:assert(msg:find('at <%?>%.outer%.theinner%.baz%.torch'))
+end
+
+function tests.test_referenced()
+   local file = torch.MemoryFile('rw'):binary()
+   file:referenced(false)
+
+   local foo = 'bar'
+   file:writeObject(foo)
+   file:close()
+end
+
 myTester:add(tests)
 myTester:run()


### PR DESCRIPTION
When serialization fails, it's hard to figure out what object can't be synchronized. Especially comes up in torch-threads. Any interest in this PR?

With this PR, you would now get the following error:

```
luajit: ...al/git/torch-distro/install/share/lua/5.1/torch/File.lua:115: Unwritable object <function>
at <?>.outer.theinner.baz.torch.cat
```

for this code

```lua
   local torch = require 'torch'
   local inner = {
       baz = function(a) torch.somefunc() end
   }
   local outer = {
       theinner = inner
   }
   function evil_func()
      outer.prop = 1
   end
   torch.save('saved.t7', evil_func)
end
```
