### PR TITLE
Fix broken torch.cat{} and added tests

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -51,6 +51,18 @@ static int torch_isnonemptytable(lua_State *L, int idx)
 }
 ]])
 
+
+interface:print([[
+static const void* torch_istensorarray(lua_State *L, int idx)
+{
+  if (!torch_isnonemptytable(L, idx)) return 0;
+
+  lua_checkstack(L, 1);
+  lua_rawgeti(L, 1, 1);
+  return (torch_istensortype(L, luaT_typename(L, -1)));
+}
+]])
+
 interface.dispatchregistry = {}
 function interface:wrap(name, ...)
    -- usual stuff
@@ -72,12 +84,9 @@ static int torch_NAME(lua_State *L)
   else if(narg >= 2 && (tname = torch_istensortype(L, luaT_typename(L, 2)))) /* second? */
   {
   }
-  else if(narg >= 1 && lua_istable(L, 1)) /* torch table argument? */
+  else if(narg >= 1 && (tname = torch_istensorarray(L, 1))) /* torch table argument? */
   {
-     lua_checkstack(L, 1);
-     lua_rawgeti(L, 1, 1);
-     tname = torch_istensortype(L, luaT_typename(L, -1));
-     lua_remove(L, -2);
+    lua_remove(L, -2);
   }
   else if(narg >= 1 && lua_type(L, narg) == LUA_TSTRING
 	  && (tname = torch_istensortype(L, lua_tostring(L, narg)))) /* do we have a valid tensor type string then? */

--- a/test/test.lua
+++ b/test/test.lua
@@ -1744,8 +1744,14 @@ function torchtest.catArray()
       mytester:assertTensorEq(mx:narrow(dim, 14, 17), y, 0, 'torch.cat value')
       mytester:assertTensorEq(mx:narrow(dim, 31, 19), z, 0, 'torch.cat value')
 
+      mytester:assertError(function() torch.cat{} end, 'torch.cat empty table')
+
       local mxx = torch.Tensor()
       torch.cat(mxx, {x, y, z}, dim)
+      mytester:assertTensorEq(mx, mxx, 0, 'torch.cat value')
+      torch.cat(mxx:float(), {x:float(), y:float(), z:float()}, dim)
+      mytester:assertTensorEq(mx, mxx, 0, 'torch.cat value')
+      torch.cat(mxx:double(), {x:double(), y:double(), z:double()}, dim)
       mytester:assertTensorEq(mx, mxx, 0, 'torch.cat value')
    end
 end


### PR DESCRIPTION
Sorry for breaking torch.cat{} in my previous pull request #582, also broke torch.cat{1}, torch.add{} etc. resulting in a segmentation fault.

Rewrote the function to check for the table being empty, and put it in a function to allow it to use the default tensor if it is empty or contains an invalid tensor. Also added additional unit tests.