### PR TITLE
File: get rid of extra NULL character (serialize)

### DIFF
--- a/File.lua
+++ b/File.lua
@@ -424,6 +424,8 @@ function torch.serializeToStorage(object, mode)
    f = f[mode](f)
    f:writeObject(object)
    local storage = f:storage()
+   -- the storage includes an extra NULL character: get rid of it
+   storage:resize(storage:size()-1)
    f:close()
    return storage
 end

--- a/test/test_writeObject.lua
+++ b/test/test_writeObject.lua
@@ -213,6 +213,17 @@ function tests.test_SerializationHook()
    myTester:assert(string.format('%x',torch.pointer(clone.s1)) == string.format('%x',torch.pointer(clone.s2)))
 end
 
+function tests.test_serializeToStorage()
+   torch.save("foo.t7", "foo")
+   local f = io.open("foo.t7", "rb")
+   local size = f:seek("end")
+   f:close()
+   myTester:eq(
+      torch.serializeToStorage("foo"):size(), size,
+      "memory and disk serializations should have the same size"
+   )
+end
+
 myTester:add(tests)
 myTester:run()
 if myTester.errors[1] then os.exit(1) end


### PR DESCRIPTION
This extra slot comes from [here](https://github.com/torch/torch7/blob/814836bb3115fa0a0b3f3d6982122e08f9f6530d/lib/TH/THMemoryFile.c#L230). IMHO we should get rid of it in the context of `serialize` / `serializeToStorage` so that archives are identical to those produced by `save`.