### PR TITLE
fixing Cmdline:log to get the print function lazily

### DIFF
--- a/CmdLine.lua
+++ b/CmdLine.lua
@@ -187,9 +187,10 @@ function CmdLine:string(prefix, params, ignore)
    end
 end
 
-local oprint = print
+local oprint = nil
 function CmdLine:log(file, params)   
    local f = io.open(file, 'w')
+   oprint = oprint or print -- get the current print function lazily
    function print(...)
       local n = select("#", ...)
       local arg = {...}


### PR DESCRIPTION
fixes https://github.com/torch/torch7/issues/528