### PR TITLE
Fix for issue #517: torch.all

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1963,12 +1963,12 @@ LAB_IMPLEMENT_BASIC_FUNCTION(abs,abs)
   { \
     THArgCheck(tensor->nDimension > 0, 1, "empty Tensor"); \
     int sum = INIT_VALUE;                               \
-    TH_TENSOR_APPLY(real, tensor, sum OP *tensor_data;); \
+    TH_TENSOR_APPLY(real, tensor, sum = sum OP *tensor_data;); \
     return sum; \
   }
 
-TENSOR_IMPLEMENT_LOGICAL_SUM(logicalall, &=, 1)
-TENSOR_IMPLEMENT_LOGICAL_SUM(logicalany, |=, 0)
+TENSOR_IMPLEMENT_LOGICAL_SUM(logicalall, &&, 1)
+TENSOR_IMPLEMENT_LOGICAL_SUM(logicalany, ||, 0)
 
 #endif /* Byte only part */
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -439,6 +439,10 @@ for i, v in ipairs{{10}, {5, 5}} do
            x:zero()
            mytester:assert(not x:all(), 'error in all()')
            mytester:assert(not x:any(), 'error in any()')
+           
+           x:fill(2)
+           mytester:assert(x:all(), 'error in all()')
+           mytester:assert(x:any(), 'error in any()')
        end
 end
 


### PR DESCRIPTION
Fix for "torch.all only returns true if all numbers in the tensor are odd #517"