### PR TITLE
Alternate implementation of torch.chunk()

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -514,8 +514,20 @@ function Tensor.chunk(result, tensor, nChunk, dim)
       result = {}
    end
    dim = dim or 1
-   local splitSize = math.ceil(tensor:size(dim)/nChunk)
-   return torch.split(result, tensor, splitSize, dim)
+   local n = tensor:size(dim)
+   local lo = 0
+   local z              -- empty tensor variable used when nChunk > tensor:size(dim)
+   for i=1,nChunk do    -- (loop is skipped if nChunk < 1, returning empty table)
+      local hi = math.min(math.ceil(i*n/nChunk), n)
+      if lo < hi then
+        table.insert(result, tensor:narrow(dim, lo+1, hi-lo))
+        lo = hi
+      else
+        z = z or torch.Tensor():typeAs(tensor)
+        table.insert(result, z)
+      end
+   end
+   return result
 end
 torch.chunk = Tensor.chunk
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -3102,7 +3102,7 @@ function torchtest.chunk()
    local result = {}
    local tensor = torch.rand(4,7)
    local nChunk = 3
-   local targetSize = {{4,3},{4,3},{4,1}}
+   local targetSize = {{4,3},{4,2},{4,2}}
    local dim = 2
    local splits = tensor:chunk(nChunk, dim)
    local start = 1
@@ -3111,12 +3111,10 @@ function torchtest.chunk()
       mytester:assertTensorEq(tensor:narrow(dim, start, targetSize[i][dim]), split, 0.00001, 'Content error in chunk '..i)
       start = start + targetSize[i][dim]
    end
-   torch.split(result, tensor, nChunk, dim)
    local start = 1
-   for i, split in ipairs(result) do
-      mytester:assertTableEq(split:size():totable(), targetSize[i], 'Result size error in chunk '..i)
-      mytester:assertTensorEq(tensor:narrow(dim, start, targetSize[i][dim]), split, 0.000001, 'Result content error in chunk '..i)
-      start = start + targetSize[i][dim]
+   for i, split in ipairs(splits) do
+      mytester:assertTensorEq(tensor:narrow(dim, start, split:size(dim)), split, 0.000001, 'Result content error in chunk '..i)
+      start = start + split:size(dim)
    end
 end
 


### PR DESCRIPTION
This PR tries to address https://github.com/torch/torch7/issues/617. The new implementation returns a table with nChunk entries, even in the case that the tensor has < nChunk entries in the specified dimension. 

TODO: If new behaviour is as intended the documentation has to be updated since it currently says chunk() would use split().

Old behaviour:
```
th> torch.rand(11):chunk(5)
{
  1 : DoubleTensor - size: 3
  2 : DoubleTensor - size: 3
  3 : DoubleTensor - size: 3
  4 : DoubleTensor - size: 2
}

th> torch.rand(10):chunk(7)
{
  1 : DoubleTensor - size: 2
  2 : DoubleTensor - size: 2
  3 : DoubleTensor - size: 2
  4 : DoubleTensor - size: 2
  5 : DoubleTensor - size: 2
}

th> torch.rand(5):chunk(10)
{
  1 : DoubleTensor - size: 1
  2 : DoubleTensor - size: 1
  3 : DoubleTensor - size: 1
  4 : DoubleTensor - size: 1
  5 : DoubleTensor - size: 1
}
```

New behaviour:
```
th> torch.rand(11):chunk(5)
{
  1 : DoubleTensor - size: 3
  2 : DoubleTensor - size: 2
  3 : DoubleTensor - size: 2
  4 : DoubleTensor - size: 2
  5 : DoubleTensor - size: 2
}

th> torch.rand(10):chunk(7)
{
  1 : DoubleTensor - size: 2
  2 : DoubleTensor - size: 1
  3 : DoubleTensor - size: 2
  4 : DoubleTensor - size: 1
  5 : DoubleTensor - size: 2
  6 : DoubleTensor - size: 1
  7 : DoubleTensor - size: 1
}

th> torch.rand(5):chunk(10)
{
  1 : DoubleTensor - size: 1
  2 : DoubleTensor - empty
  3 : DoubleTensor - size: 1
  4 : DoubleTensor - empty
  5 : DoubleTensor - size: 1
  6 : DoubleTensor - empty
  7 : DoubleTensor - size: 1
  8 : DoubleTensor - empty
  9 : DoubleTensor - size: 1
  10 : DoubleTensor - empty
}
```