### PR TITLE
tensor:free() should only free underlying storage.

### DIFF
--- a/doc/tensor.md
+++ b/doc/tensor.md
@@ -1570,7 +1570,7 @@ The source `tensor` should have at least as many elements as the number of 1s in
 ```lua
 x = torch.range(1,4):double():resize(2,2)
 > x
- 1  2  
+ 1  2
  3  4
 [torch.DoubleTensor of dimension 2x4]
 
@@ -1959,7 +1959,7 @@ y = torch.Tensor(2,2)
 Returns a tensor where dimensions `dim1` and `dim2` have been swapped. For 2D tensors,
 the convenience method of [t()](#torch.Tensor.t) is available.
 ```lua
-x = torch.Tensor(3,4):zero()                  
+x = torch.Tensor(3,4):zero()
 x:select(2,3):fill(7) -- fill column 3 with 7
 > x
  0  0  7  0
@@ -2392,3 +2392,13 @@ Increment the reference counter of the tensor.
 
 Decrement the reference counter of the tensor. Free the tensor if the
 counter is at 0.
+
+<a name="torch.Tensor.empty"></a>
+### empty() ###
+
+Empty the tensor, i.e. free the underlying storage and resize the tensor
+to nil. After this call, the tensor is in a state equivalent to
+`tensor = torch.Tensor()`.
+
+If the underlying storage is only referenced by this tensor, then
+the memory referenced by the storage is released immediatly.

--- a/generic/Tensor.c
+++ b/generic/Tensor.c
@@ -1004,6 +1004,28 @@ static int torch_Tensor_(free)(lua_State *L)
   return 0;
 }
 
+static int torch_Tensor_(empty)(lua_State *L)
+{
+  THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
+
+  THLongStorage *size = THLongStorage_newWithSize(8);
+  THLongStorage *stride = THLongStorage_newWithSize(8);
+  THLongStorage_fill(size, -1);
+  THLongStorage_fill(stride, -1);
+
+  THTensor_(resize)(tensor, size, stride);
+
+  THLongStorage_free(size);
+  THLongStorage_free(stride);
+
+  if(tensor->storage) {
+    THStorage_(free)(tensor->storage);
+    tensor->storage = NULL;
+  }
+
+  return 0;
+}
+
 /* helpful functions */
 static void torch_Tensor_(c_readSizeStride)(lua_State *L, int index, int allowStride, THLongStorage **size_, THLongStorage **stride_)
 {
@@ -1259,6 +1281,7 @@ static int torch_Tensor_(read)(lua_State *L)
 static const struct luaL_Reg torch_Tensor_(_) [] = {
   {"retain", torch_Tensor_(retain)},
   {"free", torch_Tensor_(free)},
+  {"empty", torch_Tensor_(empty)},
   {"contiguous", torch_Tensor_(contiguous)},
   {"size", torch_Tensor_(size)},
   {"elementSize", torch_Tensor_(elementSize)},


### PR DESCRIPTION
In Lua, explicitly calling `:free()` on a Tensor is currently buggy - it actually frees the THTensor struct itself  in C, making any future reference to it invalid (leading to segfaults). This patch makes `:free()` only act on the referenced storage, but preserves the THTensor struct intact (and also maintains the ref counter to 1) — the result: the user can free a tensor-referenced storage from Lua, but the THTensor struct itself will always be handled by the GC. 