### PR TITLE
[POC] Adds TH_TENSOR_APPLY2_PARALLEL

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1803,14 +1803,14 @@ TENSOR_IMPLEMENT_LOGICAL(ne,!=)
   void THTensor_(NAME)(THTensor *r_, THTensor *t)                \
   {                                                           \
     THTensor_(resizeAs)(r_, t);                               \
-    TH_TENSOR_APPLY2(real, t, real, r_, *r__data = CFUNC(*t_data);); \
+    TH_TENSOR_APPLY2_PARALLEL(real, t, real, r_, *r__data = CFUNC(*t_data);); \
   }                                                           \
 
 #define LAB_IMPLEMENT_BASIC_FUNCTION_VALUE(NAME, CFUNC)                 \
   void THTensor_(NAME)(THTensor *r_, THTensor *t, real value)              \
   {                                                                     \
     THTensor_(resizeAs)(r_, t);                                         \
-    TH_TENSOR_APPLY2(real, t, real, r_, *r__data = CFUNC(*t_data, value);); \
+    TH_TENSOR_APPLY2_PARALLEL(real, t, real, r_, *r__data = CFUNC(*t_data, value);); \
   }                                                                     \
 
 #if defined(TH_REAL_IS_LONG)


### PR DESCRIPTION
Following the discussion in https://github.com/torch/torch7/issues/323, I've tried to add a macro `TH_TENSOR_APPLY2_PARALLEL`, which uses omp if both tensors are contiguous. For the moment, I haven't set a threshold to use omp or not.

As a proof of concept, I added it to the unary operations implemented by `LAB_IMPLEMENT_BASIC_FUNCTION` (like `abs`, `tan`, etc).

Any thoughts ?
cc @dominikgrewe 