### PR TITLE
Add support for loading data saved on 32/64 bit OS

### DIFF
--- a/File.lua
+++ b/File.lua
@@ -381,13 +381,22 @@ function torch.save(filename, object, mode, referenced)
 end
 
 function torch.load(filename, mode, referenced)
-   assert(mode == nil or mode == 'binary' or mode == 'ascii', '"binary" or "ascii" (or nil) expected for mode')
-   assert(referenced == nil or referenced == true or referenced == false, 'true or false (or nil) expected for referenced')
+   assert(mode == 'binary' or mode == 'b32' or mode == 'b64' or
+          mode == nil or mode == 'ascii',
+          '"binary", "b32", "b64" or "ascii" (or nil) expected for mode')
+   assert(referenced == nil or referenced == true or referenced == false,
+          'true or false (or nil) expected for referenced')
+   local longSize
+   if mode == 'b32' or mode == 'b64' then
+      longSize = tonumber(mode:match('%d+')) / 8
+      mode = 'binary'
+   end
    mode = mode or 'binary'
    referenced = referenced == nil and true or referenced
    local file = torch.DiskFile(filename, 'r')
    file[mode](file)
    file:referenced(referenced)
+   if longSize then file:longSize(longSize) end
    local object = file:readObject()
    file:close()
    return object

--- a/doc/serialization.md
+++ b/doc/serialization.md
@@ -48,14 +48,13 @@ torch.save('test.dat', obj)
 <a name="torch.load"></a>
 ### [object] torch.load(filename [, format, referenced]) ###
 
-Reads `object` from a file named `filename`. The `format` can be set to
-`ascii` or `binary` (default is binary). Binary format is platform
-dependent, but typically more compact and faster to read/write. The ASCII
-format is platform-independent, and should be used to share data structures
-across platforms. The option `referenced` specifies if
-[object references](file.md#torch.File.referenced) should be tracked or not
-(`true` by default). Note that files written with `referenced` at `true`
-cannot be loaded with `referenced` at `false`.
+Reads `object` from a file named `filename`.
+The `format` can be set to `ascii`, `binary`, `b32` or `b64` (default is binary).
+Binary format is platform dependent, but typically more compact and faster to read/write.
+Use `b32`/`b64`, instead of `binary`, for loading files saved on a 32/64 bit OS.
+The ASCII format is platform-independent, and may be used to share data structures across platforms.
+The option `referenced` specifies if [object references](file.md#torch.File.referenced) should be tracked or not (`true` by default).
+Note that files written with `referenced` at `true` cannot be loaded with `referenced` at `false`.
 
 ```
 -- given serialized object from section above, reload:


### PR DESCRIPTION
`torch.load32()` and `torch.load64()` have been replaced by `torch.load(fileName, 'b32')` and `torch.load(fileName, 'b64')` as discussed in #540.