### PR TITLE
Fixed unsigned overflows in THFile

### DIFF
--- a/lib/TH/THFile.c
+++ b/lib/TH/THFile.c
@@ -11,7 +11,7 @@
   {                                                               \
     return (*self->vtable->write##TYPEC)(self, data, n);          \
   }
-  
+
 IMPLEMENT_THFILE_RW(Byte, unsigned char)
 IMPLEMENT_THFILE_RW(Char, char)
 IMPLEMENT_THFILE_RW(Short, short)


### PR DESCRIPTION
Several days ago there was a commit that replaced `long` with `size_t` in THFile, THDiskFile and THMemoryFile. Because it is an unsigned type an overflow happened in several places. This commit fixes it.