### PR TITLE
Typo, Examples

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -37,10 +37,10 @@ Similarly, `torch.conv2` function can be used in the following manner.
 
 x = torch.rand(100,100)
 k = torch.rand(10,10)
-res1 = torch.conv2(x,k)
+res1 = torch.conv2(x,k)   -- case 1
 
 res2 = torch.Tensor()
-torch.conv2(res2,x,k)
+torch.conv2(res2,x,k)     -- case 2
 
 =res2:dist(res1)
 0
@@ -77,7 +77,6 @@ Also supports arrays with arbitrary numbers of tensors as inputs.
 Examples:
 ```lua
 > print(torch.cat(torch.ones(3),torch.zeros(2)))
-
  1
  1
  1
@@ -85,16 +84,13 @@ Examples:
  0
 [torch.Tensor of dimension 5]
 
-
 > print(torch.cat(torch.ones(3,2),torch.zeros(2,2),1))
-
  1  1
  1  1
  1  1
  0  0
  0  0
 [torch.DoubleTensor of dimension 5x2]
-
 
 > print(torch.cat(torch.ones(2,2),torch.zeros(2,2),1))
  1  1
@@ -108,9 +104,7 @@ Examples:
  1  1  0  0
 [torch.DoubleTensor of dimension 2x4]
 
-
 > print(torch.cat(torch.cat(torch.ones(2,2),torch.zeros(2,2),1),torch.rand(3,2),1))
-
  1.0000  1.0000
  1.0000  1.0000
  0.0000  0.0000
@@ -120,9 +114,7 @@ Examples:
  0.2206  0.7449
 [torch.DoubleTensor of dimension 7x2]
 
-
 > print(torch.cat({torch.ones(2,2), torch.zeros(2,2), torch.rand(3,2)},1))
-
  1.0000  1.0000
  1.0000  1.0000
  0.0000  0.0000
@@ -184,7 +176,7 @@ range.
 ### [res] torch.logspace([res,] x1, x2, [,n]) ###
 <a name="torch.logspace"></a>
 
-`y=torch.logspace(x1,x2)` returns a one-dimensional tensor of 50 logarithmically eqally spaced points between `10^x1` and `10^x2`.
+`y=torch.logspace(x1,x2)` returns a one-dimensional tensor of 100 logarithmically eqally spaced points between `10^x1` and `10^x2`.
 
 `y=torch.logspace(x1,x2,n)` returns a one-dimensional tensor of `n` logarithmically equally spaced points between `10^x1` and `10^x2`.
 
@@ -259,7 +251,7 @@ For more than 4 dimensions, you can use a storage as argument:
 `y=torch.rand(m,n)` returns a `m x n` tensor of random numbers from a uniform distribution on the interval `(0,1)`.
 
 For more than 4 dimensions, you can use a storage as argument:
-`y=torch.rand(torch.LongStorage{m,n,k,l,o})`
+`y=torch.rand(torch.LongStorage{m,n,k,l,o})`.
 
 <a name="torch.randn"></a>
 ### [res] torch.randn([res,] m [,n...]) ###
@@ -270,7 +262,7 @@ For more than 4 dimensions, you can use a storage as argument:
 `y=torch.randn(m,n)` returns a `m x n` tensor of random numbers from a normal distribution with mean zero and variance one.
 
 For more than 4 dimensions, you can use a storage as argument:
-`y=torch.rand(torch.LongStorage{m,n,k,l,o})`
+`y=torch.randn(torch.LongStorage{m,n,k,l,o})`.
 
 <a name="torch.range"></a>
 ### [res] torch.range([res,] x, y [,step]) ###
@@ -308,7 +300,7 @@ from `x` to `y` with step `step` (default to 1).
 are taken rowwise from `x`, which must have `m*n` elements. The elements are copied into the new tensor.
 
 For more than 4 dimensions, you can use a storage:
-`y=torch.reshape(x,torch.LongStorage{m,n,k,l,o})`
+`y=torch.reshape(x,torch.LongStorage{m,n,k,l,o})`.
 
 <a name="torch.tril"></a>
 ### [res] torch.tril([res,] x [,k]) ###
@@ -340,7 +332,7 @@ is below the main diagonal.
 `y=torch.zeros(m,n)` returns a `m x n` tensor filled with zeros.
 
 For more than 4 dimensions, you can use a storage:
-`y=torch.zeros(torch.LongStorage{m,n,k,l,o})`
+`y=torch.zeros(torch.LongStorage{m,n,k,l,o})`.
 
 
 <a name="torch.elementwise.dok"></a>
@@ -530,7 +522,6 @@ of elements must match, but sizes do not matter.
 > y = torch.Tensor(4):fill(3)
 > x:add(y)
 > = x
-
  5  5
  5  5
 [torch.Tensor of dimension 2x2]
@@ -586,7 +577,7 @@ Multiply all elements in the tensor by the given `value`.
 `z:mul(x,2)` will put the result of `x*2` in `z`.
 
 <a name="torch.clamp"></a>
-### [res] torch.clamp([res,] tensor1, min_value, max_value) ###
+### [res] torch.clamp([res,] tensor, min_value, max_value) ###
 <a name="torch.mul"></a>
 
 Clamp all elements in the tensor into the range `[min_value, max_value]`.  ie:
@@ -617,7 +608,6 @@ of elements must match, but sizes do not matter.
 > y = torch.Tensor(4):fill(3)
 > x:cmul(y)
 > = x
-
  6  6
  6  6
 [torch.Tensor of dimension 2x2]
@@ -644,7 +634,6 @@ but sizes do not matter.
 > y = torch.Tensor(4):fill(3)
 > x:cpow(y)
 > = x
-
  8  8
  8  8
 [torch.Tensor of dimension 2x2]
@@ -673,7 +662,6 @@ to `x`. The number of elements must match, but sizes do not matter.
 > z = torch.Tensor(2,2):fill(5)
 > x:addcmul(2, y, z)
 > = x
-
  32  32
  32  32
 [torch.Tensor of dimension 2x2]
@@ -708,11 +696,9 @@ number of elements must match, but sizes do not matter.
 
 ```lua
 > x = torch.Tensor(2,2):fill(1)
-> y = torch.Tensor(4)
-> for i=1,4 do y[i] = i end
+> y = torch.range(1,4)
 > x:cdiv(y)
 > = x
-
  1.0000  0.5000
  0.3333  0.2500
 [torch.Tensor of dimension 2x2]
@@ -736,12 +722,10 @@ The number of elements must match, but sizes do not matter.
 
 ```lua
 > x = torch.Tensor(2,2):fill(1)
-> y = torch.Tensor(4)
+> y = torch.range(1,4)
 > z = torch.Tensor(2,2):fill(5)
-> for i=1,4 do y[i] = i end
 > x:addcdiv(2, y, z)
 > = x
-
  1.4000  1.8000
  2.2000  2.6000
 [torch.Tensor of dimension 2x2]
@@ -785,7 +769,7 @@ Optional value `beta` is  a scalar that scales the result tensor, before accumul
 In other words,
 
 ```
-res = beta * res + v1 * vec1 + v2 * mat * vec2
+res = (beta * res) + (v1 * vec1) + (v2 * (mat * vec2))
 ```
 
 Sizes must respect the matrix-multiplication operation: if `mat` is
@@ -798,7 +782,6 @@ be a vector of size `n`.
 > y = torch.Tensor(2):fill(2)
 > x:addmv(M, y)
 > = x
-
  12
  12
  12
@@ -823,30 +806,45 @@ be a vector of size `n`.
 Performs the outer-product between `vec1` (1D tensor) and `vec2` (1D tensor).
 
 Optional values `v1` and `v2` are scalars that multiply
-`M` and `vec1 [out] vec2` respectively.
+`mat` and `vec1 [out] vec2` respectively.
 
 In other words,
 
 ```
-res_ij = v1 * mat_ij + v2 * vec1_i * vec2_j
+res_ij = (v1 * mat_ij) + (v2 * vec1_i * vec2_j)
 ```
 
 If `vec1` is a vector of size `n` and `vec2` is a vector of size `m`,
-then mat must be a matrix of size `n x m`.
+then `mat` must be a matrix of size `n x m`.
 
 ```lua
-> x = torch.Tensor(3)
-> y = torch.Tensor(2)
-> for i=1,3 do x[i] = i end
-> for i=1,2 do y[i] = i end
-> M = torch.Tensor(3, 2):zero()
-> M:addr(x, y)
-> = M
+> x = torch.range(1,3)
+> y = torch.range(1,2)
+> M = torch.Tensor(3,2):zero()
+> M:addr(x,y)
+ 1  2         --     |0 0|     |1 2|
+ 2  4         -- = 1*|0 0| + 1*|2 4|
+ 3  6         --     |0 0|     |3 6|
+[torch.DoubleTensor of size 3x2]
+-- default values of v1 and v2 are 1.
 
+> M:addr(2,1,x,y)
+  3   6        --     |1 2|     |1 2|
+  6  12        -- = 2*|2 4| + 1*|2 4|
+  9  18        --     |3 6|     |3 6|
+[torch.DoubleTensor of size 3x2]
+
+> A=torch.range(1,6):resize(3,2)
+> A
  1  2
- 2  4
- 3  6
-[torch.Tensor of dimension 3x2]
+ 3  4
+ 5  6
+[torch.DoubleTensor of size 3x2]
+> M:addr(2,A,1,x,y)
+  3   6        --   |1 2|     |1 2|
+  8  12        -- 2*|3 4| + 1*|2 4|
+ 13  18        --   |5 6|     |3 6|
+[torch.DoubleTensor of size 3x2]
 ```
 
 `torch.addr(M,x,y)` returns the result in a new tensor.
@@ -874,7 +872,7 @@ Optional value `beta` is  a scalar that scales the result tensor, before accumul
 In other words,
 
 ```
-res = res * beta + v1 * M + v2 * mat1*mat2
+res = (res * beta) + (v1 * M) + (v2 * mat1*mat2)
 ```
 
 If `mat1` is a `n x m` matrix, `mat2` a `m x p` matrix,
@@ -904,7 +902,7 @@ tensor, res will be a `n x p` tensor.
 In other words,
 
 ```
-res = v1 * M + v2 * sum(batch1_i * batch2_i, i=1,b)
+res = (v1 * M) + (v2 * sum(batch1_i * batch2_i, i=1,b))
 ```
 
 `torch.addbmm(M,x,y)` puts the result in a new tensor.
@@ -927,7 +925,7 @@ tensor, res will be a `b x n x p` tensor.
 In other words,
 
 ```
-res_i = v1 * M_i + v2 * batch1_i * batch2_i
+res_i = (v1 * M_i) + (v2 * batch1_i * batch2_i)
 ```
 
 `torch.baddbmm(M,x,y)` puts the result in a new tensor.
@@ -942,7 +940,7 @@ res_i = v1 * M_i + v2 * batch1_i * batch2_i
 
 Matrix vector product of `mat` and `vec`. Sizes must respect
 the matrix-multiplication operation: if `mat` is a `n x m` matrix,
-`vec` must be vector of size `m` and res must be a vector of size `n`.
+`vec` must be vector of size `m` and `res` must be a vector of size `n`.
 
 `torch.mv(x,y)` puts the result in a new tensor.
 
@@ -955,7 +953,7 @@ the matrix-multiplication operation: if `mat` is a `n x m` matrix,
 <a name="torch.mm"></a>
 
 Matrix matrix product of `mat1` and `mat2`. If `mat1` is a
-`n x m` matrix, `mat2` a `m x p` matrix, res must be a
+`n x m` matrix, `mat2` a `m x p` matrix, `res` must be a
 `n x p` matrix.
 
 
@@ -972,7 +970,7 @@ Matrix matrix product of `mat1` and `mat2`. If `mat1` is a
 Batch matrix matrix product of matrices stored in `batch1` and `batch2`.
 `batch1` and `batch2` must be 3D tensors each containing the same number
 of matrices. If `batch1` is a `b x n x m` tensor, `batch2` a `b x m x p`
-tensor, res will be a `b x n x p` tensor.
+tensor, `res` will be a `b x n x p` tensor.
 
 
 `torch.bmm(x,y)` puts the result in a new tensor.
@@ -986,7 +984,7 @@ tensor, res will be a `b x n x p` tensor.
 <a name="torch.ger"></a>
 
 Outer product of `vec1` and `vec2`. If `vec1` is a vector of
-size `n` and `vec2` is a vector of size `m`, then res must
+size `n` and `vec2` is a vector of size `m`, then `res` must
 be a matrix of size `n x m`.
 
 
@@ -1021,13 +1019,11 @@ of the returned tensor will be the size of the first tensor.
 > x = torch.Tensor(2,2):fill(2)
 > y = torch.Tensor(4):fill(3)
 > = x+y
-
  5  5
  5  5
 [torch.Tensor of dimension 2x2]
 
 > = y-x
-
  1
  1
  1
@@ -1040,7 +1036,6 @@ A scalar might also be added or subtracted to a tensor. The scalar needs to be o
 ```lua
 > x = torch.Tensor(2,2):fill(2)
 > = x+3
-
  5  5
  5  5
 [torch.Tensor of dimension 2x2]
@@ -1054,7 +1049,6 @@ A tensor can be negated with the `-` operator placed in front:
 ```lua
 > x = torch.Tensor(2,2):fill(2)
 > = -x
-
 -2 -2
 -2 -2
 [torch.Tensor of dimension 2x2]
@@ -1081,14 +1075,13 @@ Examples:
 > y = torch.Tensor(2):fill(5)
 > = x*y -- dot product
 40
-> = M*x --- matrix-vector
 
+> = M*x --- matrix-vector
  16
  16
 [torch.Tensor of dimension 2]
 
 > = M*N -- matrix-matrix
-
  12  12  12  12
  12  12  12  12
 [torch.Tensor of dimension 2x4]
@@ -1103,7 +1096,6 @@ Example:
 ```lua
 > x = torch.Tensor(2,2):fill(2)
 > = x/3
-
  0.6667  0.6667
  0.6667  0.6667
 [torch.Tensor of dimension 2x2]
@@ -1132,6 +1124,68 @@ of `x`, performing the operation over the last dimension.
 `y=torch.cumprod(x,n)` returns the cumulative product of the
 elements of `x`, performing the operation over dimension `n`.
 
+```lua
+-- 1. cumulative product for a vector
+> A=torch.range(1,5)
+> A
+ 1
+ 2
+ 3
+ 4
+ 5
+[torch.DoubleTensor of size 5]
+> B=torch.cumprod(A)
+> B
+   1     -- B(1) = A(1) = 1
+   2     -- B(2) = A(1)*A(2) = 1*2 = 2
+   6     -- B(3) = A(1)*A(2)*A(3) = 1*2*3 = 6
+  24     -- B(4) = A(1)*A(2)*A(3)*A(4) = 1*2*3*4 = 24
+ 120     -- B(5) = A(1)*A(2)*A(3)*A(4)*A(5) =1*2*3*4*5 = 120
+[torch.DoubleTensor of size 5]
+
+-- 2. cumulative product for a matrix
+> A=torch.LongTensor{{1,4,7},{2,5,8},{3,6,9}}
+> A
+ 1  4  7
+ 2  5  8
+ 3  6  9
+[torch.LongTensor of size 3x3]
+> B=torch.cumprod(A)
+> B
+   1    4    7
+   2   20   56
+   6  120  504
+[torch.LongTensor of size 3x3]
+-- Why?
+-- B(1,1) = A(1,1) = 1
+-- B(2,1) = A(1,1)*A(2,1) = 1*2 = 2
+-- B(3,1) = A(1,1)*A(2,1)*A(3,1) = 1*2*3 = 6
+-- B(1,2) = A(1,2) = 4
+-- B(2,2) = A(1,2)*A(2,2) = 4*5 = 20
+-- B(3,2) = A(1,2)*A(2,2)*A(3,2) = 4*5*6 = 120
+-- B(1,3) = A(1,3) = 7
+-- B(2,3) = A(1,3)*A(2,3) = 7*8 = 56
+-- B(3,3) = A(1,3)*A(2,3)*A(3,3) = 7*8*9 = 504
+
+-- 3. cumulative product along 2-dim
+> B=torch.cumprod(A,2)
+> B
+   1    4   28
+   2   10   80
+   3   18  162
+[torch.LongTensor of size 3x3]
+-- Why?
+-- B(1,1) = A(1,1) = 1
+-- B(1,2) = A(1,1)*A(1,2) = 1*4 = 4
+-- B(1,3) = A(1,1)*A(1,2)*A(1,3) = 1*4*7 = 28
+-- B(2,1) = A(2,1) = 2
+-- B(2,2) = A(2,1)*A(2,2) = 2*5 = 10
+-- B(2,3) = A(2,1)*A(2,2)*A(2,3) = 2*5*8 = 80
+-- B(3,1) = A(3,1) = 3
+-- B(3,2) = A(3,1)*A(2,3) = 3*6 = 18
+-- B(3,3) = A(3,1)*A(2,3)*A(3,3) = 3*6*9 = 162
+```
+
 <a name="torch.cumsum"></a>
 ### [res] torch.cumsum([res,] x [,dim]) ###
 
@@ -1150,9 +1204,39 @@ of `x`, performing the operation over dimension `n`.
 (across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.max(x,2)` performs the max operation across rows.
+`y,i=torch.max(x,2)` performs the max operation for each row.
 
 `y,i=torch.max(x,n)` performs the max operation over the dimension `n`.
+
+```lua
+> x=torch.randn(3,3)
+> x
+ 1.1994 -0.6290  0.6888
+-0.0038 -0.0908 -0.2075
+ 0.3437 -0.9948  0.1216
+[torch.DoubleTensor of size 3x3]
+
+th> torch.max(x)
+1.1993977428735	
+
+th> torch.max(x,1)
+ 1.1994 -0.0908  0.6888
+[torch.DoubleTensor of size 1x3]
+
+ 1  2  1
+[torch.LongTensor of size 1x3]
+
+th> torch.max(x,2)
+ 1.1994
+-0.0038
+ 0.3437
+[torch.DoubleTensor of size 3x1]
+
+ 1
+ 1
+ 1
+[torch.LongTensor of size 3x1]
+```
 
 
 <a name="torch.mean"></a>
@@ -1176,7 +1260,7 @@ each column of `x`.
 (across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.min(x,2)` performs the min operation across rows.
+`y,i=torch.min(x,2)` performs the min operation for each row.
 
 `y,i=torch.min(x,n)` performs the min operation over the dimension `n`.
 
@@ -1274,9 +1358,50 @@ in `a` and `v`.
 (across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.median(x,2)` performs the median operation across rows.
+`y,i=torch.median(x,2)` performs the median operation for each row.
 
 `y,i=torch.median(x,n)` performs the median operation over the dimension `n`.
+
+```lua
+> x=torch.randn(3,3)
+> x
+ 0.7860  0.7687 -0.9362
+ 0.0411  0.5407 -0.3616
+-0.0129 -0.2499 -0.5786
+[torch.DoubleTensor of size 3x3]
+
+> y,i=torch.median(x)
+> y
+ 0.7687
+ 0.0411
+-0.2499
+[torch.DoubleTensor of size 3x1]
+> i
+ 2
+ 1
+ 2
+[torch.LongTensor of size 3x1]
+
+> y,i=torch.median(x,1)
+> y
+ 0.0411  0.5407 -0.5786
+[torch.DoubleTensor of size 1x3]
+> i
+ 2  2  3
+[torch.LongTensor of size 1x3]
+
+> y,i=torch.median(x,2)
+> y
+ 0.7687
+ 0.0411
+-0.2499
+[torch.DoubleTensor of size 3x1]
+> i
+ 2
+ 1
+ 2
+[torch.LongTensor of size 3x1]
+```
 
 <a name="torch.mode"></a>
 ### torch.mode([resval, resind,] x [,dim]) ###
@@ -1287,7 +1412,7 @@ in `a` and `v`.
 (across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.mode(x,2)` performs the mode operation across rows.
+`y,i=torch.mode(x,2)` performs the mode operation for each row.
 
 `y,i=torch.mode(x,n)` performs the mode operation over the dimension `n`.
 
@@ -1300,7 +1425,7 @@ in `a` and `v`.
 (across rows) of `x`, and a tensor `i` of their corresponding indices in
 `x`.
 
-`y,i=torch.kthvalue(x,k,2)` performs the k-th value operation across rows.
+`y,i=torch.kthvalue(x,k,2)` performs the k-th value operation for each row.
 
 `y,i=torch.kthvalue(x,k,n)` performs the k-th value operation over the dimension `n`.
 
@@ -1329,6 +1454,24 @@ in `a` and `v`.
    5  12
   21  32
 [torch.DoubleTensor of dimension 1x2x2]
+
+> torch.prod(a, 2)
+(1,.,.) = 
+   3   8
+   
+(2,.,.) = 
+  35  48
+[torch.DoubleTensor of size 2x1x2]
+
+> torch.prod(a, 3)
+(1,.,.) = 
+   2
+  12
+  
+(2,.,.) = 
+  30
+  56
+[torch.DoubleTensor of size 2x2x1]
 ```
 
 
@@ -1347,6 +1490,26 @@ a specific dimension `d`.
 
 `y,i=torch.sort(x,d,true)` performs the sort operation along
 a specific dimension `d`, in __descending__ order.
+
+```lua
+> x=torch.randn(3,3)
+> x
+-1.2470 -0.4288 -0.5337
+ 0.8836 -0.1622  0.9604
+ 0.6297  0.2397  0.0746
+[torch.DoubleTensor of size 3x3]
+
+> torch.sort(x)
+-1.2470 -0.5337 -0.4288
+-0.1622  0.8836  0.9604
+ 0.0746  0.2397  0.6297
+[torch.DoubleTensor of size 3x3]
+
+ 1  3  2
+ 2  1  3
+ 3  2  1
+[torch.LongTensor of size 3x3]
+```
 
 <a name="torch.std"></a>
 ### [res] torch.std([res,] x, [,dim] [,flag]) ###
@@ -1373,11 +1536,11 @@ a specific dimension `d`, in __descending__ order.
 
 `y=torch.var(x)` returns the variance of the elements of `x`.
 
-`y=torch.var(x,dim)` performs the var operation over the dimension dim.
+`y=torch.var(x,dim)` performs the `var` operation over the dimension `dim`.
 
-`y=torch.var(x,dim,false)` performs the var operation normalizing by `n-1` (this is the default).
+`y=torch.var(x,dim,false)` performs the `var` operation normalizing by `n-1` (this is the default).
 
-`y=torch.var(x,dim,true)` performs the var operation normalizing by `n` instead of `n-1`.
+`y=torch.var(x,dim,true)` performs the `var` operation normalizing by `n` instead of `n-1`.
 
 <a name="torch.matrixwide.dok"></a>
 ## Matrix-wide operations  (tensor-wide operations) ##
@@ -1395,7 +1558,7 @@ Note that many of the operations in [dimension-wise operations](#torch.columnwis
 
 <a name="torch.renorm"></a>
 ### torch.renorm([res], x, p, dim, maxnorm) ###
-Renormalizes the sub-tensors along dimension `dim` such that they do not exceed norm `maxnorm`.
+Renormalizes the sub-tensors along dimension `dim` such that they exceed norm `maxnorm`.
 
 `y=torch.renorm(x,p,dim,maxnorm)` returns a version of `x` with `p`-norms lower than `maxnorm` over non-`dim` dimensions.
 The `dim` argument is not to be confused with the argument of the same name in function [norm](#torch.norm).
@@ -1444,7 +1607,7 @@ The returned value `y` is a number, not a tensor.
 <a name="torch.conv.dok"></a>
 ## Convolution Operations ##
 
-These function implement convolution or cross-correlation of an input
+These functions implement convolution or cross-correlation of an input
 image (or set of input images) with a kernel (or set of kernels). The
 convolution function in Torch can handle different types of
 input/kernel dimensions and produces corresponding outputs. The
@@ -1467,18 +1630,15 @@ x = torch.rand(100,100)
 k = torch.rand(10,10)
 c = torch.conv2(x,k)
 > c:size()
-
  91
  91
 [torch.LongStorage of size 2]
 
 c = torch.conv2(x,k,'F')
 > c:size()
-
  109
  109
 [torch.LongStorage of size 2]
-
 ```
 
 <a name="torch.xcorr2"></a>
@@ -1506,7 +1666,6 @@ x = torch.rand(100,100,100)
 k = torch.rand(10,10,10)
 c = torch.conv3(x,k)
 > c:size()
-
  91
  91
  91
@@ -1514,7 +1673,6 @@ c = torch.conv3(x,k)
 
 c = torch.conv3(x,k,'F')
 > c:size()
-
  109
  109
  109
@@ -1539,7 +1697,7 @@ If LAPACK libraries are not found during compilation step,
 then these functions will not be available.
 
 <a name="torch.gesv"></a>
-### [x,lu] torch.gesv([resb, resa,] b, a) ###
+### [x,lu] torch.gesv([resb, resa,] B, A) ###
 
 `X,LU=torch.gesv(B,A)` returns the solution of `AX=B` and `LU` contains
 `L` and `U` factors for `LU` factorization of `A`.
@@ -1557,13 +1715,13 @@ Note: Irrespective of the original strides, the returned matrices `resb` and
 `resa` will be transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
-a = torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
+> a = torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
                   {-6.05, -3.30,  5.36, -4.44,  1.08},
                   {-0.45,  2.58, -2.70,  0.27,  9.04},
                   {8.32,  2.71,  4.35,  -7.17,  2.14},
                   {-9.67, -5.14, -7.26,  6.08, -6.87}}):t()
 
-b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
+> b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
                   {-1.56,  4.00, -8.67,  1.75,  2.86},
                   {9.81, -4.09, -4.57, -8.61,  8.99}}):t()
 
@@ -1584,7 +1742,7 @@ b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
 [torch.DoubleTensor of dimension 5x5]
 
 
-x = torch.gesv(b,a)
+> x = torch.gesv(b,a)
 > x
 -0.8007 -0.3896  0.9555
 -0.6952 -0.5544  0.2207
@@ -1615,7 +1773,7 @@ The function has several options:
 * `trans` (`'N'` or `'T`') specifies the system of equations: `'N'` for
   `A * X = B` (no transpose), or `'T'` for `A^T * X = B` (transpose);
   the default value is `'N'`.
-* `diag` (`'N'` or `'U'`) `'U'` specifies that `A` is non-unit triangular, i.e.,
+* `diag` (`'N'` or `'U'`) `'U'` specifies that `A` is unit triangular, i.e.,
    it has ones on its diagonal; `'N'` specifies that `A` is not (necessarily) unit
    triangular; the default value is `'N'`.
 
@@ -1627,13 +1785,13 @@ Note: Irrespective of the original strides, the returned matrices `resb` and
 `resa` will be transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
-a = torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
+> a = torch.Tensor({{6.80, -2.11,  5.66,  5.97,  8.23},
                   {0, -3.30,  5.36, -4.44,  1.08},
                   {0,  0, -2.70,  0.27,  9.04},
                   {0,  0,  0,  -7.17,  2.14},
                   {0,  0,  0,  0, -6.87}})
 
-b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
+> b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
                   {-1.56,  4.00, -8.67,  1.75,  2.86},
                   {9.81, -4.09, -4.57, -8.61,  8.99}}):t()
 
@@ -1653,8 +1811,7 @@ b = torch.Tensor({{4.02,  6.19, -8.22, -7.57, -3.03},
  0.0000  0.0000  0.0000  0.0000 -6.8700
 [torch.DoubleTensor of dimension 5x5]
 
-
-x = torch.trtrs(b, a)
+> x = torch.trtrs(b, a)
 > x
 -3.5416 -0.2514  3.0847
  4.2072  2.0391 -4.5146
@@ -1674,21 +1831,21 @@ Cholesky Decomposition of 2D tensor `A`. Matrix `A` has to be a positive-definit
 
 Optional character `uplo` = {'U', 'L'} specifies whether the upper or lower triangular decomposition should be returned. By default, `uplo` = 'U'.
 
-`X = torch.potrf(A, 'U')` returns the upper triangular Cholesky decomposition of X.
+`X = torch.potrf(A, 'U')` returns the upper triangular Cholesky decomposition of `X`.
 
-`X = torch.potrf(A, 'L')` returns the lower triangular Cholesky decomposition of X.
+`X = torch.potrf(A, 'L')` returns the lower triangular Cholesky decomposition of `X`.
 
 If tensor `res` is provided, the resulting decomposition will be stored therein.
 
-```
-A = torch.Tensor({
+```lua
+> A = torch.Tensor({
     {1.2705,  0.9971,  0.4948,  0.1389,  0.2381},
     {0.9971,  0.9966,  0.6752,  0.0686,  0.1196},
     {0.4948,  0.6752,  1.1434,  0.0314,  0.0582},
     {0.1389,  0.0686,  0.0314,  0.0270,  0.0526},
     {0.2381,  0.1196,  0.0582,  0.0526,  0.3957}})
 
-chol = torch.potrf(A)
+> chol = torch.potrf(A)
 > chol
  1.1272  0.8846  0.4390  0.1232  0.2112
  0.0000  0.4626  0.6200 -0.0874 -0.1453
@@ -1697,7 +1854,7 @@ chol = torch.potrf(A)
  0.0000  0.0000  0.0000  0.0000  0.5255
 [torch.DoubleTensor of size 5x5]
 
-torch.potrf(chol, A, 'L')
+> torch.potrf(chol, A, 'L')
 > chol
  1.1272  0.0000  0.0000  0.0000  0.0000
  0.8846  0.4626  0.0000  0.0000  0.0000
@@ -1718,7 +1875,7 @@ Optional character `uplo` = {'U', 'L'} specifies matrix `chol` as either upper o
 
 If tensor `res` is provided, the resulting decomposition will be stored therein.
 
-```
+```lua
 A = torch.Tensor({
     {1.2705,  0.9971,  0.4948,  0.1389,  0.2381},
     {0.9971,  0.9966,  0.6752,  0.0686,  0.1196},
@@ -1774,15 +1931,15 @@ Optional character `uplo` = {'U', 'L'} specifies matrix `chol` as either upper o
 
 If tensor `res` is provided, the resulting inverse will be stored therein.
 
-```
-A = torch.Tensor({
+```lua
+> A = torch.Tensor({
     {1.2705,  0.9971,  0.4948,  0.1389,  0.2381},
     {0.9971,  0.9966,  0.6752,  0.0686,  0.1196},
     {0.4948,  0.6752,  1.1434,  0.0314,  0.0582},
     {0.1389,  0.0686,  0.0314,  0.0270,  0.0526},
     {0.2381,  0.1196,  0.0582,  0.0526,  0.3957}})
 
-chol = torch.potrf(A)
+> chol = torch.potrf(A)
 > chol
  1.1272  0.8846  0.4390  0.1232  0.2112
  0.0000  0.4626  0.6200 -0.0874 -0.1453
@@ -1821,13 +1978,12 @@ Note: Irrespective of the original strides, the returned matrices `resb` and
 `resa` will be transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
-
-a = torch.Tensor({{ 1.44, -9.96, -7.55,  8.34,  7.08, -5.45},
+> a = torch.Tensor({{ 1.44, -9.96, -7.55,  8.34,  7.08, -5.45},
                   {-7.84, -0.28,  3.24,  8.09,  2.52, -5.70},
                   {-4.39, -3.24,  6.27,  5.28,  0.74, -1.19},
                   {4.53,  3.83, -6.64,  2.06, -2.47,  4.70}}):t()
 
-b = torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
+> b = torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
                   {9.35, -4.43, -0.70, -0.26, -7.36, -2.52}}):t()
 
 > a
@@ -1848,7 +2004,7 @@ b = torch.Tensor({{8.58,  8.26,  8.48, -5.28,  5.72,  8.93},
  8.9300 -2.5200
 [torch.DoubleTensor of dimension 6x2]
 
-x = torch.gels(b,a)
+> x = torch.gels(b,a)
 > x
  -0.4506   0.2497
  -0.8492  -0.9020
@@ -1889,7 +2045,7 @@ Note: Irrespective of the original strides, the returned matrix `V` will be
 transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
-a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
+> a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
                   {-6.49,  3.80,  0.00,  0.00,  0.00},
                   {-0.47, -6.39,  4.17,  0.00,  0.00},
                   {-7.20,  1.50, -1.51,  5.70,  0.00},
@@ -1903,7 +2059,7 @@ a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
  0.0000  0.0000  0.0000  0.0000 -7.1000
 [torch.DoubleTensor of dimension 5x5]
 
-e = torch.symeig(a)
+> e = torch.symeig(a)
 > e
 -11.0656
  -6.2287
@@ -1912,7 +2068,7 @@ e = torch.symeig(a)
  16.0948
 [torch.DoubleTensor of dimension 5]
 
-e,v = torch.symeig(a,'V')
+> e,v = torch.symeig(a,'V')
 > e
 -11.0656
  -6.2287
@@ -1966,7 +2122,7 @@ Note: Irrespective of the original strides, the returned matrix `V` will be
 transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
-a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
+> a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
                   {-6.49,  3.80,  0.00,  0.00,  0.00},
                   {-0.47, -6.39,  4.17,  0.00,  0.00},
                   {-7.20,  1.50, -1.51,  5.70,  0.00},
@@ -1980,7 +2136,7 @@ a = torch.Tensor({{ 1.96,  0.00,  0.00,  0.00,  0.00},
  0.0000  0.0000  0.0000  0.0000 -7.1000
 [torch.DoubleTensor of dimension 5x5]
 
-b = a + torch.triu(a,1):t()
+> b = a + torch.triu(a,1):t()
 > b
 
   1.9600 -6.4900 -0.4700 -7.2000 -0.6500
@@ -1990,7 +2146,7 @@ b = a + torch.triu(a,1):t()
  -0.6500 -6.3400  2.6700  1.8000 -7.1000
 [torch.DoubleTensor of dimension 5x5]
 
-e = torch.eig(b)
+> e = torch.eig(b)
 > e
  16.0948   0.0000
 -11.0656   0.0000
@@ -1999,7 +2155,7 @@ e = torch.eig(b)
   8.8655   0.0000
 [torch.DoubleTensor of dimension 5x2]
 
-e,v = torch.eig(b,'V')
+> e,v = torch.eig(b,'V')
 > e
  16.0948   0.0000
 -11.0656   0.0000
@@ -2044,7 +2200,7 @@ Note: Irrespective of the original strides, the returned matrix `U` will be
 transposed, i.e. with strides `1,n` instead of `n,1`.
 
 ```lua
-a = torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
+> a = torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
                   {9.93,  6.91, -7.93,  1.64,  4.02,  0.15},
                   {9.83,  5.04,  4.86,  8.83,  9.80, -8.99},
                   {5.45, -0.27,  4.85,  0.74, 10.00, -6.02},
@@ -2058,7 +2214,7 @@ a = torch.Tensor({{8.79,  6.11, -9.15,  9.57, -3.49,  9.84},
  -3.4900   4.0200   9.8000  10.0000   4.2700
   9.8400   0.1500  -8.9900  -6.0200  -5.3100
 
-u,s,v = torch.svd(a)
+> u,s,v = torch.svd(a)
 > u
 -0.5911  0.2632  0.3554  0.3143  0.2299
 -0.3976  0.2438 -0.2224 -0.7535 -0.3636
@@ -2111,9 +2267,9 @@ Note: Irrespective of the original strides, the returned matrix `y` will be
 transposed, i.e. with strides `1,m` instead of `m,1`.
 
 ```lua
-x = torch.rand(10,10)
-y = torch.inverse(x)
-z = x * y
+> x = torch.rand(10,10)
+> y = torch.inverse(x)
+> z = x * y
 > z
  1.0000 -0.0000  0.0000 -0.0000  0.0000  0.0000  0.0000 -0.0000  0.0000  0.0000
  0.0000  1.0000 -0.0000 -0.0000  0.0000  0.0000 -0.0000 -0.0000 -0.0000  0.0000
@@ -2198,7 +2354,7 @@ to use `torch.qr()` instead.
 Computes a QR decomposition of `a`, but without constructing Q and R as explicit
 separate matrices. Rather, this directly calls the underlying LAPACK function
  `?geqrf` which produces a sequence of 'elementary reflectors'. See
-[LAPACK documentation](http://www.netlib.org/netlib/lapack/double/dgeqrf.f)
+[LAPACK documentation](https://software.intel.com/en-us/node/521004)
 for further details.
 
 <a name="torch.orgqr"></a>
@@ -2209,7 +2365,7 @@ to use `torch.qr()` instead.
 
 Constructs a Q matrix from a sequence of elementary reflectors, such as that
 given by `torch.geqrf`. See
- [LAPACK documentation](http://www.netlib.org/netlib/lapack/double/dorgqr.f) for
+ [LAPACK documentation](https://software.intel.com/en-us/node/521010) for
 further details.
 
 <a name="torch.ormqr"></a>
@@ -2221,12 +2377,11 @@ calling LAPACK directly. You'll generally want to use `torch.qr()`
 instead.
 
 * `side` (`'L'` or `'R'`) specifies whether `mat` should be
-  left-multiplied, `Q * mat`, or right-multiplied, `mat * Q`.
+  left-multiplied, `mat * Q`, or right-multiplied, `Q * mat`.
 * `trans` (`'N'` or `'T`') specifies whether `Q` should be transposed
   before being multiplied.
 
-See [LAPACK
-documentation](http://www.netlib.org/netlib/lapack/double/dormqr.f) for
+See [LAPACK documentation](https://software.intel.com/en-us/node/521011) for
 further details.
 
 <a name="torch.logical.dok"></a>
@@ -2363,7 +2518,7 @@ of the tensor element-wise logical operations.
  0
 [torch.ByteTensor of dimension 10]
 
-a[torch.gt(a,b)] = 10
+> a[torch.gt(a,b)] = 10
 > a
  10.0000
  10.0000
@@ -2377,7 +2532,7 @@ a[torch.gt(a,b)] = 10
   0.0740
 [torch.DoubleTensor of dimension 10]
 
-a[torch.gt(a,1)] = -1
+> a[torch.gt(a,1)] = -1
 > a
 -1.0000
 -1.0000
@@ -2391,18 +2546,18 @@ a[torch.gt(a,1)] = -1
  0.0740
 [torch.DoubleTensor of dimension 10]
 
-a = torch.ones(3):byte()
+> a = torch.ones(3):byte()
 > torch.all(a)
 true
 
-a[2] = 0
+> a[2] = 0
 > torch.all(a)
 false
 
 > torch.any(a)
 true
 
-a:zero()
+> a:zero()
 > torch.any(a)
 false
 


### PR DESCRIPTION
I've tried to fix some typos and to add examples.
On line 2118, [LAPACK convention] link is broken, but I couldn't find a
proper web page to fix it.

Thank you. :)