### PR TITLE
Lua 5.3 integer support

### DIFF
--- a/generic/Storage.c
+++ b/generic/Storage.c
@@ -2,6 +2,8 @@
 #define TH_GENERIC_FILE "generic/Storage.c"
 #else
 
+#include "luaG.h"
+
 static int torch_Storage_(new)(lua_State *L)
 {
   int index = 1;
@@ -138,22 +140,22 @@ static int torch_Storage_(copy)(lua_State *L)
 static int torch_Storage_(fill)(lua_State *L)
 {
   THStorage *storage = luaT_checkudata(L, 1, torch_Storage);
-  double value = luaL_checknumber(L, 2);
-  THStorage_(fill)(storage, (real)value);
+  real value = luaG_(checkreal)(L, 2);
+  THStorage_(fill)(storage, value);
   lua_settop(L, 1);
   return 1;
 }
 
 static int torch_Storage_(elementSize)(lua_State *L)
 {
-  lua_pushnumber(L, THStorage_(elementSize)());
+  luaT_pushlong(L, THStorage_(elementSize)());
   return 1;
 }
 
 static int torch_Storage_(__len__)(lua_State *L)
 {
   THStorage *storage = luaT_checkudata(L, 1, torch_Storage);
-  lua_pushnumber(L, storage->size);
+  luaT_pushlong(L, storage->size);
   return 1;
 }
 
@@ -163,8 +165,8 @@ static int torch_Storage_(__newindex__)(lua_State *L)
   {
     THStorage *storage = luaT_checkudata(L, 1, torch_Storage);
     long index = luaL_checklong(L, 2) - 1;
-    double number = luaL_checknumber(L, 3);
-    THStorage_(set)(storage, index, (real)number);
+    real number = luaG_(checkreal)(L, 3);
+    THStorage_(set)(storage, index, number);
     lua_pushboolean(L, 1);
   }
   else
@@ -179,7 +181,7 @@ static int torch_Storage_(__index__)(lua_State *L)
   {
     THStorage *storage = luaT_checkudata(L, 1, torch_Storage);
     long index = luaL_checklong(L, 2) - 1;
-    lua_pushnumber(L, THStorage_(get)(storage, index));
+    luaG_(pushreal)(L, THStorage_(get)(storage, index));
     lua_pushboolean(L, 1);
     return 2;
   }
@@ -217,7 +219,7 @@ static int torch_Storage_(totable)(lua_State *L)
   lua_newtable(L);
   for(i = 0; i < storage->size; i++)
   {
-    lua_pushnumber(L, (lua_Number)storage->data[i]);
+    luaG_(pushreal)(L, storage->data[i]);
     lua_rawseti(L, -2, i+1);
   }
   return 1;

--- a/generic/luaG.h
+++ b/generic/luaG.h
@@ -6,7 +6,7 @@
 #define luaG_(NAME) TH_CONCAT_3(luaG_,Real,NAME)
 #endif
 
-inline void luaG_(pushreal)(lua_State *L, accreal n) {
+static void luaG_(pushreal)(lua_State *L, accreal n) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || LUA_VERSION_NUM < 503
 	lua_pushnumber(L, (lua_Number)n);
 #elif defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
@@ -16,7 +16,7 @@ inline void luaG_(pushreal)(lua_State *L, accreal n) {
 #endif
 }
 
-inline real luaG_(checkreal)(lua_State *L, int idx) {
+static real luaG_(checkreal)(lua_State *L, int idx) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || LUA_VERSION_NUM < 503
 	return (lua_Number)luaL_checknumber(L, idx);
 #elif defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
@@ -26,7 +26,7 @@ inline real luaG_(checkreal)(lua_State *L, int idx) {
 #endif
 }
 
-inline real luaG_(optreal)(lua_State *L, int idx, real n) {
+static real luaG_(optreal)(lua_State *L, int idx, real n) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || LUA_VERSION_NUM < 503
 	return (lua_Number)luaL_optnumber(L, idx, (lua_Number)n);
 #elif defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)

--- a/generic/luaG.h
+++ b/generic/luaG.h
@@ -1,0 +1,37 @@
+#if !defined(real) || !defined(TH_GENERIC_FILE)
+#error "luaG.h must not be included outside of a generic file."
+#endif
+
+#ifndef luaG_
+#define luaG_(NAME) TH_CONCAT_3(luaG_,Real,NAME)
+#endif
+
+inline void luaG_(pushreal)(lua_State *L, accreal n) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || LUA_VERSION_NUM < 503
+	lua_pushnumber(L, (lua_Number)n);
+#elif defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
+	lua_pushinteger(L, (lua_Integer)n);
+#else
+	#error "unhandled real type in luaG_pushreal"
+#endif
+}
+
+inline real luaG_(checkreal)(lua_State *L, int idx) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || LUA_VERSION_NUM < 503
+	return (lua_Number)luaL_checknumber(L, idx);
+#elif defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
+	return (lua_Integer)luaL_checkinteger(L, idx);
+#else
+	#error "unhandled real type in luaG_checkreal"
+#endif
+}
+
+inline real luaG_(optreal)(lua_State *L, int idx, real n) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || LUA_VERSION_NUM < 503
+	return (lua_Number)luaL_optnumber(L, idx, (lua_Number)n);
+#elif defined(TH_REAL_IS_BYTE) || defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
+	return (lua_Integer)luaL_optinteger(L, idx, (lua_Integer)n);
+#else
+	#error "unhandled real type in luaG_checkreal"
+#endif
+}

--- a/lib/luaT/luaT.c
+++ b/lib/luaT/luaT.c
@@ -348,6 +348,47 @@ void *luaT_checkudata(lua_State *L, int ud, const char *tname)
   return p;
 }
 
+void luaT_pushlong(lua_State *L, long n)
+{
+#if LUA_VERSION_NUM >= 503
+  /* Only push the value as an integer if it fits in lua_Integer,
+   or if the lua_Number representation will be even worse */
+  if (sizeof(lua_Integer) >= sizeof(long) || sizeof(lua_Number) == sizeof(lua_Integer)) {
+    lua_pushinteger(L, n);
+  } else {
+    lua_pushnumber(L, (lua_Number)n);
+  }
+#else
+  lua_pushnumber(L, (lua_Number)n);
+#endif
+}
+
+long luaT_checklong(lua_State *L, int idx)
+{
+#if LUA_VERSION_NUM >= 503
+  if (sizeof(lua_Integer) >= sizeof(long) || sizeof(lua_Number) == sizeof(lua_Integer)) {
+    return (long)luaL_checkinteger(L, idx);
+  } else {
+    return (long)luaL_checknumber(L, idx);
+  }
+#else
+  return (long)luaL_checknumber(L, idx);
+#endif
+}
+
+long luaT_tolong(lua_State *L, int idx)
+{
+#if LUA_VERSION_NUM == 503
+  if (sizeof(lua_Integer) >= sizeof(long) || sizeof(lua_Number) == sizeof(lua_Integer)) {
+    return (long)lua_tointeger(L, idx);
+  } else {
+    return (long)lua_tonumber(L, idx);
+  }
+#else
+  return (long)lua_tonumber(L, idx);
+#endif
+}
+
 void *luaT_getfieldcheckudata(lua_State *L, int ud, const char *field, const char *tname)
 {
   void *p;

--- a/lib/luaT/luaT.h
+++ b/lib/luaT/luaT.h
@@ -69,6 +69,10 @@ LUAT_API void *luaT_toudata(lua_State *L, int ud, const char *tname);
 LUAT_API int luaT_isudata(lua_State *L, int ud, const char *tname);
 LUAT_API void *luaT_checkudata(lua_State *L, int ud, const char *tname);
 
+LUAT_API void luaT_pushlong(lua_State *L, long n);
+LUAT_API long luaT_checklong(lua_State *L, int idx);
+LUAT_API long luaT_tolong(lua_State *L, int idx);
+
 LUAT_API void *luaT_getfieldcheckudata(lua_State *L, int ud, const char *field, const char *tname);
 LUAT_API void *luaT_getfieldchecklightudata(lua_State *L, int ud, const char *field);
 LUAT_API double luaT_getfieldchecknumber(lua_State *L, int ud, const char *field);


### PR DESCRIPTION
This shouldn't change any behavior when compiled with Lua < 5.3 or LuaJIT.

Will post the corresponding change to cwrap. This works fine independent of that, but some functions like :fill() on LongTensor won't properly support 64-bit inputs until cwrap is updated.