### PR TITLE
Fixed large data storing and restoring 

### DIFF
--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -38,10 +38,10 @@ size_t fread__(void *ptr, size_t size, size_t nitems, FILE *stream)
 #endif
 
 #define READ_WRITE_METHODS(TYPE, TYPEC, ASCII_READ_ELEM, ASCII_WRITE_ELEM) \
-  static long THDiskFile_read##TYPEC(THFile *self, TYPE *data, long n)  \
+  static size_t THDiskFile_read##TYPEC(THFile *self, TYPE *data, size_t n)  \
   {                                                                     \
     THDiskFile *dfself = (THDiskFile*)(self);                           \
-    long nread = 0L;                                                    \
+    size_t nread = 0L;                                                    \
                                                                         \
     THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file"); \
     THArgCheck(dfself->file.isReadable, 1, "attempt to read in a write-only file"); \
@@ -54,7 +54,7 @@ size_t fread__(void *ptr, size_t size, size_t nitems, FILE *stream)
     }                                                                   \
     else                                                                \
     {                                                                   \
-      long i;                                                           \
+      size_t i;                                                           \
       for(i = 0; i < n; i++)                                            \
       {                                                                 \
         ASCII_READ_ELEM; /* increment here result and break if wrong */ \
@@ -77,10 +77,10 @@ size_t fread__(void *ptr, size_t size, size_t nitems, FILE *stream)
     return nread;                                                       \
   }                                                                     \
                                                                         \
-  static long THDiskFile_write##TYPEC(THFile *self, TYPE *data, long n) \
+  static size_t THDiskFile_write##TYPEC(THFile *self, TYPE *data, size_t n) \
   {                                                                     \
     THDiskFile *dfself = (THDiskFile*)(self);                           \
-    long nwrite = 0L;                                                   \
+    size_t nwrite = 0L;                                                   \
                                                                         \
     THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file"); \
     THArgCheck(dfself->file.isWritable, 1, "attempt to write in a read-only file"); \
@@ -106,7 +106,7 @@ size_t fread__(void *ptr, size_t size, size_t nitems, FILE *stream)
     }                                                                   \
     else                                                                \
     {                                                                   \
-      long i;                                                           \
+      size_t i;                                                           \
       for(i = 0; i < n; i++)                                            \
       {                                                                 \
         ASCII_WRITE_ELEM;                                               \
@@ -163,7 +163,7 @@ static void THDiskFile_synchronize(THFile *self)
   fflush(dfself->handle);
 }
 
-static void THDiskFile_seek(THFile *self, long position)
+static void THDiskFile_seek(THFile *self, size_t position)
 {
   THDiskFile *dfself = (THDiskFile*)(self);
 
@@ -192,7 +192,7 @@ static void THDiskFile_seekEnd(THFile *self)
   }
 }
 
-static long THDiskFile_position(THFile *self)
+static size_t THDiskFile_position(THFile *self)
 {
   THDiskFile *dfself = (THDiskFile*)(self);
   THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file");
@@ -209,14 +209,14 @@ static void THDiskFile_close(THFile *self)
 
 /* Little and Big Endian */
 
-static void THDiskFile_reverseMemory(void *dst, const void *src, long blockSize, long numBlocks)
+static void THDiskFile_reverseMemory(void *dst, const void *src, size_t blockSize, size_t numBlocks)
 {
   if(blockSize != 1)
   {
-    long halfBlockSize = blockSize/2;
+    size_t halfBlockSize = blockSize/2;
     char *charSrc = (char*)src;
     char *charDst = (char*)dst;
-    long b, i;
+    size_t b, i;
     for(b = 0; b < numBlocks; b++)
     {
       for(i = 0; i < halfBlockSize; i++)
@@ -313,7 +313,7 @@ READ_WRITE_METHODS(double, Double,
                    int ret = fscanf(dfself->handle, "%lg", &data[i]); if(ret <= 0) break; else nread++,
                    int ret = fprintf(dfself->handle, "%.17g", data[i]); if(ret <= 0) break; else nwrite++)
 
-static long THDiskFile_readString(THFile *self, const char *format, char **str_)
+static size_t THDiskFile_readString(THFile *self, const char *format, char **str_)
 {
   THDiskFile *dfself = (THDiskFile*)(self);
   THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file");
@@ -327,8 +327,8 @@ static long THDiskFile_readString(THFile *self, const char *format, char **str_)
   if(format[1] == 'a')
   {
     char *p = THAlloc(TBRS_BSZ);
-    long total = TBRS_BSZ;
-    long pos = 0L;
+    size_t total = TBRS_BSZ;
+    size_t pos = 0L;
     
     for (;;)
     {
@@ -358,9 +358,9 @@ static long THDiskFile_readString(THFile *self, const char *format, char **str_)
   else
   {
     char *p = THAlloc(TBRS_BSZ);
-    long total = TBRS_BSZ;
-    long pos = 0L;
-    long size;
+    size_t total = TBRS_BSZ;
+    size_t pos = 0L;
+    size_t size;
 
     for (;;)
     {
@@ -403,10 +403,10 @@ static long THDiskFile_readString(THFile *self, const char *format, char **str_)
 }
 
 
-static long THDiskFile_writeString(THFile *self, const char *str, long size)
+static size_t THDiskFile_writeString(THFile *self, const char *str, size_t size)
 {
   THDiskFile *dfself = (THDiskFile*)(self);
-  long nwrite;
+  size_t nwrite;
 
   THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file");
   THArgCheck(dfself->file.isWritable, 1, "attempt to write in a read-only file");

--- a/lib/TH/THFile.c
+++ b/lib/TH/THFile.c
@@ -2,12 +2,12 @@
 #include "THFilePrivate.h"
 
 #define IMPLEMENT_THFILE_RW(TYPEC, TYPE)                          \
-  long THFile_read##TYPEC##Raw(THFile *self, TYPE *data, long n)  \
+  size_t THFile_read##TYPEC##Raw(THFile *self, TYPE *data, size_t n)  \
   {                                                               \
     return (*self->vtable->read##TYPEC)(self, data, n);           \
   }                                                               \
                                                                   \
-  long THFile_write##TYPEC##Raw(THFile *self, TYPE *data, long n) \
+  size_t THFile_write##TYPEC##Raw(THFile *self, TYPE *data, size_t n) \
   {                                                               \
     return (*self->vtable->write##TYPEC)(self, data, n);          \
   }
@@ -20,12 +20,12 @@ IMPLEMENT_THFILE_RW(Long, long)
 IMPLEMENT_THFILE_RW(Float, float)
 IMPLEMENT_THFILE_RW(Double, double)
 
-long THFile_readStringRaw(THFile *self, const char *format, char **str_)
+size_t THFile_readStringRaw(THFile *self, const char *format, char **str_)
 {
   return self->vtable->readString(self, format, str_);
 }
 
-long THFile_writeStringRaw(THFile *self, const char *str, long size)
+size_t THFile_writeStringRaw(THFile *self, const char *str, size_t size)
 {
   return self->vtable->writeString(self, str, size);
 }
@@ -35,7 +35,7 @@ void THFile_synchronize(THFile *self)
   self->vtable->synchronize(self);
 }
 
-void THFile_seek(THFile *self, long position)
+void THFile_seek(THFile *self, size_t position)
 {
   self->vtable->seek(self, position);
 }
@@ -45,7 +45,7 @@ void THFile_seekEnd(THFile *self)
   self->vtable->seekEnd(self);
 }
 
-long THFile_position(THFile *self)
+size_t THFile_position(THFile *self)
 {
   return self->vtable->position(self);
 }
@@ -135,12 +135,12 @@ IMPLEMENT_THFILE_SCALAR(Float, float)
 IMPLEMENT_THFILE_SCALAR(Double, double)
 
 #define IMPLEMENT_THFILE_STORAGE(TYPEC, TYPE)                           \
-  long THFile_read##TYPEC(THFile *self, TH##TYPEC##Storage *storage)    \
+  size_t THFile_read##TYPEC(THFile *self, TH##TYPEC##Storage *storage)    \
   {                                                                     \
     return THFile_read##TYPEC##Raw(self, storage->data, storage->size); \
   }                                                                     \
                                                                         \
-  long THFile_write##TYPEC(THFile *self, TH##TYPEC##Storage *storage)   \
+  size_t THFile_write##TYPEC(THFile *self, TH##TYPEC##Storage *storage)   \
   {                                                                     \
     return THFile_write##TYPEC##Raw(self, storage->data, storage->size); \
   }

--- a/lib/TH/THFile.h
+++ b/lib/TH/THFile.h
@@ -39,45 +39,45 @@ TH_API void THFile_writeFloatScalar(THFile *self, float scalar);
 TH_API void THFile_writeDoubleScalar(THFile *self, double scalar);
 
 /* storage */
-TH_API long THFile_readByte(THFile *self, THByteStorage *storage);
-TH_API long THFile_readChar(THFile *self, THCharStorage *storage);
-TH_API long THFile_readShort(THFile *self, THShortStorage *storage);
-TH_API long THFile_readInt(THFile *self, THIntStorage *storage);
-TH_API long THFile_readLong(THFile *self, THLongStorage *storage);
-TH_API long THFile_readFloat(THFile *self, THFloatStorage *storage);
-TH_API long THFile_readDouble(THFile *self, THDoubleStorage *storage);
+TH_API size_t THFile_readByte(THFile *self, THByteStorage *storage);
+TH_API size_t THFile_readChar(THFile *self, THCharStorage *storage);
+TH_API size_t THFile_readShort(THFile *self, THShortStorage *storage);
+TH_API size_t THFile_readInt(THFile *self, THIntStorage *storage);
+TH_API size_t THFile_readLong(THFile *self, THLongStorage *storage);
+TH_API size_t THFile_readFloat(THFile *self, THFloatStorage *storage);
+TH_API size_t THFile_readDouble(THFile *self, THDoubleStorage *storage);
 
-TH_API long THFile_writeByte(THFile *self, THByteStorage *storage);
-TH_API long THFile_writeChar(THFile *self, THCharStorage *storage);
-TH_API long THFile_writeShort(THFile *self, THShortStorage *storage);
-TH_API long THFile_writeInt(THFile *self, THIntStorage *storage);
-TH_API long THFile_writeLong(THFile *self, THLongStorage *storage);
-TH_API long THFile_writeFloat(THFile *self, THFloatStorage *storage);
-TH_API long THFile_writeDouble(THFile *self, THDoubleStorage *storage);
+TH_API size_t THFile_writeByte(THFile *self, THByteStorage *storage);
+TH_API size_t THFile_writeChar(THFile *self, THCharStorage *storage);
+TH_API size_t THFile_writeShort(THFile *self, THShortStorage *storage);
+TH_API size_t THFile_writeInt(THFile *self, THIntStorage *storage);
+TH_API size_t THFile_writeLong(THFile *self, THLongStorage *storage);
+TH_API size_t THFile_writeFloat(THFile *self, THFloatStorage *storage);
+TH_API size_t THFile_writeDouble(THFile *self, THDoubleStorage *storage);
 
 /* raw */
-TH_API long THFile_readByteRaw(THFile *self, unsigned char *data, long n);
-TH_API long THFile_readCharRaw(THFile *self, char *data, long n);
-TH_API long THFile_readShortRaw(THFile *self, short *data, long n);
-TH_API long THFile_readIntRaw(THFile *self, int *data, long n);
-TH_API long THFile_readLongRaw(THFile *self, long *data, long n);
-TH_API long THFile_readFloatRaw(THFile *self, float *data, long n);
-TH_API long THFile_readDoubleRaw(THFile *self, double *data, long n);
-TH_API long THFile_readStringRaw(THFile *self, const char *format, char **str_); /* you must deallocate str_ */
+TH_API size_t THFile_readByteRaw(THFile *self, unsigned char *data, size_t n);
+TH_API size_t THFile_readCharRaw(THFile *self, char *data, size_t n);
+TH_API size_t THFile_readShortRaw(THFile *self, short *data, size_t n);
+TH_API size_t THFile_readIntRaw(THFile *self, int *data, size_t n);
+TH_API size_t THFile_readLongRaw(THFile *self, long *data, size_t n);
+TH_API size_t THFile_readFloatRaw(THFile *self, float *data, size_t n);
+TH_API size_t THFile_readDoubleRaw(THFile *self, double *data, size_t n);
+TH_API size_t THFile_readStringRaw(THFile *self, const char *format, char **str_); /* you must deallocate str_ */
 
-TH_API long THFile_writeByteRaw(THFile *self, unsigned char *data, long n);
-TH_API long THFile_writeCharRaw(THFile *self, char *data, long n);
-TH_API long THFile_writeShortRaw(THFile *self, short *data, long n);
-TH_API long THFile_writeIntRaw(THFile *self, int *data, long n);
-TH_API long THFile_writeLongRaw(THFile *self, long *data, long n);
-TH_API long THFile_writeFloatRaw(THFile *self, float *data, long n);
-TH_API long THFile_writeDoubleRaw(THFile *self, double *data, long n);
-TH_API long THFile_writeStringRaw(THFile *self, const char *str, long size);
+TH_API size_t THFile_writeByteRaw(THFile *self, unsigned char *data, size_t n);
+TH_API size_t THFile_writeCharRaw(THFile *self, char *data, size_t n);
+TH_API size_t THFile_writeShortRaw(THFile *self, short *data, size_t n);
+TH_API size_t THFile_writeIntRaw(THFile *self, int *data, size_t n);
+TH_API size_t THFile_writeLongRaw(THFile *self, long *data, size_t n);
+TH_API size_t THFile_writeFloatRaw(THFile *self, float *data, size_t n);
+TH_API size_t THFile_writeDoubleRaw(THFile *self, double *data, size_t n);
+TH_API size_t THFile_writeStringRaw(THFile *self, const char *str, size_t size);
 
 TH_API void THFile_synchronize(THFile *self);
-TH_API void THFile_seek(THFile *self, long position);
+TH_API void THFile_seek(THFile *self, size_t position);
 TH_API void THFile_seekEnd(THFile *self);
-TH_API long THFile_position(THFile *self);
+TH_API size_t THFile_position(THFile *self);
 TH_API void THFile_close(THFile *self);
 TH_API void THFile_free(THFile *self);
 

--- a/lib/TH/THFilePrivate.h
+++ b/lib/TH/THFilePrivate.h
@@ -16,28 +16,28 @@ struct THFileVTable
 {
     int (*isOpened)(THFile *self);
 
-    long (*readByte)(THFile *self, unsigned char *data, long n);
-    long (*readChar)(THFile *self, char *data, long n);
-    long (*readShort)(THFile *self, short *data, long n);
-    long (*readInt)(THFile *self, int *data, long n);
-    long (*readLong)(THFile *self, long *data, long n);
-    long (*readFloat)(THFile *self, float *data, long n);
-    long (*readDouble)(THFile *self, double *data, long n);
-    long (*readString)(THFile *self, const char *format, char **str_);
+    size_t (*readByte)(THFile *self, unsigned char *data, size_t n);
+    size_t (*readChar)(THFile *self, char *data, size_t n);
+    size_t (*readShort)(THFile *self, short *data, size_t n);
+    size_t (*readInt)(THFile *self, int *data, size_t n);
+    size_t (*readLong)(THFile *self, long *data, size_t n);
+    size_t (*readFloat)(THFile *self, float *data, size_t n);
+    size_t (*readDouble)(THFile *self, double *data, size_t n);
+    size_t (*readString)(THFile *self, const char *format, char **str_);
 
-    long (*writeByte)(THFile *self, unsigned char *data, long n);
-    long (*writeChar)(THFile *self, char *data, long n);
-    long (*writeShort)(THFile *self, short *data, long n);
-    long (*writeInt)(THFile *self, int *data, long n);
-    long (*writeLong)(THFile *self, long *data, long n);
-    long (*writeFloat)(THFile *self, float *data, long n);
-    long (*writeDouble)(THFile *self, double *data, long n);
-    long (*writeString)(THFile *self, const char *str, long size);
+    size_t (*writeByte)(THFile *self, unsigned char *data, size_t n);
+    size_t (*writeChar)(THFile *self, char *data, size_t n);
+    size_t (*writeShort)(THFile *self, short *data, size_t n);
+    size_t (*writeInt)(THFile *self, int *data, size_t n);
+    size_t (*writeLong)(THFile *self, long *data, size_t n);
+    size_t (*writeFloat)(THFile *self, float *data, size_t n);
+    size_t (*writeDouble)(THFile *self, double *data, size_t n);
+    size_t (*writeString)(THFile *self, const char *str, size_t size);
 
     void (*synchronize)(THFile *self);
-    void (*seek)(THFile *self, long position);
+    void (*seek)(THFile *self, size_t position);
     void (*seekEnd)(THFile *self);
-    long (*position)(THFile *self);
+    size_t (*position)(THFile *self);
     void (*close)(THFile *self);
     void (*free)(THFile *self);
 };


### PR DESCRIPTION
When tensors size starts to exceed around 4GB the type long can’t hold this size anymore and torch.save/torch.load act unpredictably (due to the underlying c functions - fwrite etc). Reproduced when using convolutional neural networks for big image processing.