### PR TITLE
Add torch.mode and fix median/kthvalue docs

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -556,6 +556,13 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name="index"},
          {name="index", default=lastdim(3)}})
 
+   wrap("mode",
+       cname("mode"),
+       {{name=Tensor, default=true, returned=true},
+           {name="IndexTensor", default=true, returned=true, noreadadd=true},
+           {name=Tensor},
+           {name="index", default=lastdim(3)}})
+
    wrap("median",
         cname("median"),
         {{name=Tensor, default=true, returned=true},

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1259,7 +1259,7 @@ in `a` and `v`.
 <a name="torch.median"></a>
 ### torch.median([resval, resind,] x [,dim]) ###
 
-`y=torch.median(x)` returns the median element of `x`
+`y=torch.median(x)` performs the median operation over the last dimension of `x`.
 (one-before-middle in the case of an even number of elements).
 
 `y,i=torch.median(x,1)` returns the median element in each column
@@ -1270,10 +1270,23 @@ in `a` and `v`.
 
 `y,i=torch.median(x,n)` performs the median operation over the dimension `n`.
 
+<a name="torch.mode"></a>
+### torch.mode([resval, resind,] x [,dim]) ###
+
+`y=torch.mode(x)` returns the most frequent element of `x` over its last dimension.
+
+`y,i=torch.mode(x,1)` returns the mode element in each column
+(across rows) of `x`, and a tensor `i` of their corresponding indices in
+`x`.
+
+`y,i=torch.mode(x,2)` performs the mode operation across rows.
+
+`y,i=torch.mode(x,n)` performs the mode operation over the dimension `n`.
+
 <a name="torch.kthvalue"></a>
 ### torch.kthvalue([resval, resind,] x, k [,dim]) ###
 
-`y=torch.kthvalue(x,k)` returns the k-th smallest element of `x`.
+`y=torch.kthvalue(x,k)` returns the k-th smallest element of `x` over its last dimension.
 
 `y,i=torch.kthvalue(x,k,1)` returns the k-th smallest element in each column
 (across rows) of `x`, and a tensor `i` of their corresponding indices in

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -52,6 +52,7 @@ TH_API long THTensor_(numel)(THTensor *t);
 TH_API void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t, long k, int dimension);
+TH_API void THTensor_(mode)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension);
 TH_API void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension);
 TH_API void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1339,6 +1339,43 @@ function torchtest.median()
    end
 end
 
+function torchtest.mode()
+   local x = torch.range(1, msize * msize):reshape(msize, msize)
+   x:select(1, 1):fill(1)
+   x:select(1, 2):fill(1)
+   x:select(2, 1):fill(1)
+   x:select(2, 2):fill(1)
+   local x0 = x:clone()
+
+   -- Pre-calculated results.
+   local res = torch.Tensor(msize):fill(1)
+   -- The indices are the position of the last appearance of the mode element.
+   local resix = torch.LongTensor(msize):fill(2)
+   resix[1] = msize
+   resix[2] = msize
+
+   local mx, ix = torch.mode(x)
+
+   mytester:assertTensorEq(res:view(msize, 1), mx, 0, 'torch.mode value')
+   mytester:assertTensorEq(resix:view(msize, 1), ix, 0, 'torch.mode index')
+
+   -- Test use of result tensor
+   local mr = torch.Tensor()
+   local ir = torch.LongTensor()
+   torch.mode(mr, ir, x)
+   mytester:assertTensorEq(mr, mx, 0, 'torch.mode result tensor value')
+   mytester:assertTensorEq(ir, ix, 0, 'torch.mode result tensor index')
+
+   -- Test non-default dim
+   mx, ix = torch.mode(x, 1)
+   mytester:assertTensorEq(res:view(1, msize), mx, 0, 'torch.mode value')
+   mytester:assertTensorEq(resix:view(1, msize), ix, 0, 'torch.mode index')
+
+   -- input unchanged
+   mytester:assertTensorEq(x, x0, 0, 'torch.mode modified input')
+end
+
+
 function torchtest.tril()
    local x = torch.rand(msize,msize)
    local mx = torch.tril(x)


### PR DESCRIPTION
The `torch.median` and `torch.kthvalue` do not seem to operate as the docs say. This adds the tensor `torch.mode` operation and changes the docs of those 2 operations to match their current behaviour.