### PR TITLE
Add function to get the amount of memory used by torch tensors

### DIFF
--- a/lib/TH/THGeneral.c
+++ b/lib/TH/THGeneral.c
@@ -268,3 +268,8 @@ double THLog1p(const double x)
   return log1p(x);
 #endif
 }
+
+long THGetHeapSize()
+{
+  return heapSize;
+}

--- a/lib/TH/THGeneral.h.in
+++ b/lib/TH/THGeneral.h.in
@@ -51,6 +51,7 @@ TH_API void* THAlloc(long size);
 TH_API void* THRealloc(void *ptr, long size);
 TH_API void THFree(void *ptr);
 TH_API void THSetGCHandler( void (*torchGCHandlerFunction)(void *data), void *data );
+TH_API long THGetHeapSize(void);
 // this hook should only be called by custom allocator functions
 TH_API void THHeapUpdate(long size);
 

--- a/utils.c
+++ b/utils.c
@@ -227,6 +227,12 @@ static int torch_updateerrorhandlers(lua_State *L)
   return 0;
 }
 
+static int torch_getmemory(lua_State *L)
+{
+  lua_pushinteger(L, THGetHeapSize());
+  return 1;
+}
+
 static const struct luaL_Reg torch_utils__ [] = {
   {"getdefaulttensortype", torch_lua_getdefaulttensortype},
   {"isatty", torch_isatty},
@@ -250,6 +256,7 @@ static const struct luaL_Reg torch_utils__ [] = {
   {"pointer", luaT_lua_pointer},
   {"setheaptracking", torch_setheaptracking},
   {"updateerrorhandlers", torch_updateerrorhandlers},
+  {"getmemory", torch_getmemory},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
Allows to get the amount of memory used by torch tensors.

In conjunction with `collectgarbage('count')`, we can have some good estimates of the total amount of memory used (except if other data structures are used, like `tds`).

**Note**: as `heapSize` is only updated by batches of ~ 1MB, so creating really small tensors won't show any immediate difference.

I will add docs if we agree to merge this.