### PR TITLE
Prevent runover refcount of tensor

### DIFF
--- a/lib/TH/generic/THTensor.c
+++ b/lib/TH/generic/THTensor.c
@@ -598,7 +598,7 @@ void THTensor_(free)(THTensor *self)
   if(!self)
     return;
 
-  if(self->flag & TH_TENSOR_REFCOUNTED)
+  if((self->flag & TH_TENSOR_REFCOUNTED) && (THAtomicGet(&self->refcount) > 0))
   {
     if(THAtomicDecrementRef(&self->refcount))
     {


### PR DESCRIPTION
This is necessary since for integrations with C one never knows what or when the lua gc kicks in.