### PR TITLE
return self in maskedCopy, make consistent with cutorch

### DIFF
--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -513,6 +513,9 @@ static int torch_Tensor_(maskedCopy)(lua_State *L)
 
   THTensor_(maskedCopy)(tensor,mask,src);
 
+  /* return destination */
+  lua_pop(L, 2);
+
   return 1;
 }
 


### PR DESCRIPTION
Fixes #361 

Returning the source makes no sense, this is likely a historical oversight. Cutorch does it correctly by returning self.