### PR TITLE
[doc] math expression fix

### DIFF
--- a/doc/random.md
+++ b/doc/random.md
@@ -65,7 +65,7 @@ Returns an unsigned 32 bit integer random number.
 <a name="torch.uniform"></a>
 ### [number] uniform([a],[b]) ###
 
-Returns a random real number according to uniform distribution on [a,b]. By default `a` is 0 and `b` is 1.
+Returns a random real number according to uniform distribution on [a,b). By default `a` is 0 and `b` is 1.
 
 <a name="torch.normal"></a>
 ### [number] normal([mean],[stdv]) ###


### PR DESCRIPTION
at #450 bamos pointed out that open bracket `[a,b[` is actually correct here  [(the code)](https://github.com/torch/torch7/blob/master/lib/TH/THRandom.c#L203).

I just changed it to `[a,b)` for better intuition 