### PR TITLE
Add DiskFile:noBuffer()

### DIFF
--- a/DiskFile.c
+++ b/DiskFile.c
@@ -62,10 +62,18 @@ static int torch_DiskFile_longSize(lua_State *L)
   return 1;
 }
 
+static int torch_DiskFile_noBuffer(lua_State *L)
+{
+  THFile *self = luaT_checkudata(L, 1, "torch.DiskFile");
+  THDiskFile_noBuffer(self);
+  lua_settop(L, 1);
+  return 1;
+}
+
 static int torch_DiskFile___tostring__(lua_State *L)
 {
   THFile *self = luaT_checkudata(L, 1, "torch.DiskFile");
-  lua_pushfstring(L, "torch.DiskFile on <%s> [status: %s -- mode %c%c]", 
+  lua_pushfstring(L, "torch.DiskFile on <%s> [status: %s -- mode %c%c]",
                   THDiskFile_name(self),
                   (THFile_isOpened(self) ? "open" : "closed"),
                   (THFile_isReadable(self) ? 'r' : ' '),
@@ -80,6 +88,7 @@ static const struct luaL_Reg torch_DiskFile__ [] = {
   {"littleEndianEncoding", torch_DiskFile_littleEndianEncoding},
   {"bigEndianEncoding", torch_DiskFile_bigEndianEncoding},
   {"longSize", torch_DiskFile_longSize},
+  {"noBuffer", torch_DiskFile_noBuffer},
   {"__tostring__", torch_DiskFile___tostring__},
   {NULL, NULL}
 };
@@ -88,7 +97,7 @@ void torch_DiskFile_init(lua_State *L)
 {
   luaT_newmetatable(L, "torch.DiskFile", "torch.File",
                     torch_DiskFile_new, torch_DiskFile_free, NULL);
-  
+
   luaT_setfuncs(L, torch_DiskFile__, 0);
   lua_pop(L, 1);
 }

--- a/doc/diskfile.md
+++ b/doc/diskfile.md
@@ -12,7 +12,7 @@ the [binary](file.md#torch.File.binary) mode, the default endian encoding is the
 computer one.
 
 The file might be open in read, write, or read-write mode, depending on the parameter
-`mode` (which can take the value `"r"`, `"w"` or `"rw"` respectively) 
+`mode` (which can take the value `"r"`, `"w"` or `"rw"` respectively)
 given to the [torch.DiskFile(fileName, mode)](#torch.DiskFile).
 
 <a name="torch.DiskFile"></a>
@@ -32,7 +32,7 @@ The file is opened in [ASCII](file.md#torch.File.ascii) mode by default.
 <a name="torch.DiskFile.bigEndianEncoding"></a>
 ### bigEndianEncoding() ###
 
-In [binary](file.md#torch.File.binary) mode, force encoding in _big endian_. 
+In [binary](file.md#torch.File.binary) mode, force encoding in _big endian_.
 (_big end first_: decreasing numeric significance with increasing memory
 addresses)
 
@@ -67,3 +67,8 @@ In [binary](file.md#torch.File.binary) mode, force encoding in _native endian_.
 
 Longs will be written and read from the file as `size` bytes long, which
 can be 0, 4 or 8. 0 means system default.
+
+<a name="torch.DiskFile.noBuffer"/></a>
+### noBuffer() ###
+
+Disables read and write buffering on the `DiskFile`.

--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -291,6 +291,15 @@ void THDiskFile_longSize(THFile *self, int size)
   dfself->longSize = size;
 }
 
+void THDiskFile_noBuffer(THFile *self)
+{
+  THDiskFile *dfself = (THDiskFile*)(self);
+  THArgCheck(dfself->handle != NULL, 1, "attempt to use a closed file");
+  if (setvbuf(dfself->handle, NULL, _IONBF, 0)) {
+    THError("error: cannot disable buffer");
+  }
+}
+
 static void THDiskFile_free(THFile *self)
 {
   THDiskFile *dfself = (THDiskFile*)(self);

--- a/lib/TH/THDiskFile.h
+++ b/lib/TH/THDiskFile.h
@@ -14,5 +14,6 @@ TH_API void THDiskFile_nativeEndianEncoding(THFile *self);
 TH_API void THDiskFile_littleEndianEncoding(THFile *self);
 TH_API void THDiskFile_bigEndianEncoding(THFile *self);
 TH_API void THDiskFile_longSize(THFile *self, int size);
+TH_API void THDiskFile_noBuffer(THFile *self);
 
 #endif


### PR DESCRIPTION
The noBuffer function disables read and write buffering via setvbuf.

This is particularly useful for random reads from files on networked storage, which otherwise results in much larger network transfers.