### PR TITLE
TensorMath.lua: zero init result tensor

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -314,6 +314,13 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                         string.format("TH%s_resize1d(%s, %s->size[0]);", Tensor, arg:carg(), arg.args[5]:carg())
                      }, '\n')
                end,
+          precall=function(arg)
+                  return table.concat(
+                     {
+                        string.format("TH%s_zero(%s);", Tensor, arg:carg()),
+                        arg.__metatable.precall(arg)
+                     }, '\n')
+               end,
        },
          {name=real, default=0, invisible=true},
          {name=Tensor, default=1, invisible=true},
@@ -330,6 +337,13 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                      {
                         arg.__metatable.init(arg),
                         string.format("TH%s_resize2d(%s, %s->size[0], %s->size[1]);", Tensor, arg:carg(), arg.args[5]:carg(), arg.args[6]:carg())
+                     }, '\n')
+               end,
+          precall=function(arg)
+                  return table.concat(
+                     {
+                        string.format("TH%s_zero(%s);", Tensor, arg:carg()),
+                        arg.__metatable.precall(arg)
                      }, '\n')
                end,
        },
@@ -349,6 +363,13 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                         arg.__metatable.init(arg),
                         string.format("TH%s_resize3d(%s, %s->size[0], %s->size[1], %s->size[2]);",
                                       Tensor, arg:carg(), arg.args[5]:carg(), arg.args[5]:carg(), arg.args[6]:carg())
+                     }, '\n')
+               end,
+          precall=function(arg)
+                  return table.concat(
+                     {
+                        string.format("TH%s_zero(%s);", Tensor, arg:carg()),
+                        arg.__metatable.precall(arg)
                      }, '\n')
                end,
        },


### PR DESCRIPTION
I found this issue while debugging this (crazy) [problem](http://stackoverflow.com/q/33047651/1688185): the product of two zero matrices has NaN entries. This occurs with the default implementation when there is no BLAS support (interestingly there is - apparently - no problem with OpenBLAS).

Properly initializing the result tensor (that is involved in `res = beta x res + alpha x sum` operations behind the scenes) obviously solves the problem. By the way this is already done for [`torch.ger`](https://github.com/torch/torch7/blob/28de026/TensorMath.lua#L372-L378) via a precall.

At first I planned to extend the init hook as follow:

```Lua
init=function(arg)
  return table.concat(
  {
    arg.__metatable.init(arg),
    string.format("TH%s_resize1d(%s, %s->size[0]);", Tensor, arg:carg(), arg.args[5]:carg()),
    string.format("TH%s_zero(%s);", Tensor, arg:carg())
  }, '\n')
end,
```

But doing the initialization at precall time has for benefit to *systematically* initialize the result so it covers the case where the user provides it like `torch.mm(res, a, b)`.

I did this for `torch.mv` and `torch.bmm` since there is the same problem. But I have not reviewed `torch.addmv` et al.. I have not considered any unit test (since we should have no BLAS support). I am opened to any suggestion(s) on all of these.