### PR TITLE
Fix _msize crash on windows xp

### DIFF
--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -130,7 +130,7 @@ static long getAllocSize(void *ptr) {
 #elif defined(__APPLE__)
   return malloc_size(ptr);
 #elif defined(_WIN32)
-  return _msize(ptr);
+  if(ptr) { return _msize(ptr); } else { return 0; }
 #else
   return 0;
 #endif


### PR DESCRIPTION
It will crash application when calling _msize(NULL) on windows xp.