### PR TITLE
Fix bad size evaluation

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1370,7 +1370,7 @@ void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound incoherent with step sign");
 
-  size = (long)((xmax/step - xmin/step)+1);
+  size = (long) (((xmax - xmin) / step) + 1);
 
   THTensor_(resize1d)(r_, size);
 


### PR DESCRIPTION
xmax, xmin and step are accreal. Therefore, computations are carried out in both int and double logic. The separate division does introduce a bug when int logic is used.

## Before
```lua
th> torch.range(1, 25, 5, 'torch.LongTensor')
  1
  6
 11
 16
 21
 26
[torch.LongTensor of size 6]

th> torch.range(1, 25, 5, 'torch.FloatTensor')
  1
  6
 11
 16
 21
[torch.FloatTensor of size 5]
```

## After
```lua
th> torch.range(1, 25, 5, 'torch.FloatTensor')
  1
  6
 11
 16
 21
[torch.FloatTensor of size 5]

th> torch.range(1, 25, 5, 'torch.LongTensor')
  1
  6
 11
 16
 21
[torch.LongTensor of size 5]

th> torch.range(1, 25, 5, 'torch.DoubleTensor')                                                      
  1
  6
 11
 16
 21
[torch.DoubleTensor of size 5]

th> torch.range(1, 25, 5, 'torch.IntTensor')                                                         
  1
  6
 11
 16
 21
[torch.IntTensor of size 5]

th> torch.range(1, 25, 5, 'torch.ByteTensor')                                                        
  1
  6
 11
 16
 21
[torch.ByteTensor of size 5]
```