### PR TITLE
Fix a bug in :isSetTo

### DIFF
--- a/lib/TH/generic/THTensor.c
+++ b/lib/TH/generic/THTensor.c
@@ -547,6 +547,8 @@ int THTensor_(isSameSizeAs)(const THTensor *self, const THTensor* src)
 
 int THTensor_(isSetTo)(const THTensor *self, const THTensor* src)
 {
+  if (!self->storage)
+    return 0;
   if (self->storage == src->storage &&
       self->storageOffset == src->storageOffset &&
       self->nDimension == src->nDimension)

--- a/test/test.lua
+++ b/test/test.lua
@@ -2935,6 +2935,9 @@ function torchtest.isSetTo()
    mytester:assert(t1:isSetTo(t3) == true, "tensor is set to other")
    mytester:assert(t3:isSetTo(t1) == true, "isSetTo should be symmetric")
    mytester:assert(t1:isSetTo(t4) == false, "tensors have different view")
+   mytester:assert(not torch.Tensor():isSetTo(torch.Tensor()),
+                   "Tensors with no storages should not appear to be set " ..
+                   "to each other")
 end
 
 function torchtest.isSize()


### PR DESCRIPTION
The case of self->storage == NULL was not checked, so any two Tensors
with no storage would effectively appear to be shared with each other.
Added a test to prevent regressions.