### PR TITLE
Make nBufferWritten signed for writing longs

### DIFF
--- a/lib/TH/THMemoryFile.c
+++ b/lib/TH/THMemoryFile.c
@@ -479,7 +479,7 @@ static size_t THMemoryFile_writeLong(THFile *self, long *data, size_t n)
     size_t i;
     for(i = 0; i < n; i++)
     {
-      size_t nByteWritten;
+      ssize_t nByteWritten;
       while (1)
       {
         nByteWritten = snprintf(mfself->storage->data+mfself->position, mfself->storage->size-mfself->position, "%ld", data[i]);


### PR DESCRIPTION
Comparison on line 486 (nBufferWritten > -1) sometime fails when size_t resolves to unsigned int. 