### PR TITLE
Improve memory cleanup handling and fix memory leaks

### DIFF
--- a/lib/TH/THGeneral.h.in
+++ b/lib/TH/THGeneral.h.in
@@ -57,13 +57,27 @@ TH_API void THSetGCHandler( void (*torchGCHandlerFunction)(void *data), void *da
 TH_API void THHeapUpdate(long size);
 
 #define THError(...) _THError(__FILE__, __LINE__, __VA_ARGS__)
-#define THArgCheck(...) _THArgCheck(__FILE__, __LINE__, __VA_ARGS__)
+
+#define THCleanup(...) __VA_ARGS__
+
+#define THArgCheck(...)                                               \
+do {                                                                  \
+  _THArgCheck(__FILE__, __LINE__, __VA_ARGS__);                       \
+} while(0)
+
+#define THArgCheckWithCleanup(condition, cleanup, ...)                \
+do if (!(condition)) {                                                \
+  cleanup                                                             \
+  _THArgCheck(__FILE__, __LINE__, 0, __VA_ARGS__);                    \
+} while(0)
+
 #define THAssert(exp)                                                 \
 do {                                                                  \
   if (!(exp)) {                                                       \
     _THAssertionFailed(__FILE__, __LINE__, #exp, "");                 \
   }                                                                   \
 } while(0)
+
 #define THAssertMsg(exp, ...)                                         \
 do {                                                                  \
   if (!(exp)) {                                                       \

--- a/lib/TH/THLapack.h
+++ b/lib/TH/THLapack.h
@@ -4,6 +4,7 @@
 #include "THGeneral.h"
 
 #define THLapack_(NAME) TH_CONCAT_4(TH,Real,Lapack_,NAME)
+
 #define THLapackCheck(fmt, func, info , ...)						\
 if (info < 0) {														\
   THError("Lapack Error in %s : Illegal Argument %d", func, -info); \
@@ -11,7 +12,14 @@ if (info < 0) {														\
   THError(fmt, func, info, ##__VA_ARGS__);							\
 }																	\
 
-
+#define THLapackCheckWithCleanup(fmt, cleanup, func, info , ...)    \
+if (info < 0) {                                                     \
+  cleanup                                                           \
+  THError("Lapack Error in %s : Illegal Argument %d", func, -info); \
+} else if(info > 0) {                                               \
+  cleanup                                                           \
+  THError(fmt, func, info, ##__VA_ARGS__);                          \
+}
 
 #include "generic/THLapack.h"
 #include "THGenerateAllTypes.h"

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -19,8 +19,16 @@ void THTensor_(zero)(THTensor *r_)
 void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, real value)
 {
   TH_TENSOR_APPLY2(real, tensor, unsigned char, mask,
-                   if (*mask_data > 1) THError("Mask tensor can take 0 and 1 values only");
-                   else if (*mask_data == 1) *tensor_data = value;);
+                   if (*mask_data > 1)
+                   {
+                     THFree(mask_counter);
+                     THFree(tensor_counter);
+                     THError("Mask tensor can take 0 and 1 values only");
+                   }
+                   else if (*mask_data == 1)
+                   {
+                     *tensor_data = value;
+                   });
 }
 
 void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src )
@@ -38,12 +46,17 @@ void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src )
                    if (*mask_data > 1)
                    {
                      THTensor_(free)(srct);
+                     THFree(mask_counter);
+                     THFree(tensor_counter);
                      THError("Mask tensor can take 0 and 1 values only");
                    }
                    else if (*mask_data == 1)
                    {
-                     if (cntr == nelem) {
+                     if (cntr == nelem)
+                     {
                        THTensor_(free)(srct);
+                       THFree(mask_counter);
+                       THFree(tensor_counter);
                        THError("Number of elements of src < number of ones in mask");
                      }
                      *tensor_data = *src_data;
@@ -63,6 +76,8 @@ void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask
   TH_TENSOR_APPLY2(real, src, unsigned char, mask,
                    if (*mask_data > 1)
                    {
+                     THFree(mask_counter);
+                     THFree(src_counter);
                      THError("Mask tensor can take 0 and 1 values only");
                    }
                    else if (*mask_data == 1)
@@ -298,7 +313,11 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
                        for (i = 0; i < elems_per_row; ++i)
                        {
                          idx = *(index_data + i*index_stride);
-                         if (idx < 1 || idx > src_size) THError("Invalid index in gather");
+                         if (idx < 1 || idx > src_size)
+                         {
+                           THFree(TH_TENSOR_DIM_APPLY_counter);
+                           THError("Invalid index in gather");
+                         }
                          *(tensor_data + i*tensor_stride) = src_data[(idx - 1) * src_stride];
                        })
 }
@@ -319,7 +338,11 @@ void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor
                        for (i = 0; i < elems_per_row; ++i)
                        {
                          idx = *(index_data + i*index_stride);
-                         if (idx < 1 || idx > tensor_size) THError("Invalid index in scatter");
+                         if (idx < 1 || idx > tensor_size)
+                         {
+                           THFree(TH_TENSOR_DIM_APPLY_counter);
+                           THError("Invalid index in scatter");
+                         }
                          tensor_data[(idx - 1) * tensor_stride] = *(src_data + i*src_stride);
                        })
 }
@@ -338,7 +361,11 @@ void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, real
                        for (i = 0; i < elems_per_row; ++i)
                        {
                          idx = *(index_data + i*index_stride);
-                         if (idx < 1 || idx > tensor_size) THError("Invalid index in scatter");
+                         if (idx < 1 || idx > tensor_size)
+                         {
+                           THFree(TH_TENSOR_DIM_APPLY_counter);
+                           THError("Invalid index in scatter");
+                         }
                          tensor_data[(idx - 1) * tensor_stride] = val;
                        })
 }


### PR DESCRIPTION
Two commits in this PR create a generic facility for passing cleanup code to various error macros that do not return. The third commit adds clean-up to various `APPLY` macro uses in `THTensorMath.c`.