### PR TITLE
[TensorOperator.c] Make unary negation expression have real type, not double

### DIFF
--- a/generic/TensorOperator.c
+++ b/generic/TensorOperator.c
@@ -60,7 +60,7 @@ static int torch_TensorOperator_(__sub__)(lua_State *L)
     {
       THTensor_(resizeAs)(r, tensor1);
       THTensor_(copy)(r, tensor1);
-      THTensor_(add)(r, r, -luaL_checknumber(L, 2));
+      THTensor_(add)(r, r, -(real)luaL_checknumber(L, 2));
     }
     else
     {


### PR DESCRIPTION
Before this change, the expression `-luaL_checknumber(L, ...)` has type `double`, and its value may not be representable as `real`, leading to undefined behaviour. After this change, the unary negation is applied to a value of type `real`, and the arithmetic promotion and conversion rules give this well-defined behaviour.