### PR TITLE
Typo in documentation

### DIFF
--- a/doc/utility.md
+++ b/doc/utility.md
@@ -127,11 +127,11 @@ Checks if `object` has a metatable. If it does, and if it corresponds to a
 class. Returns `nil` in any other cases.
 
 ```lua
-> torch.type(torch.Tensor())
+> torch.typename(torch.Tensor())
 torch.DoubleTensor
-> torch.type({})
+> torch.typename({})
 
-> torch.type(7)
+> torch.typename(7)
 
 ```
 


### PR DESCRIPTION
Change torch.type -> torch.typename in corresponding example.