### PR TITLE
changing function load errors to warnings

### DIFF
--- a/File.lua
+++ b/File.lua
@@ -275,7 +275,7 @@ function File:readObject()
        local dumped = self:readChar(size):string()
        local func, err = loadstring(dumped)
        if not func then
-          error(string.format('Failed to load function from bytecode: %s', err))
+          io.stderr:write(string.format('Warning: Failed to load function from bytecode: %s', err))
        end
        local upvalues = self:readObject()
        for index,upvalue in ipairs(upvalues) do
@@ -298,7 +298,7 @@ function File:readObject()
          local dumped = self:readChar(size):string()
          local func, err = loadstring(dumped)
          if not func then
-            error(string.format('Failed to load function from bytecode: %s', err))
+	    io.stderr:write(string.format('Warning: Failed to load function from bytecode: %s', err))
          end
          if not force then
              objects[index] = func


### PR DESCRIPTION
This seems like a needed change, now that we have LuaJIT 2.1, 2.0, Lua 5.2 and soon Lua 5.3 used by torch users.

The models which are serialized usually have no functions, but occasionally have some functions which usually are not needed.

Fixes https://github.com/torch/torch7/issues/641 and #741 