### PR TITLE
Make THInf type-specific

### DIFF
--- a/lib/TH/THGeneral.h.in
+++ b/lib/TH/THGeneral.h.in
@@ -31,8 +31,6 @@
 # define TH_API TH_EXTERNC
 #endif
 
-#define THInf DBL_MAX
-
 #define TH_INLINE @TH_INLINE@
 
 #ifndef __cplusplus

--- a/lib/TH/THGenerateAllTypes.h
+++ b/lib/TH/THGenerateAllTypes.h
@@ -5,6 +5,7 @@
 #define real unsigned char
 #define accreal long
 #define Real Byte
+#define THInf UCHAR_MAX
 #define TH_REAL_IS_BYTE
 #line 1 TH_GENERIC_FILE
 /*#line 1 "THByteStorage.h"*/
@@ -12,72 +13,85 @@
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_BYTE
 
 #define real char
 #define accreal long
 #define Real Char
+#define THInf CHAR_MAX
 #define TH_REAL_IS_CHAR
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_CHAR
 
 #define real short
 #define accreal long
 #define Real Short
+#define THInf SHRT_MAX
 #define TH_REAL_IS_SHORT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_SHORT
 
 #define real int
 #define accreal long
 #define Real Int
+#define THInf INT_MAX
 #define TH_REAL_IS_INT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_INT
 
 #define real long
 #define accreal long
 #define Real Long
+#define THInf LONG_MAX
 #define TH_REAL_IS_LONG
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_LONG
 
 #define real float
 #define accreal double
 #define Real Float
+#define THInf FLT_MAX
 #define TH_REAL_IS_FLOAT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_FLOAT
 
 #define real double
 #define accreal double
 #define Real Double
+#define THInf DBL_MAX
 #define TH_REAL_IS_DOUBLE
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_DOUBLE
 
 #undef TH_GENERIC_FILE

--- a/lib/TH/THGenerateFloatTypes.h
+++ b/lib/TH/THGenerateFloatTypes.h
@@ -5,23 +5,27 @@
 #define real float
 #define accreal double
 #define Real Float
+#define THInf FLT_MAX
 #define TH_REAL_IS_FLOAT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef accreal
 #undef real
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_FLOAT
 
 #define real double
 #define accreal double
 #define Real Double
+#define THInf DBL_MAX
 #define TH_REAL_IS_DOUBLE
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef accreal
 #undef real
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_DOUBLE
 
 #undef TH_GENERIC_FILE

--- a/lib/TH/THGenerateIntTypes.h
+++ b/lib/TH/THGenerateIntTypes.h
@@ -5,56 +5,66 @@
 #define real unsigned char
 #define accreal long
 #define Real Byte
+#define THInf UCHAR_MAX
 #define TH_REAL_IS_BYTE
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_BYTE
 
 #define real char
 #define accreal long
 #define Real Char
+#define THInf CHAR_MAX
 #define TH_REAL_IS_CHAR
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_CHAR
 
 #define real short
 #define accreal long
 #define Real Short
+#define THInf SHRT_MAX
 #define TH_REAL_IS_SHORT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_SHORT
 
 #define real int
 #define accreal long
 #define Real Int
+#define THInf INT_MAX
 #define TH_REAL_IS_INT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_INT
 
 #define real long
 #define accreal long
 #define Real Long
+#define THInf LONG_MAX
 #define TH_REAL_IS_LONG
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef real
 #undef accreal
 #undef Real
+#undef THInf
 #undef TH_REAL_IS_LONG
 
 #undef TH_GENERIC_FILE

--- a/lib/TH/THLogAdd.c
+++ b/lib/TH/THLogAdd.c
@@ -1,5 +1,7 @@
 #include "THLogAdd.h"
 
+#include <float.h>
+
 #ifdef USE_DOUBLE
 #define MINUS_LOG_THRESHOLD -39.14
 #else
@@ -7,7 +9,7 @@
 #endif
 
 const double THLog2Pi=1.83787706640934548355;
-const double THLogZero=-THInf;
+const double THLogZero=-DBL_MAX;
 const double THLogOne=0;
 
 double THLogAdd(double log_a, double log_b)


### PR DESCRIPTION
I have not tested this change with libraries other than `torch7` itself. From a search though our internal codebase, I believe that whatever code does break (e.g. in `cunn`) is actually incorrect in its current form and needs to be fixed (usually something like `float x = -THInf;`, which needs to become `float x = -FLT_MAX;`).

What do you think?