### PR TITLE
Fix addmm for non-contiguous result tensor

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -808,8 +808,8 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   {
     transpose_r = 'n';
 
-    r__ = THTensor_(newWithSize2d)(r_->size[1], r_->size[0]);
-    THTensor_(copy)(r__, r_);
+    THTensor *transp_r_ = THTensor_(newTranspose)(r_, 0, 1);
+    r__ = THTensor_(newClone)(transp_r_);
     THTensor_(transpose)(r__, NULL, 0, 1);
   }
 


### PR DESCRIPTION
`addmm` didn't support properly non-contiguous result tensors.
The goal of this part of the code is to copy the contents of `r_` into `r__` such that `r__` contains the transpose of `r_` contiguous in memory.
The way it was doing was by considering `c_inv = torch.Tensor(c:size(2),c:size(1)):copy(c)`, which doesn't transpose the tensor but only change its shape.

This problem was introduced in https://github.com/torch/torch7/commit/0d534e64f5569fea2992a2754f0b87e27b3c1d8c .

I'll add more unit tests later if you want.

Should fix https://github.com/torch/torch7/issues/671

Also, something similar should be added to `cutorch`.