### PR TITLE
Doc: remove line saying that 4Dx2D tensor multiplication is supported.

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1049,7 +1049,6 @@ depends on the sizes of the tensors.
  - 1D and 1D: Returns the dot product between the two tensors (scalar).
  - 2D and 1D: Returns the matrix-vector operation between the two tensors (1D tensor).
  - 2D and 2D: Returns the matrix-matrix operation between the two tensors (2D tensor).
- - 4D and 2D: Returns a tensor product (2D tensor).
 
 Sizes must be relevant for the corresponding operation.
 


### PR DESCRIPTION
The doc is confusing - currently TensorOperator only supports 1Dx1D, 2Dx1D,
and 2Dx2D tensor multiplication (see torch_TensorOperator_(__mul__) in
TensorOperator.c).