### PR TITLE
Use stdint types for tensors

### DIFF
--- a/lib/TH/THFile.c
+++ b/lib/TH/THFile.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "THFile.h"
 #include "THFilePrivate.h"
 
@@ -12,11 +13,11 @@
     return (*self->vtable->write##TYPEC)(self, data, n);          \
   }
 
-IMPLEMENT_THFILE_RW(Byte, unsigned char)
-IMPLEMENT_THFILE_RW(Char, char)
-IMPLEMENT_THFILE_RW(Short, short)
-IMPLEMENT_THFILE_RW(Int, int)
-IMPLEMENT_THFILE_RW(Long, long)
+IMPLEMENT_THFILE_RW(Byte, uint8_t)
+IMPLEMENT_THFILE_RW(Char, int8_t)
+IMPLEMENT_THFILE_RW(Short, int16_t)
+IMPLEMENT_THFILE_RW(Int, int32_t)
+IMPLEMENT_THFILE_RW(Long, int64_t)
 IMPLEMENT_THFILE_RW(Float, float)
 IMPLEMENT_THFILE_RW(Double, double)
 
@@ -126,11 +127,11 @@ void THFile_clearError(THFile *self)
     THFile_write##TYPEC##Raw(self, &scalar, 1);               \
   }
 
-IMPLEMENT_THFILE_SCALAR(Byte, unsigned char)
-IMPLEMENT_THFILE_SCALAR(Char, char)
-IMPLEMENT_THFILE_SCALAR(Short, short)
-IMPLEMENT_THFILE_SCALAR(Int, int)
-IMPLEMENT_THFILE_SCALAR(Long, long)
+IMPLEMENT_THFILE_SCALAR(Byte, uint8_t)
+IMPLEMENT_THFILE_SCALAR(Char, int8_t)
+IMPLEMENT_THFILE_SCALAR(Short, int16_t)
+IMPLEMENT_THFILE_SCALAR(Int, int32_t)
+IMPLEMENT_THFILE_SCALAR(Long, int64_t)
 IMPLEMENT_THFILE_SCALAR(Float, float)
 IMPLEMENT_THFILE_SCALAR(Double, double)
 
@@ -145,10 +146,10 @@ IMPLEMENT_THFILE_SCALAR(Double, double)
     return THFile_write##TYPEC##Raw(self, storage->data, storage->size); \
   }
 
-IMPLEMENT_THFILE_STORAGE(Byte, unsigned char)
-IMPLEMENT_THFILE_STORAGE(Char, char)
-IMPLEMENT_THFILE_STORAGE(Short, short)
-IMPLEMENT_THFILE_STORAGE(Int, int)
-IMPLEMENT_THFILE_STORAGE(Long, long)
+IMPLEMENT_THFILE_STORAGE(Byte, uint8_t)
+IMPLEMENT_THFILE_STORAGE(Char, int8_t)
+IMPLEMENT_THFILE_STORAGE(Short, int16_t)
+IMPLEMENT_THFILE_STORAGE(Int, int32_t)
+IMPLEMENT_THFILE_STORAGE(Long, int64_t)
 IMPLEMENT_THFILE_STORAGE(Float, float)
 IMPLEMENT_THFILE_STORAGE(Double, double)

--- a/lib/TH/THFile.h
+++ b/lib/TH/THFile.h
@@ -1,6 +1,7 @@
 #ifndef TH_FILE_INC
 #define TH_FILE_INC
 
+#include <stdint.h>
 #include "THStorage.h"
 
 typedef struct THFile__ THFile;
@@ -22,19 +23,19 @@ TH_API void THFile_pedantic(THFile *self);
 TH_API void THFile_clearError(THFile *self);
 
 /* scalar */
-TH_API unsigned char THFile_readByteScalar(THFile *self);
-TH_API char THFile_readCharScalar(THFile *self);
-TH_API short THFile_readShortScalar(THFile *self);
-TH_API int THFile_readIntScalar(THFile *self);
-TH_API long THFile_readLongScalar(THFile *self);
+TH_API uint8_t THFile_readByteScalar(THFile *self);
+TH_API int8_t THFile_readCharScalar(THFile *self);
+TH_API int16_t THFile_readShortScalar(THFile *self);
+TH_API int32_t THFile_readIntScalar(THFile *self);
+TH_API int64_t THFile_readLongScalar(THFile *self);
 TH_API float THFile_readFloatScalar(THFile *self);
 TH_API double THFile_readDoubleScalar(THFile *self);
 
-TH_API void THFile_writeByteScalar(THFile *self, unsigned char scalar);
-TH_API void THFile_writeCharScalar(THFile *self, char scalar);
-TH_API void THFile_writeShortScalar(THFile *self, short scalar);
-TH_API void THFile_writeIntScalar(THFile *self, int scalar);
-TH_API void THFile_writeLongScalar(THFile *self, long scalar);
+TH_API void THFile_writeByteScalar(THFile *self, uint8_t scalar);
+TH_API void THFile_writeCharScalar(THFile *self, int8_t scalar);
+TH_API void THFile_writeShortScalar(THFile *self, int16_t scalar);
+TH_API void THFile_writeIntScalar(THFile *self, int32_t scalar);
+TH_API void THFile_writeLongScalar(THFile *self, int64_t scalar);
 TH_API void THFile_writeFloatScalar(THFile *self, float scalar);
 TH_API void THFile_writeDoubleScalar(THFile *self, double scalar);
 
@@ -56,20 +57,20 @@ TH_API size_t THFile_writeFloat(THFile *self, THFloatStorage *storage);
 TH_API size_t THFile_writeDouble(THFile *self, THDoubleStorage *storage);
 
 /* raw */
-TH_API size_t THFile_readByteRaw(THFile *self, unsigned char *data, size_t n);
-TH_API size_t THFile_readCharRaw(THFile *self, char *data, size_t n);
-TH_API size_t THFile_readShortRaw(THFile *self, short *data, size_t n);
-TH_API size_t THFile_readIntRaw(THFile *self, int *data, size_t n);
-TH_API size_t THFile_readLongRaw(THFile *self, long *data, size_t n);
+TH_API size_t THFile_readByteRaw(THFile *self, uint8_t *data, size_t n);
+TH_API size_t THFile_readCharRaw(THFile *self, int8_t *data, size_t n);
+TH_API size_t THFile_readShortRaw(THFile *self, int16_t *data, size_t n);
+TH_API size_t THFile_readIntRaw(THFile *self, int32_t *data, size_t n);
+TH_API size_t THFile_readLongRaw(THFile *self, int64_t *data, size_t n);
 TH_API size_t THFile_readFloatRaw(THFile *self, float *data, size_t n);
 TH_API size_t THFile_readDoubleRaw(THFile *self, double *data, size_t n);
 TH_API size_t THFile_readStringRaw(THFile *self, const char *format, char **str_); /* you must deallocate str_ */
 
-TH_API size_t THFile_writeByteRaw(THFile *self, unsigned char *data, size_t n);
-TH_API size_t THFile_writeCharRaw(THFile *self, char *data, size_t n);
-TH_API size_t THFile_writeShortRaw(THFile *self, short *data, size_t n);
-TH_API size_t THFile_writeIntRaw(THFile *self, int *data, size_t n);
-TH_API size_t THFile_writeLongRaw(THFile *self, long *data, size_t n);
+TH_API size_t THFile_writeByteRaw(THFile *self, uint8_t *data, size_t n);
+TH_API size_t THFile_writeCharRaw(THFile *self, int8_t *data, size_t n);
+TH_API size_t THFile_writeShortRaw(THFile *self, int16_t *data, size_t n);
+TH_API size_t THFile_writeIntRaw(THFile *self, int32_t *data, size_t n);
+TH_API size_t THFile_writeLongRaw(THFile *self, int64_t *data, size_t n);
 TH_API size_t THFile_writeFloatRaw(THFile *self, float *data, size_t n);
 TH_API size_t THFile_writeDoubleRaw(THFile *self, double *data, size_t n);
 TH_API size_t THFile_writeStringRaw(THFile *self, const char *str, size_t size);

--- a/lib/TH/THGenerateAllTypes.h
+++ b/lib/TH/THGenerateAllTypes.h
@@ -2,10 +2,12 @@
 #error "You must define TH_GENERIC_FILE before including THGenerateAllTypes.h"
 #endif
 
-#define real unsigned char
-#define accreal long
+#include <stdint.h>
+
+#define real uint8_t
+#define accreal int64_t
 #define Real Byte
-#define THInf UCHAR_MAX
+#define THInf UINT8_MAX
 #define TH_REAL_IS_BYTE
 #line 1 TH_GENERIC_FILE
 /*#line 1 "THByteStorage.h"*/
@@ -16,10 +18,10 @@
 #undef THInf
 #undef TH_REAL_IS_BYTE
 
-#define real char
-#define accreal long
+#define real int8_t
+#define accreal int64_t
 #define Real Char
-#define THInf CHAR_MAX
+#define THInf INT8_MAX
 #define TH_REAL_IS_CHAR
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
@@ -29,10 +31,10 @@
 #undef THInf
 #undef TH_REAL_IS_CHAR
 
-#define real short
-#define accreal long
+#define real int16_t
+#define accreal int64_t
 #define Real Short
-#define THInf SHRT_MAX
+#define THInf INT16_MAX
 #define TH_REAL_IS_SHORT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
@@ -42,10 +44,10 @@
 #undef THInf
 #undef TH_REAL_IS_SHORT
 
-#define real int
-#define accreal long
+#define real int32_t
+#define accreal int64_t
 #define Real Int
-#define THInf INT_MAX
+#define THInf INT32_MAX
 #define TH_REAL_IS_INT
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
@@ -55,10 +57,10 @@
 #undef THInf
 #undef TH_REAL_IS_INT
 
-#define real long
-#define accreal long
+#define real int64_t
+#define accreal int64_t
 #define Real Long
-#define THInf LONG_MAX
+#define THInf INT64_MAX
 #define TH_REAL_IS_LONG
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE


### PR DESCRIPTION
The most important changes are that:
 * LongTensor is now 64-bit on all platforms
 * CharTensor is always signed

cc @szagoruyko @apaszke 