### PR TITLE
fix cpuid ecx; change to compile with msvc; compile with MKL on windows

### DIFF
--- a/lib/TH/cmake/FindMKL.cmake
+++ b/lib/TH/cmake/FindMKL.cmake
@@ -55,6 +55,9 @@ ELSE(CMAKE_COMPILER_IS_GNUCC)
   SET(mklthreads "mkl_intel_thread")
   SET(mklifaces  "intel")
   SET(mklrtls "iomp5" "guide")
+  IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    SET(mklrtls "libiomp5md")
+  ENDIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 ENDIF (CMAKE_COMPILER_IS_GNUCC)
 
 # Kernel libraries dynamically loaded
@@ -80,6 +83,10 @@ IF (INTEL_MKL_DIR)
     "${INTEL_MKL_DIR}/include")
   SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
     "${INTEL_MKL_DIR}/lib/${mklvers}")
+  IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
+      "${INTEL_MKL_DIR}/lib/${iccvers}")
+  ENDIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 ENDIF (INTEL_MKL_DIR)
 
 # Try linking multiple libs

--- a/lib/TH/generic/simd/simd.h
+++ b/lib/TH/generic/simd/simd.h
@@ -2,6 +2,9 @@
 #define TH_SIMD_INC
 
 #include <stdint.h>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
 
 // Can be found on Intel ISA Reference for CPUID
 #define CPUID_AVX2_BIT 0x10       // Bit 5 of EBX for EAX=0x7
@@ -56,13 +59,22 @@ static inline uint32_t detectHostSIMDExtensions()
 
 static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)
 {
+#ifndef _MSC_VER
   uint32_t a = *eax, b, c, d;
   asm volatile ( "cpuid\n\t"
-                 : "+a"(a), "=b"(b), "+c"(c), "=d"(d) );
+                 : "+a"(a), "=b"(b), "=c"(c), "=d"(d) );
   *eax = a;
   *ebx = b;
   *ecx = c;
   *edx = d;
+#else
+  uint32_t cpuInfo[4];
+  __cpuid(cpuInfo, *eax);
+  *eax = cpuInfo[0];
+  *ebx = cpuInfo[1];
+  *ecx = cpuInfo[2];
+  *edx = cpuInfo[3];
+#endif
 }
 
 static inline uint32_t detectHostSIMDExtensions()

--- a/lib/TH/vector/SSE.c
+++ b/lib/TH/vector/SSE.c
@@ -1,4 +1,8 @@
+#ifndef _MSC_VER
 #include <x86intrin.h>
+#else
+#include <intrin.h>
+#endif
 
 
 static void THDoubleVector_fill_SSE(double *x, const double c, const long n) {


### PR DESCRIPTION
Hi,

This small change contains three parts:
1. fix one line cupid code from "+c" to "=c"
2. change master branch to compile with msvc
3. compile against mkl on windows with msvc

This change only affect those who use msvc, please let me know if any change is improper or can be improved.

Thanks