### PR TITLE
Fix implementation of logNormal

### DIFF
--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -255,10 +255,8 @@ double THRandom_cauchy(THGenerator *_generator, double median, double sigma)
    M'enfin. */
 double THRandom_logNormal(THGenerator *_generator, double mean, double stdv)
 {
-  double zm = mean*mean;
-  double zs = stdv*stdv;
   THArgCheck(stdv > 0, 2, "standard deviation must be strictly positive");
-  return(exp(THRandom_normal(_generator, log(zm/sqrt(zs + zm)), sqrt(log(zs/zm+1)) )));
+  return(exp(THRandom_normal(_generator, mean, stdv)));
 }
 
 int THRandom_geometric(THGenerator *_generator, double p)

--- a/test/test.lua
+++ b/test/test.lua
@@ -3435,6 +3435,17 @@ function torchtest.bernoulli()
   mytester:assert(isBinary(t), 'Sample from torch.bernoulli is not binary')
 end
 
+function torchtest.logNormal()
+    local t = torch.FloatTensor(10, 10)
+    local mean, std = torch.uniform(), 0.1 * torch.uniform()
+    local tolerance = 0.01
+
+    t:logNormal(mean, std)
+    local logt = t:log()
+    mytester:assertalmosteq(logt:mean(), mean, tolerance, 'mean is wrong')
+    mytester:assertalmosteq(logt:std(), std, tolerance, 'tolerance is wrong')
+end
+
 function torch.test(tests)
    torch.setheaptracking(true)
    math.randomseed(os.time())


### PR DESCRIPTION
Current implementation was broken. See numpy:

https://github.com/numpy/numpy/blob/c90d7c94fd2077d0beca48fa89a423da2b0bb663/numpy/random/mtrand/distributions.c#L691

for a correct implementation, which we adopted here.

Test Plan:

- Add unit test, stolen from cutorch