### PR TITLE
Use proper precision for accumulators in multinomial

### DIFF
--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -93,7 +93,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
   for (i=0; i<n_dist; i++)
   {
     /* Get normalized cumulative distribution from prob distribution */
-    real sum = 0;
+    accreal sum = 0;
     for (j=0; j<n_categories; j++)
     {
       sum += THStorage_(get)( \
@@ -160,7 +160,7 @@ void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTenso
         /* update cumulative distribution so that sample cannot be drawn again */
         real diff;
         real new_val = 0;
-        real sum;
+        accreal sum;
 
         if (sample_idx != 0)
         {


### PR DESCRIPTION
This fixes #418 by setting the accumulators to the proper type as suggested by @andresy 

The following code is now working as expected with `FloatTensor`s

```lua
do
p = torch.FloatTensor(100000):fill(1)
p:narrow(1, 50000 + 1, 50000):fill(1e-3)
p:div(p:sum())
N = 1001000

n = 0
c = torch.LongTensor(p:nElement()):zero()
c_ptr = c:data() - 1
tmp = torch.LongTensor()
for i = 1, 100 do
p.multinomial(tmp, p, N, true);
n = n + N
tmp:apply(function(i) c_ptr[i] = c_ptr[i] + 1 end)
end

actual = c:narrow(1, 50001, 50000):sum()
expected = n*p:narrow(1, 50001, 50000):sum()
print(actual, expected)
end
```