### PR TITLE
k-selection implementation: torch.topk

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -78,7 +78,7 @@ static int torch_NAME(lua_State *L)
   }
   else if(!(tname = torch_istensortype(L, torch_getdefaulttensortype(L))))
     luaL_error(L, "internal error: the default tensor type does not seem to be an actual tensor");
-  
+
   lua_pushstring(L, "NAME");
   lua_rawget(L, -2);
   if(lua_isfunction(L, -1))
@@ -104,7 +104,7 @@ function interface:dispatchregister(name)
    end
    table.insert(txt, '{NULL, NULL}')
    table.insert(txt, '};')
-   table.insert(txt, '')   
+   table.insert(txt, '')
    self.dispatchregistry = {}
 end
 
@@ -183,11 +183,11 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
                 return string.format("TH%s_nDimension(arg%d_data[0])", Tensor, arg.args[argn].i)
              end
    end
-   
+
    wrap("zero",
         cname("zero"),
         {{name=Tensor, returned=true}})
-   
+
    wrap("fill",
         cname("fill"),
         {{name=Tensor, returned=true},
@@ -243,7 +243,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor},
          {name=Tensor},
          {name=accreal, creturned=true}})
-   
+
    wrap("add",
         cname("add"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -277,7 +277,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
          {name=Tensor, method={default=1}},
          {name=real}})
-  
+
    wrap("clamp",
         cname("clamp"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -495,7 +495,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name="index"}})
-   
+
    for _,name in ipairs({"min", "max"}) do
       wrap(name,
            cname(name .. "all"),
@@ -524,26 +524,26 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         cname("trace"),
         {{name=Tensor},
          {name=accreal, creturned=true}})
-   
+
    wrap("cross",
         cname("cross"),
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name=Tensor},
          {name="index", default=0}})
-   
+
    wrap("diag",
         cname("diag"),
         {{name=Tensor, default=true, returned=true},
          {name=Tensor},
          {name="long", default=0}})
-   
+
    wrap("eye",
         cname("eye"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
          {name="long"},
          {name="long", default=0}})
-   
+
    wrap("range",
         cname("range"),
         {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -571,6 +571,16 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
          {name=Tensor},
          {name="index", default=lastdim(3)},
          {name="boolean", default=0}})
+
+wrap("topk",
+     cname("topk"),
+     {{name=Tensor, default=true, returned=true},
+        {name="IndexTensor", default=true, returned=true, noreadadd=true},
+        {name=Tensor},
+        {name="long", default=1},
+        {name="index", default=lastdim(3)},
+        {name="boolean", default=0},
+        {name="boolean", default=0}})
 
    wrap("kthvalue",
         cname("kthvalue"),
@@ -616,7 +626,7 @@ for _,Tensor in ipairs({"ByteTensor", "CharTensor",
         {{name=Tensor, default=true, returned=true},
          {name=Tensor .. "Array"},
          {name="index", default=lastdimarray(2)}})
-   
+
    if Tensor == 'ByteTensor' then -- we declare this only once
       interface:print(
          [[
@@ -625,7 +635,7 @@ static long THRandom_random2__(THGenerator *gen, long a, long b)
   THArgCheck(b >= a, 2, "upper bound must be larger than lower bound");
   return((THRandom_random(gen) % (b+1-a)) + a);
 }
-         
+
 static long THRandom_random1__(THGenerator *gen, long b)
 {
   THArgCheck(b > 0, 1, "upper bound must be strictly positive");
@@ -677,7 +687,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
 
    for _,f in ipairs({{name='geometric'},
                       {name='bernoulli', a=0.5}}) do
-      
+
       wrap(f.name,
            string.format("THRandom_%s", f.name),
            {{name='Generator', default=true},
@@ -928,7 +938,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
            {{name=Tensor, default=true, returned=true},
             {name=Tensor},
             {name="index"}})
-      
+
       for _,name in ipairs({"var", "std"}) do
          wrap(name,
               cname(name .. "all"),
@@ -958,7 +968,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=Tensor},
             {name=real},
             {name="index"}})
-            
+
       wrap("renorm",
            cname("renorm"),
            {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -966,14 +976,14 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=real},
             {name="index"},
             {name=real}})
-      
+
       wrap("dist",
            cname("dist"),
            {{name=Tensor},
             {name=Tensor},
             {name=real, default=2},
             {name=accreal, creturned=true}})
-      
+
       wrap("linspace",
            cname("linspace"),
            {{name=Tensor, default=true, returned=true, method={default='nil'}},
@@ -987,7 +997,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name=real},
             {name=real},
             {name="long", default=100}})
-      
+
       for _,name in ipairs({"log", "log1p", "exp",
                             "cos", "acos", "cosh",
                             "sin", "asin", "sinh",
@@ -996,14 +1006,14 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
                             "round", "ceil", "floor"}) do
                             --"abs"}) do
 
-         wrap(name, 
+         wrap(name,
               cname(name),
               {{name=Tensor, default=true, returned=true, method={default='nil'}},
                {name=Tensor, method={default=1}}},
               name,
               {{name=real},
                {name=real, creturned=true}})
-         
+
       end
          wrap("abs",
               cname("abs"),
@@ -1054,20 +1064,20 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
            {{name=Tensor, default=true, returned=true, method={default='nil'}},
             {name='Generator', default=true},
             {name="LongArg"}})
-            
+
       wrap("multinomial",
            cname("multinomial"),
            {{name="IndexTensor", default=true, returned=true, method={default='nil'}},
             {name='Generator', default=true},
-            {name=Tensor}, 
-            {name="int"}, 
+            {name=Tensor},
+            {name="int"},
             {name="boolean", default=false}})
-      
+
       for _,f in ipairs({{name='uniform', a=0, b=1},
                          {name='normal', a=0, b=1},
                          {name='cauchy', a=0, b=1},
                          {name='logNormal', a=1, b=2}}) do
-         
+
          wrap(f.name,
               string.format("THRandom_%s", f.name),
               {{name='Generator', default=true},
@@ -1082,7 +1092,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
       end
 
       for _,f in ipairs({{name='exponential'}}) do
-         
+
          wrap(f.name,
               string.format("THRandom_%s", f.name),
               {{name='Generator', default=true},
@@ -1093,7 +1103,7 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
                {name='Generator', default=true},
                {name=real, default=f.a}})
       end
-      
+
       for _,name in ipairs({"gesv","gels"}) do
          interface:wrap(name,
                         cname(name),

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -1534,6 +1534,18 @@ It also returns a `Tensor` `i` that provides the corresponding indices from `x`.
 [torch.LongTensor of size 3x3]
 ```
 
+<a name="torch.topk"></a>
+### torch.topk([resval, resind,] x, k, [,dim] [,dir] [,sort]) ###
+
+`y, i = torch.topk(x, k)` returns all `k` smallest elements in `x` over its last dimension including their indices, in unsorted order.
+
+`y, i = torch.topk(x, k, dim)` performs the same operation except over dimension `dim`.
+
+`y, i = torch.topk(x, k, dim, dir)` adds a sorting direction that has the same sense as `torch.sort`; `false` returns the `k` smallest elements in the slice, `true` returns the `k` largest elements in the slice.
+
+`y, i = torch.topk(x, k, dim, dir, true)` specifies that the results in `y` should be sorted with respect to `dir`; by default, the results are potentially unsorted since the computation may be faster, but if sorting is desired, the sort flag may be passed, in which case the results are returned from smallest to `k`-th smallest (`dir == false`) or highest to `k`-th highest (`dir == true`).
+
+The implementation provides no guarantee of the order of selection (indices) among equivalent elements (e.g., topk `k == 2` selection of a vector `{1, 2, 1, 1}`; the values returned could be any pair of `1` entries in the vector).
 
 <a name="torch.std"></a>
 ### [res] torch.std([res,] x, [,dim] [,flag]) ###

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1746,6 +1746,32 @@ void THTensor_(median)(THTensor *values_, THLongTensor *indices_, THTensor *t, i
   THTensor_(kthvalue)(values_, indices_, t, k, dimension);
 }
 
+void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, long k, int dim, int dir, int sorted)
+{
+  int numDims = THTensor_(nDimension)(t);
+  THArgCheck(dim >= 0 && dim < numDims, 3, "dim not in range");
+
+  long sliceSize = THTensor_(size)(t, dim);
+  THArgCheck(k > 0 && k <= sliceSize, 2, "k not in range for dimension");
+
+  /* Just implement in terms of sort and narrow for now */
+  THTensor* tmpResults = THTensor_(new)();
+  THLongTensor* tmpIndices = THLongTensor_new();
+
+  THLongStorage* topKSize = THTensor_(newSizeOf)(t);
+  THLongStorage_set(topKSize, dim, k);
+  THTensor_(resize)(rt_, topKSize, NULL);
+  THLongTensor_resize(ri_, topKSize, NULL);
+  THLongStorage_free(topKSize);
+
+  THTensor_(sort)(tmpResults, tmpIndices, t, dim, dir);
+  THTensor_(narrow)(tmpResults, NULL, dim, 0, k);
+  THLongTensor_narrow(tmpIndices, NULL, dim, 0, k);
+
+  THTensor_(freeCopyTo)(tmpResults, rt_);
+  THLongTensor_freeCopyTo(tmpIndices, ri_);
+}
+
 void THTensor_(tril)(THTensor *r_, THTensor *t, long k)
 {
   long t_size_0, t_size_1;

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -83,6 +83,7 @@ TH_API void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, long n);
 
 TH_API void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size);
 TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder);
+TH_API void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, long k, int dim, int dir, int sorted);
 TH_API void THTensor_(tril)(THTensor *r_, THTensor *t, long k);
 TH_API void THTensor_(triu)(THTensor *r_, THTensor *t, long k);
 TH_API void THTensor_(cat)(THTensor *r_, THTensor *ta, THTensor *tb, int dimension);


### PR DESCRIPTION
This is an implementation of k-selection: returning the `k` highest or lowest values in a selected dimension.

For sorted results, it is functionally equivalent to:

```
local function topKViaSort(t, k, dim, dir)
  local sorted, indices = t:sort(dim, dir)
  return sorted:narrow(dim, 1, k), indices:narrow(dim, 1, k)
end
```

This torch7 CPU implementation I provide here actually just maps to the above (in effect, always sorting the results). It could be improved to use selection to find the kth element and a second scan at some point.

I am adding this as a simple, albeit functional placeholder because I have an efficient, optimized GPU cutorch implementation of this based on radix selection. I need this in torch7 in order to allow the torch.topk() bindings to work. @soumith and @andresy are aware of my cutorch implementation internally; I will provide a cutorch pull request for CudaTensor topk as soon as I fix remaining issues with cutorch sort once and for all.
