### PR TITLE
More informative error message for pipefile fail

### DIFF
--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -582,7 +582,7 @@ THFile *THPipeFile_new(const char *name, const char *mode, int isQuiet)
     if(isQuiet)
       return 0;
     else
-      THError("cannot open <%s> in mode %c%c", name, (isReadable ? 'r' : ' '), (isWritable ? 'w' : ' '));
+      THError("cannot open <%s> in mode %c%c.  This might be because eg the executable doesn't exist, but it could also be because you are out of memory.", name, (isReadable ? 'r' : ' '), (isWritable ? 'w' : ' '));
   }
 
   self = THAlloc(sizeof(THDiskFile));


### PR DESCRIPTION
This makes the error message for pipefail suggest that out-of-memory is a possibility too.  I spent ages trying to figure out why gnuplot sometimes didnt work for me.  Now, if gnuplot fails, it will give a stack trace like:

```
/home/user/torch/install/bin/luajit: cannot open </usr/bin/gnuplot -persist > /dev/null 2>&1> in mode  w.  This might be because eg the executable doesn't exist, but it could also be because you are out of memory. at /home/user/git/torch7/lib/TH/THDiskFile.c:585
stack traceback:
	[C]: at 0x7f1054b81e10
	[C]: in function 'PipeFile'
	/home/user/torch/install/share/lua/5.1/gnuplot/gnuplot.lua:134: in function 'getfigure'
	/home/user/torch/install/share/lua/5.1/gnuplot/gnuplot.lua:736: in function 'filefigure'
	/home/user/torch/install/share/lua/5.1/gnuplot/gnuplot.lua:754: in function 'pngfigure'
```

Note that I considered putting this in gnuplot, rather than in torch7, but it seems like this is something that could happen with any usage of pipes in fact, which will typically be starting new processes?