### PR TITLE
Fixed a bug in TorchPackage macro arguments test

### DIFF
--- a/cmake/TorchPackage.cmake
+++ b/cmake/TorchPackage.cmake
@@ -2,9 +2,11 @@
 
 MACRO(ADD_TORCH_PACKAGE package src luasrc)
   INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+  INCLUDE_DIRECTORIES(${Torch_LUA_INCLUDE_DIR})
 
-  ### C/C++ sources
-  IF(src)      
+ ### C/C++ sources
+ # As per CMake doc, macro arguments are not variables, so simple test syntax not working
+  IF(NOT "${src}" STREQUAL "")
 
     ADD_LIBRARY(${package} MODULE ${src})
     if(BUILD_STATIC)
@@ -15,8 +17,9 @@ MACRO(ADD_TORCH_PACKAGE package src luasrc)
     SET_TARGET_PROPERTIES(${package} PROPERTIES
       PREFIX "lib"
       IMPORT_PREFIX "lib"
+      LINKER_LANGUAGE "C"
       INSTALL_NAME_DIR "@executable_path/${Torch_INSTALL_BIN2CPATH}")
-    
+
     IF(APPLE)
       SET_TARGET_PROPERTIES(${package} PROPERTIES
         LINK_FLAGS "-undefined dynamic_lookup")
@@ -32,13 +35,13 @@ MACRO(ADD_TORCH_PACKAGE package src luasrc)
     INSTALL(TARGETS ${package}
       RUNTIME DESTINATION ${Torch_INSTALL_LUA_CPATH_SUBDIR}
       LIBRARY DESTINATION ${Torch_INSTALL_LUA_CPATH_SUBDIR})
-    
-  ENDIF(src)
-  
+
+  ENDIF(NOT "${src}" STREQUAL "")
+
   ### lua sources
-  IF(luasrc)
-    INSTALL(FILES ${luasrc} 
+  IF(NOT "${luasrc}" STREQUAL "")
+    INSTALL(FILES ${luasrc}
       DESTINATION ${Torch_INSTALL_LUA_PATH_SUBDIR}/${package})
-  ENDIF(luasrc)
-    
+  ENDIF(NOT "${luasrc}" STREQUAL "")
+
 ENDMACRO(ADD_TORCH_PACKAGE)


### PR DESCRIPTION
.. "if ($src)" does not work if $src i a macro, as cmake does not consider macro argument to be a variable (!). So only the case that had an upper scope variables named $src and luasrc worked before. 
Also, C linker language specified for sources as CMake gets lost if all sources are .cu CUDA files
So now cunn can use ADD_TORCH_PACKAGE  macro (used to break on both issues above)