### PR TITLE
Extend torch.bernoulli()

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -698,19 +698,33 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
         {{name=Tensor, returned=true},
          {name='Generator', default=true}})
 
-   for _,f in ipairs({{name='geometric'},
-                      {name='bernoulli', a=0.5}}) do
+   wrap("geometric",
+     "THRandom_geometric",
+     {{name="Generator", default=true},
+      {name="double"},
+      {name="double", creturned=true}},
+     cname("geometric"),
+     {{name=Tensor, returned=true},
+      {name="Generator", default=true},
+      {name="double"}})
 
-      wrap(f.name,
-           string.format("THRandom_%s", f.name),
-           {{name='Generator', default=true},
-            {name="double", default=f.a},
-            {name="double", creturned=true}},
-           cname(f.name),
-           {{name=Tensor, returned=true},
-            {name='Generator', default=true},
-            {name="double", default=f.a}})
-   end
+   wrap("bernoulli",
+      "THRandom_bernoulli",
+      {{name="Generator", default=true},
+       {name="double", default=0.5},
+       {name="double", creturned=true}},
+      cname("bernoulli"),
+      {{name=Tensor, returned=true},
+       {name="Generator", default=true},
+       {name="double", default=0.5}},
+      cname("bernoulli_FloatTensor"),
+      {{name=Tensor, returned=true},
+       {name="Generator", default=true},
+       {name="FloatTensor"}},
+      cname("bernoulli_DoubleTensor"),
+      {{name=Tensor, returned=true},
+       {name="Generator", default=true},
+       {name="DoubleTensor"}})
 
    wrap("squeeze",
         cname("squeeze"),

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -33,6 +33,16 @@ void THTensor_(bernoulli)(THTensor *self, THGenerator *_generator, double p)
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_bernoulli(_generator, p););
 }
 
+void THTensor_(bernoulli_FloatTensor)(THTensor *self, THGenerator *_generator, THFloatTensor *p)
+{
+  TH_TENSOR_APPLY2(real, self, float, p, *self_data = (real)THRandom_bernoulli(_generator, (double)*p_data););
+}
+
+void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, THDoubleTensor *p)
+{
+  TH_TENSOR_APPLY2(real, self, double, p, *self_data = (real)THRandom_bernoulli(_generator, (double)*p_data););
+}
+
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
 void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b)

--- a/lib/TH/generic/THTensorRandom.h
+++ b/lib/TH/generic/THTensorRandom.h
@@ -5,6 +5,8 @@
 TH_API void THTensor_(random)(THTensor *self, THGenerator *_generator);
 TH_API void THTensor_(geometric)(THTensor *self, THGenerator *_generator, double p);
 TH_API void THTensor_(bernoulli)(THTensor *self, THGenerator *_generator, double p);
+TH_API void THTensor_(bernoulli_FloatTensor)(THTensor *self, THGenerator *_generator, THFloatTensor *p);
+TH_API void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, THDoubleTensor *p);
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 TH_API void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b);

--- a/test/test.lua
+++ b/test/test.lua
@@ -3180,6 +3180,23 @@ function torchtest.testheaptracking()
   torch.setheaptracking(oldheaptracking)
 end
 
+function torchtest.bernoulli()
+  local size = torch.LongStorage{10, 10}
+  local t = torch.ByteTensor(size)
+
+  local function isBinary(t)
+    return torch.ne(t, 0):cmul(torch.ne(t, 1)):sum() == 0
+  end
+
+  local p = 0.5
+  t:bernoulli(p)
+  mytester:assert(isBinary(t), 'Sample from torch.bernoulli is not binary')
+
+  local p = torch.rand(size)
+  t:bernoulli(p)
+  mytester:assert(isBinary(t), 'Sample from torch.bernoulli is not binary')
+end
+
 function torch.test(tests)
    torch.setheaptracking(true)
    math.randomseed(os.time())


### PR DESCRIPTION
Now it also accepts a tensor of probabilities instead of a single Lua number.

Added a test that checks that the output is binary.