### PR TITLE
not defining DLL_EXPORT by default

### DIFF
--- a/init.c
+++ b/init.c
@@ -35,7 +35,7 @@ extern void torch_DoubleTensorOperator_init(lua_State *L);
 
 extern void torch_TensorMath_init(lua_State *L);
 
-LUA_EXTERNC DLL_EXPORT int luaopen_libtorch(lua_State *L);
+LUAT_API int luaopen_libtorch(lua_State *L);
 
 int luaopen_libtorch(lua_State *L)
 {

--- a/lib/luaT/luaT.h
+++ b/lib/luaT/luaT.h
@@ -27,8 +27,6 @@ extern "C" {
 #  define LUAT_API LUA_EXTERNC DLL_IMPORT
 # endif
 #else
-# define DLL_EXPORT
-# define DLL_IMPORT
 # define LUAT_API LUA_EXTERNC
 #endif
 


### PR DESCRIPTION
DLL_EXPORT is defined by default to be empty, if not windows. DLL_EXPORT can be used by other buil d systems, so this is not correct, as pointed out by @tudor 

If this looks okay, I'll fix the instances using DLL_EXPORT to LUAT_API

``` C
./extra/audio/audio.c:DLL_EXPORT int luaopen_libaudio(lua_State *L)
./extra/audio/generic/sox.c:DLL_EXPORT int libsox_(Main_init)(lua_State *L)
./extra/audio/sox.c:DLL_EXPORT int luaopen_libsox(lua_State *L)
./extra/cunn/init.cu:LUA_EXTERNC DLL_EXPORT int luaopen_libcunn(lua_State *L);
./extra/cunnx/init.cu:LUA_EXTERNC DLL_EXPORT int luaopen_libcunnx(lua_State *L);
./extra/cutorch/init.c:LUA_EXTERNC DLL_EXPORT int luaopen_libcutorch(lua_State *L);
./extra/nn/init.c:LUA_EXTERNC DLL_EXPORT int luaopen_libnn(lua_State *L);
./extra/nnx/init.c:DLL_EXPORT int luaopen_libnnx(lua_State *L)
./install/include/luaT.h:# define DLL_EXPORT __declspec(dllexport)
./install/include/luaT.h:#  define LUAT_API LUA_EXTERNC DLL_EXPORT
./install/include/luaT.h:# define DLL_EXPORT
./pkg/image/generic/jpeg.c:DLL_EXPORT int libjpeg_(Main_init)(lua_State *L)
./pkg/image/generic/png.c:DLL_EXPORT int libpng_(Main_init)(lua_State *L)
./pkg/image/generic/ppm.c:DLL_EXPORT int libppm_(Main_init)(lua_State *L)
./pkg/image/image.c:DLL_EXPORT int luaopen_libimage(lua_State *L)
./pkg/image/jpeg.c:DLL_EXPORT int luaopen_libjpeg(lua_State *L)
./pkg/image/png.c:DLL_EXPORT int luaopen_libpng(lua_State *L)
./pkg/image/ppm.c:DLL_EXPORT int luaopen_libppm(lua_State *L)
./pkg/torch/init.c:LUA_EXTERNC DLL_EXPORT int luaopen_libtorch(lua_State *L);
./pkg/torch/lib/luaT/luaT.h:# define DLL_EXPORT __declspec(dllexport)
./pkg/torch/lib/luaT/luaT.h:#  define LUAT_API LUA_EXTERNC DLL_EXPORT
./pkg/torch/lib/luaT/luaT.h:# define DLL_EXPORT
```
