### PR TITLE
Adding argmax index as second return value to max/min calls without specified dimension

### DIFF
--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1244,7 +1244,7 @@ Example:
 <a name="torch.max"></a>
 ### torch.max([resval, resind,] x [,dim]) ###
 
-`y = torch.max(x)` returns the single largest element of `x`.
+`y, i = torch.max(x)` returns the single largest element of `x`, and a `Tensor` `i` of its corresponding indices in `x`.
 
 `y, i = torch.max(x, 1)` returns the largest element in each column (across rows) of `x`, and a `Tensor` `i` of their corresponding indices in `x`.
 
@@ -1298,7 +1298,7 @@ Example:
 <a name="torch.min"></a>
 ### torch.min([resval, resind,] x [,dim]) ###
 
-`y = torch.min(x)` returns the single smallest element of `x`.
+`y, i = torch.min(x)` returns the single smallest element of `x`, and a `Tensor` `i` of its corresponding indices in `x`.
 
 `y, i = torch.min(x, 1)` returns the smallest element in each column (across rows) of `x`, and a `Tensor` `i` of their corresponding indices in `x`.
 

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -358,11 +358,24 @@ accreal THTensor_(dot)(THTensor *tensor, THTensor *src)
   return sum;
 }
 
-real THTensor_(minall)(THTensor *tensor)
-{
-  real theMin;
-  real value;
+void THTensor_(flatIndexToFullIndex)(long ind, long *index_data, long nDim, long *sizes){
+    long total = 1;
+    long i;
+    for (i = 0; i < nDim; i++){
+      total = total * sizes[i];
+    }
+    for (i = 0; i < nDim; i++){
+      total = total / sizes[i];
+      index_data[i] = ind / total;
+      ind = ind - (index_data[i]) * total;
+    }
+}
 
+real THTensor_(minall)(THLongTensor *index, THTensor *tensor)
+{
+  real value;
+  real theMin;
+  long theIndex = 0;
   THArgCheck(tensor->nDimension > 0, 1, "tensor must have one dimension");
   theMin = THTensor_(data)(tensor)[0];
   TH_TENSOR_APPLY(real, tensor,
@@ -371,28 +384,44 @@ real THTensor_(minall)(THTensor *tensor)
                   if(!(value >= theMin))
                   {
                     theMin = value;
+                    theIndex = tensor_i;
                     if (isnan(value))
                       break;
                   });
+
+  if(index != NULL){
+    THLongTensor_resize1d(index, tensor->nDimension);
+    long *index_data = THLongTensor_data(index);
+    long nDimensions = THLongTensor_nElement(index);
+    THTensor_(flatIndexToFullIndex)(theIndex, index_data, nDimensions, tensor->size);
+  }
   return theMin;
 }
 
-real THTensor_(maxall)(THTensor *tensor)
+real THTensor_(maxall)(THLongTensor *index, THTensor *tensor)
 {
-  real theMax;
   real value;
-
+  real theMax;
+  long theIndex = 0;
   THArgCheck(tensor->nDimension > 0, 1, "tensor must have one dimension");
   theMax = THTensor_(data)(tensor)[0];
   TH_TENSOR_APPLY(real, tensor,
                   value = *tensor_data;
-                  /* This is not the same as value>theMax in the case of NaNs */
+                  /* This is not the same as value<theMax in the case of NaNs */
                   if(!(value <= theMax))
                   {
                     theMax = value;
+                    theIndex = tensor_i;
                     if (isnan(value))
                       break;
                   });
+
+  if(index != NULL){
+    THLongTensor_resize1d(index, tensor->nDimension);
+    long *index_data = THLongTensor_data(index);
+    long nDimensions = THLongTensor_nElement(index);
+    THTensor_(flatIndexToFullIndex)(theIndex, index_data, nDimensions, tensor->size);
+  }
   return theMax;
 }
 
@@ -2299,8 +2328,8 @@ void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalu
   maxval = maxvalue;
   if (minval == maxval)
   {
-    minval = THTensor_(minall)(tensor);
-    maxval = THTensor_(maxall)(tensor);
+    minval = THTensor_(minall)(NULL, tensor);
+    maxval = THTensor_(maxall)(NULL, tensor);
   }
   if (minval == maxval)
   {

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -24,8 +24,10 @@ TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *inde
 
 TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 
-TH_API real THTensor_(minall)(THTensor *t);
-TH_API real THTensor_(maxall)(THTensor *t);
+TH_API void THTensor_(flatIndexToFullIndex)(long ind, long *index_data, long nDim, long *sizes);
+TH_API real THTensor_(minall)(THLongTensor *index, THTensor *tensor);
+TH_API real THTensor_(maxall)(THLongTensor *index, THTensor *tensor);
+
 TH_API accreal THTensor_(sumall)(THTensor *t);
 TH_API accreal THTensor_(prodall)(THTensor *t);
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -319,6 +319,23 @@ function torchtest.max()  -- torch.max([resval, resind,] x [,dim])
       local res1val = torch.max(m1)
       mytester:assert(res1val ~= res1val, 'error in torch.max - NaNs')
    end
+   -- Argmax for full tensor
+   for _, t in pairs{torch.Tensor(2, 3, 4, 500):random(),
+                    torch.Tensor(1, 3, 1, 5, 500):random(),
+                    torch.Tensor(12, 1, 1, 500, 1):random(),
+                    torch.FloatTensor(3, 1, 500):random(),
+                    torch.FloatTensor(12, 1, 500):random(),
+                    torch.FloatTensor(3, 5, 500):random(),
+                    torch.IntTensor(12, 500):random(),
+                    torch.IntTensor(3):random(),
+                    torch.IntTensor(13, 500):random(),
+                    torch.ByteTensor(33, 43, 500):random(),
+                    torch.ByteTensor(500):random(),
+                    torch.ByteTensor(1):random()} do
+      local max, argmax = t:max()
+      mytester:assert(max == t[argmax:storage()], 'error in torch.min (argmin) - Argmin')
+   end
+
 end
 
 function torchtest.min()  -- torch.min([resval, resind,] x [,dim])
@@ -387,6 +404,23 @@ function torchtest.min()  -- torch.min([resval, resind,] x [,dim])
       local res1val = torch.min(m1)
       mytester:assert(res1val ~= res1val, 'error in torch.min - NaNs')
    end
+      -- Argmin for full tensor
+   for _, t in pairs{torch.Tensor(2, 3, 4, 500):random(),
+                    torch.Tensor(1, 3, 1, 5, 500):random(),
+                    torch.Tensor(12, 1, 1, 500, 1):random(),
+                    torch.FloatTensor(3, 1, 500):random(),
+                    torch.FloatTensor(12, 1, 500):random(),
+                    torch.FloatTensor(3, 5, 500):random(),
+                    torch.IntTensor(12, 500):random(),
+                    torch.IntTensor(3):random(),
+                    torch.IntTensor(13, 500):random(),
+                    torch.ByteTensor(33, 43, 500):random(),
+                    torch.ByteTensor(500):random(),
+                    torch.ByteTensor(1):random()} do
+      local min, argmin = t:min()
+      mytester:assert(min == t[argmin:storage()], 'error in torch.min (argmin) - Argmin')
+   end
+
 end
 
 function torchtest.cmax()


### PR DESCRIPTION
This makes a number of changes to both lua and C code to facilitate the second return value of a torch.max(input) call without specified dimension to be a LongTensor(default) that gives the indeces of the argmax of an input tensor. The C interface for the relevant functions(THTensor_(minall)/(maxall)) is changed and therefore it is not backward compatible (e.g. see line 2274 @ lib/TH/generic/THTensorMath.c). We can keep the original functions if requested in which case C interface would be compatible with earlier versions as well. 