### PR TITLE
Fix compile error on freebsd

### DIFF
--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -2,9 +2,7 @@
 #include "THDiskFile.h"
 #include "THFilePrivate.h"
 
-#ifdef _WIN64
 #include <stdint.h>
-#endif
 
 typedef struct THDiskFile__
 {


### PR DESCRIPTION
On FreeBSD, int32_t is defined in stdint.h as well. this change fix the problem. Since stdint.h is part of Posix, it should be safe to include it unconditional.