### PR TITLE
Fix torch.mod and torch.cmod behaviors.

### DIFF
--- a/DiskFile.c
+++ b/DiskFile.c
@@ -62,10 +62,18 @@ static int torch_DiskFile_longSize(lua_State *L)
   return 1;
 }
 
+static int torch_DiskFile_noBuffer(lua_State *L)
+{
+  THFile *self = luaT_checkudata(L, 1, "torch.DiskFile");
+  THDiskFile_noBuffer(self);
+  lua_settop(L, 1);
+  return 1;
+}
+
 static int torch_DiskFile___tostring__(lua_State *L)
 {
   THFile *self = luaT_checkudata(L, 1, "torch.DiskFile");
-  lua_pushfstring(L, "torch.DiskFile on <%s> [status: %s -- mode %c%c]", 
+  lua_pushfstring(L, "torch.DiskFile on <%s> [status: %s -- mode %c%c]",
                   THDiskFile_name(self),
                   (THFile_isOpened(self) ? "open" : "closed"),
                   (THFile_isReadable(self) ? 'r' : ' '),
@@ -80,6 +88,7 @@ static const struct luaL_Reg torch_DiskFile__ [] = {
   {"littleEndianEncoding", torch_DiskFile_littleEndianEncoding},
   {"bigEndianEncoding", torch_DiskFile_bigEndianEncoding},
   {"longSize", torch_DiskFile_longSize},
+  {"noBuffer", torch_DiskFile_noBuffer},
   {"__tostring__", torch_DiskFile___tostring__},
   {NULL, NULL}
 };
@@ -88,7 +97,7 @@ void torch_DiskFile_init(lua_State *L)
 {
   luaT_newmetatable(L, "torch.DiskFile", "torch.File",
                     torch_DiskFile_new, torch_DiskFile_free, NULL);
-  
+
   luaT_setfuncs(L, torch_DiskFile__, 0);
   lua_pop(L, 1);
 }

--- a/doc/diskfile.md
+++ b/doc/diskfile.md
@@ -12,7 +12,7 @@ the [binary](file.md#torch.File.binary) mode, the default endian encoding is the
 computer one.
 
 The file might be open in read, write, or read-write mode, depending on the parameter
-`mode` (which can take the value `"r"`, `"w"` or `"rw"` respectively) 
+`mode` (which can take the value `"r"`, `"w"` or `"rw"` respectively)
 given to the [torch.DiskFile(fileName, mode)](#torch.DiskFile).
 
 <a name="torch.DiskFile"></a>
@@ -32,7 +32,7 @@ The file is opened in [ASCII](file.md#torch.File.ascii) mode by default.
 <a name="torch.DiskFile.bigEndianEncoding"></a>
 ### bigEndianEncoding() ###
 
-In [binary](file.md#torch.File.binary) mode, force encoding in _big endian_. 
+In [binary](file.md#torch.File.binary) mode, force encoding in _big endian_.
 (_big end first_: decreasing numeric significance with increasing memory
 addresses)
 
@@ -67,3 +67,8 @@ In [binary](file.md#torch.File.binary) mode, force encoding in _native endian_.
 
 Longs will be written and read from the file as `size` bytes long, which
 can be 0, 4 or 8. 0 means system default.
+
+<a name="torch.DiskFile.noBuffer"/></a>
+### noBuffer() ###
+
+Disables read and write buffering on the `DiskFile`.

--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -291,6 +291,15 @@ void THDiskFile_longSize(THFile *self, int size)
   dfself->longSize = size;
 }
 
+void THDiskFile_noBuffer(THFile *self)
+{
+  THDiskFile *dfself = (THDiskFile*)(self);
+  THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file");
+  if (setvbuf(dfself->handle, NULL, _IONBF, 0)) {
+    THError("error: cannot disable buffer");
+  }
+}
+
 static void THDiskFile_free(THFile *self)
 {
   THDiskFile *dfself = (THDiskFile*)(self);

--- a/lib/TH/THDiskFile.h
+++ b/lib/TH/THDiskFile.h
@@ -14,5 +14,6 @@ TH_API void THDiskFile_nativeEndianEncoding(THFile *self);
 TH_API void THDiskFile_littleEndianEncoding(THFile *self);
 TH_API void THDiskFile_bigEndianEncoding(THFile *self);
 TH_API void THDiskFile_longSize(THFile *self, int size);
+TH_API void THDiskFile_noBuffer(THFile *self);
 
 #endif

--- a/lib/TH/generic/THTensorLapack.c
+++ b/lib/TH/generic/THTensorLapack.c
@@ -564,7 +564,6 @@ void THTensor_(potrs)(THTensor *rb_, THTensor *b, THTensor *a, const char *uplo)
   if (b == NULL) b = rb_;
 
   THArgCheck(a->size[0] == a->size[1], 2, "A should be square");
-  THArgCheck(b->size[0] >= b->size[1], 2, "Matrix B is rank-deficient");
 
   int n, nrhs, lda, ldb, info;
   THTensor *ra__; // working version of A matrix to be passed into lapack TRTRS

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1372,7 +1372,9 @@ void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
 
   size = (long) (((xmax - xmin) / step) + 1);
 
-  THTensor_(resize1d)(r_, size);
+  if (THTensor_(nElement)(r_) != size) {
+    THTensor_(resize1d)(r_, size);
+  }
 
   TH_TENSOR_APPLY(real, r_, *r__data = xmin + (i++)*step;);
 }
@@ -2352,9 +2354,10 @@ void THTensor_(linspace)(THTensor *r_, real a, real b, long n)
   real i = 0;
 
   THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
-  THArgCheck(a <= b, 2, "end range should be greater than start range");
 
-  THTensor_(resize1d)(r_, n);
+  if (THTensor_(nElement)(r_) != n) {
+    THTensor_(resize1d)(r_, n);
+  }
 
   if(n == 1) {
      TH_TENSOR_APPLY(real, r_,
@@ -2374,9 +2377,11 @@ void THTensor_(logspace)(THTensor *r_, real a, real b, long n)
   real i = 0;
 
   THArgCheck(n > 1 || (n == 1 && (a == b)), 3, "invalid number of points");
-  THArgCheck(a <= b, 2, "end range should be greater than start range");
 
-  THTensor_(resize1d)(r_, n);
+  if (THTensor_(nElement)(r_) != n) {
+    THTensor_(resize1d)(r_, n);
+  }
+
   if(n == 1) {
     TH_TENSOR_APPLY(real, r_,
         *r__data = pow(10.0, a);

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -504,9 +504,9 @@ void THTensor_(mod)(THTensor *r_, THTensor *t, real value)
       long i;
       #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
       for (i=0; i<sz; i++)
-          rp[i] = fmod(tp[i], value);
+          rp[i] = tp[i] - value * floor(tp[i] / value);
   } else {
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = fmod(*t_data, value););
+      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data - value * floor(*t_data / value););
   }
 }
 
@@ -615,9 +615,9 @@ void THTensor_(cmod)(THTensor *r_, THTensor *t, THTensor *src)
       long i;
       #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
       for (i=0; i<sz; i++)
-        rp[i] = fmod(tp[i], sp[i]);
+        rp[i] = tp[i] - sp[i] * floor(tp[i] / sp[i]);
   } else {
-      TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = fmod(*t_data, *src_data););
+      TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data - *src_data * floor(*t_data / *src_data););
   }
 }
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1392,6 +1392,13 @@ function torchtest.range()
    local mxx = torch.Tensor()
    torch.range(mxx,0,1)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.range value')
+
+   -- Check range for non-contiguous tensors.
+   local x = torch.zeros(2, 3)
+   local y = x:narrow(2, 2, 2)
+   y:range(0, 3)
+   mytester:assertTensorEq(x, torch.Tensor{{0, 0, 1}, {0, 2, 3}}, 1e-16,
+                           'non-contiguous range failed')
 end
 function torchtest.rangenegative()
    local mx = torch.Tensor({1,0})
@@ -1771,6 +1778,19 @@ function torchtest.linspace()
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.linspace value')
    mytester:assertError(function() torch.linspace(0,1,1) end, 'accepted 1 point between 2 distinct endpoints')
    mytester:assertTensorEq(torch.linspace(0,0,1),torch.zeros(1),1e-16, 'failed to generate for torch.linspace(0,0,1)')
+
+   -- Check linspace for generating with start > end.
+   mytester:assertTensorEq(torch.linspace(2,0,3),
+                           torch.Tensor{2,1,0},
+                           1e-16,
+                           'failed to generate for torch.linspace(2,0,3)')
+
+   -- Check linspace for non-contiguous tensors.
+   local x = torch.zeros(2, 3)
+   local y = x:narrow(2, 2, 2)
+   y:linspace(0, 3, 4)
+   mytester:assertTensorEq(x, torch.Tensor{{0, 0, 1}, {0, 2, 3}}, 1e-16,
+                           'non-contiguous linspace failed')
 end
 function torchtest.logspace()
    local from = math.random()
@@ -1781,6 +1801,19 @@ function torchtest.logspace()
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.logspace value')
    mytester:assertError(function() torch.logspace(0,1,1) end, 'accepted 1 point between 2 distinct endpoints')
    mytester:assertTensorEq(torch.logspace(0,0,1),torch.ones(1),1e-16, 'failed to generate for torch.linspace(0,0,1)')
+
+   -- Check logspace for generating with start > end.
+   mytester:assertTensorEq(torch.logspace(1,0,2),
+                           torch.Tensor{10, 1},
+                           1e-16,
+                           'failed to generate for torch.logspace(1,0,2)')
+
+   -- Check logspace for non-contiguous tensors.
+   local x = torch.zeros(2, 3)
+   local y = x:narrow(2, 2, 2)
+   y:logspace(0, 3, 4)
+   mytester:assertTensorEq(x, torch.Tensor{{0, 1, 10}, {0, 100, 1000}}, 1e-16,
+                           'non-contiguous logspace failed')
 end
 function torchtest.rand()
    torch.manualSeed(123456)

--- a/test/test.lua
+++ b/test/test.lua
@@ -702,7 +702,7 @@ function torchtest.div()
 end
 
 function torchtest.mod()
-   local m1 = torch.Tensor(10,10):uniform(10)
+   local m1 = torch.Tensor(10, 10):uniform(-10, 10)
    local res1 = m1:clone()
 
    local q = 2.1
@@ -1036,8 +1036,8 @@ end
 
 function torchtest.cmod()  -- [res] torch.cmod([res,] tensor1, tensor2)
    -- contiguous
-   local m1 = torch.Tensor(10, 10, 10):uniform(10)
-   local m2 = torch.Tensor(10, 10 * 10):uniform(3)
+   local m1 = torch.Tensor(10, 10, 10):uniform(-10, 10)
+   local m2 = torch.Tensor(10, 10 * 10):uniform(-3, 3)
    local sm1 = m1[{4, {}, {}}]
    local sm2 = m2[{4, {}}]
    local res1 = torch.cmod(sm1, sm2)
@@ -1067,8 +1067,8 @@ function torchtest.cmod()  -- [res] torch.cmod([res,] tensor1, tensor2)
    mytester:assertlt(maxerr, precision, 'error in torch.cmod - contiguous')
 
    -- non-contiguous
-   local m1 = torch.Tensor(10, 10, 10):uniform(10)
-   local m2 = torch.Tensor(10 * 10, 10 * 10):uniform(3)
+   local m1 = torch.Tensor(10, 10, 10):uniform(-10, 10)
+   local m2 = torch.Tensor(10 * 10, 10 * 10):uniform(-3, 3)
    local sm1 = m1[{{}, 4, {}}]
    local sm2 = m2[{{}, 4}]
    local res1 = torch.cmod(sm1, sm2)


### PR DESCRIPTION
I met this issue #607 too. The function `fmod` in the math library behaves a little bit different with the `%` operator.
I replaced `fmod(a, b)` by `a - b*floor(a/b)` and modified test. Computing 100,000,000 remainders by
 `a - b*floor(a/b)`  will cost 0.1s more than `fmod(a, b)`, so this change will not affect the performance too much.