### PR TITLE
Only require sys.colors from sys

### DIFF
--- a/Tester.lua
+++ b/Tester.lua
@@ -377,14 +377,13 @@ end
 
 local NCOLS = 80
 local coloured
-local c = {}
-local enable_colors = pcall(require, 'sys')
+local enable_colors, c = pcall(require, 'sys.colors')
 if arg and enable_colors then  -- have we been invoked from the commandline?
-   c = sys.COLORS
    coloured = function(str, colour)
       return colour .. str .. c.none
    end
 else
+   c = {}
    coloured = function(str)
       return str
    end


### PR DESCRIPTION
Loading the sys package can cause a deadlock in some OpenBLAS
configurations when multiple Torch threads require sys (via the torch
package) at the same time.

Depends on torch/sys#8