### PR TITLE
Make CmdLine:log check whether file is a file descriptor, before creating a new file

### DIFF
--- a/CmdLine.lua
+++ b/CmdLine.lua
@@ -189,7 +189,7 @@ end
 
 local oprint = nil
 function CmdLine:log(file, params)
-   local f = (io.type(f) == 'file' and file) or io.open(file, 'w')
+   local f = (io.type(file) == 'file' and file) or io.open(file, 'w')
    oprint = oprint or print -- get the current print function lazily
    function print(...)
       local n = select("#", ...)

--- a/CmdLine.lua
+++ b/CmdLine.lua
@@ -189,7 +189,7 @@ end
 
 local oprint = nil
 function CmdLine:log(file, params)
-   local f = io.open(file, 'w')
+   local f = (io.type(f) == 'file' and file) or io.open(file, 'w')
    oprint = oprint or print -- get the current print function lazily
    function print(...)
       local n = select("#", ...)

--- a/doc/cmdline.md
+++ b/doc/cmdline.md
@@ -107,7 +107,8 @@ The final produced output for the following command is:
 ### log(filename, parameter_table) ###
 
 It sets the log filename to `filename` and prints the values of
-parameters in the `parameter_table`.
+parameters in the `parameter_table`. If filename is an open file
+descriptor, it will write to the file instead of creating a new one.
 
 <a name="torch.CmdLine.option"></a>
 ### option(name, default, help) ###


### PR DESCRIPTION
Allows the user to provide his own file (for example in a different mode or from a different source).