### PR TITLE
Add a new function bhistc to calculate histogram of batch of images only once

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -1088,6 +1088,14 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name="long",default=100},
             {name="double",default=0},
             {name="double",default=0}})
+      
+      wrap("histc2",
+           cname("histc2"),
+           {{name=Tensor, default=true, returned=true},
+            {name=Tensor},
+            {name="long",default=100},
+            {name="double",default=0},
+            {name="double",default=0}})
 
       wrap("norm",
            cname("normall"),

--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -1089,8 +1089,8 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
             {name="double",default=0},
             {name="double",default=0}})
       
-      wrap("histc2",
-           cname("histc2"),
+      wrap("bhistc",
+           cname("bhistc"),
            {{name=Tensor, default=true, returned=true},
             {name=Tensor},
             {name="long",default=100},

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -150,11 +150,11 @@ By default the elements are sorted into 100 equally spaced bins between the mini
 `y = torch.histc(x, n, min, max)` same as above with `n` bins and `[min, max]` as elements range.
 
 
-<a name="torch.histc2"></a>
-### [res] torch.histc2([res,] x [,nbins, min_value, max_value]) ###
-<a name="torch.histc2"></a>
+<a name="torch.bhistc"></a>
+### [res] torch.bhistc([res,] x [,nbins, min_value, max_value]) ###
+<a name="torch.bhistc"></a>
 
-`y = torch.histc2(x)` returns the histogram of the elements in 2d tensor `x` along the last dimension.
+`y = torch.bhistc(x)` returns the histogram of the elements in 2d tensor `x` along the last dimension.
 By default the elements are sorted into 100 equally spaced bins between the minimum and maximum values of `x`.
 
 `y = torch.histc(x, n)` same as above with `n` bins.
@@ -174,7 +174,7 @@ x =torch.Tensor(3, 6)
  3  4  2  5  5  1
 [torch.DoubleTensor of size 3x6]
 
-> torch.histc2(x, 5, 1, 5)
+> torch.bhistc(x, 5, 1, 5)
  0  3  0  2  1
  1  0  2  0  3
  1  1  1  1  2
@@ -182,7 +182,7 @@ x =torch.Tensor(3, 6)
 
 > y = torch.Tensor(1, 6):copy(x[1])
 
-> torch.histc2(y, 5)
+> torch.bhistc(y, 5)
  3  0  2  0  1
 [torch.DoubleTensor of size 1x5]
 ```

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -157,9 +157,9 @@ By default the elements are sorted into 100 equally spaced bins between the mini
 `y = torch.bhistc(x)` returns the histogram of the elements in 2d tensor `x` along the last dimension.
 By default the elements are sorted into 100 equally spaced bins between the minimum and maximum values of `x`.
 
-`y = torch.histc(x, n)` same as above with `n` bins.
+`y = torch.bhistc(x, n)` same as above with `n` bins.
 
-`y = torch.histc(x, n, min, max)` same as above with `n` bins and `[min, max]` as elements range.
+`y = torch.bhistc(x, n, min, max)` same as above with `n` bins and `[min, max]` as elements range.
 
 ```lua
 x =torch.Tensor(3, 6)

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -150,6 +150,43 @@ By default the elements are sorted into 100 equally spaced bins between the mini
 `y = torch.histc(x, n, min, max)` same as above with `n` bins and `[min, max]` as elements range.
 
 
+<a name="torch.histc2"></a>
+### [res] torch.histc2([res,] x [,nbins, min_value, max_value]) ###
+<a name="torch.histc2"></a>
+
+`y = torch.histc2(x)` returns the histogram of the elements in 2d tensor `x` along the last dimension.
+By default the elements are sorted into 100 equally spaced bins between the minimum and maximum values of `x`.
+
+`y = torch.histc(x, n)` same as above with `n` bins.
+
+`y = torch.histc(x, n, min, max)` same as above with `n` bins and `[min, max]` as elements range.
+
+```lua
+x =torch.Tensor(3, 6)
+
+> x[1] = torch.Tensor{ 2, 4, 2, 2, 5, 4 }
+> x[2] = torch.Tensor{ 3, 5, 1, 5, 3, 5 }
+> x[3] = torch.Tensor{ 3, 4, 2, 5, 5, 1 }
+
+> x
+ 2  4  2  2  5  4
+ 3  5  1  5  3  5
+ 3  4  2  5  5  1
+[torch.DoubleTensor of size 3x6]
+
+> torch.histc2(x, 5, 1, 5)
+ 0  3  0  2  1
+ 1  0  2  0  3
+ 1  1  1  1  2
+[torch.DoubleTensor of size 3x5]
+
+> y = torch.Tensor(1, 6):copy(x[1])
+
+> torch.histc2(y, 5)
+ 3  0  2  0  1
+[torch.DoubleTensor of size 1x5]
+```
+
 <a name="torch.linspace"></a>
 ### [res] torch.linspace([res,] x1, x2, [,n]) ###
 <a name="torch.linspace"></a>

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -2538,7 +2538,7 @@ void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalu
   );
 }
 
-void THTensor_(histc2)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue)
+void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue)
 {  
   THArgCheck(THTensor_(nDimension)(tensor) < 3, 2, "invalid dimension %d, the input must be a 2d tensor", THTensor_(nDimension)(tensor));
   

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -163,6 +163,7 @@ TH_API void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension
 TH_API void THTensor_(renorm)(THTensor *r_, THTensor *t, real value, int dimension, real maxnorm);
 TH_API accreal THTensor_(dist)(THTensor *a, THTensor *b, real value);
 TH_API void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue);
+TH_API void THTensor_(histc2)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue);
 
 TH_API accreal THTensor_(meanall)(THTensor *self);
 TH_API accreal THTensor_(varall)(THTensor *self);

--- a/lib/TH/generic/THTensorMath.h
+++ b/lib/TH/generic/THTensorMath.h
@@ -163,7 +163,7 @@ TH_API void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension
 TH_API void THTensor_(renorm)(THTensor *r_, THTensor *t, real value, int dimension, real maxnorm);
 TH_API accreal THTensor_(dist)(THTensor *a, THTensor *b, real value);
 TH_API void THTensor_(histc)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue);
-TH_API void THTensor_(histc2)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue);
+TH_API void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, long nbins, real minvalue, real maxvalue);
 
 TH_API accreal THTensor_(meanall)(THTensor *self);
 TH_API accreal THTensor_(varall)(THTensor *self);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1355,6 +1355,18 @@ function torchtest.histc()
    local z = torch.Tensor{ 0, 3, 0, 2, 1 }
    mytester:assertTensorEq(y,z,precision,'error in torch.histc')
 end
+function torchtest.histc2()
+   local x = torch.Tensor(3, 6)
+   x[1] = torch.Tensor{ 2, 4, 2, 2, 5, 4 }
+   x[2] = torch.Tensor{ 3, 5, 1, 5, 3, 5 }
+   x[3] = torch.Tensor{ 3, 4, 2, 5, 5, 1 }
+   local y = torch.histc2(x, 5, 1, 5) -- nbins, min, max
+   local z = torch.Tensor(3, 5)
+   z[1] = torch.Tensor{ 0, 3, 0, 2, 1 }
+   z[2] = torch.Tensor{ 1, 0, 2, 0, 3 }
+   z[3] = torch.Tensor{ 1, 1, 1, 1, 2 }
+   mytester:assertTensorEq(y,z,precision,'error in torch.histc2 in last dimension')
+end
 function torchtest.ones()
    local mx = torch.ones(msize,msize)
    local mxx = torch.Tensor()

--- a/test/test.lua
+++ b/test/test.lua
@@ -1355,17 +1355,17 @@ function torchtest.histc()
    local z = torch.Tensor{ 0, 3, 0, 2, 1 }
    mytester:assertTensorEq(y,z,precision,'error in torch.histc')
 end
-function torchtest.histc2()
+function torchtest.bhistc()
    local x = torch.Tensor(3, 6)
    x[1] = torch.Tensor{ 2, 4, 2, 2, 5, 4 }
    x[2] = torch.Tensor{ 3, 5, 1, 5, 3, 5 }
    x[3] = torch.Tensor{ 3, 4, 2, 5, 5, 1 }
-   local y = torch.histc2(x, 5, 1, 5) -- nbins, min, max
+   local y = torch.bhistc(x, 5, 1, 5) -- nbins, min, max
    local z = torch.Tensor(3, 5)
    z[1] = torch.Tensor{ 0, 3, 0, 2, 1 }
    z[2] = torch.Tensor{ 1, 0, 2, 0, 3 }
    z[3] = torch.Tensor{ 1, 1, 1, 1, 2 }
-   mytester:assertTensorEq(y,z,precision,'error in torch.histc2 in last dimension')
+   mytester:assertTensorEq(y,z,precision,'error in torch.bhistc in last dimension')
 end
 function torchtest.ones()
    local mx = torch.ones(msize,msize)


### PR DESCRIPTION
[ Description ]
When a tensor contains multiple images, and one need to calculate the histogram of each image in this two dimension tensor. If using the original `torch.histc` function, should have to write a loop to calculate them. This way is not effective enough. So I write a new function named by `torch.histc2` to output the histogram tensor only once, the input is the 2D tensor, each row indicates an image, the default bins is 100 as the original `histc`, calculate the histogram along the last dimension of input tensor.

[ Code Change ]
* In `lib/TH/generic/THTensorMath.c`, add a new math function `void THTensor_(histc2)`
* In `lib/TH/generic/THTensorMath.h`, add a statement for `void THTensor_(histc2)`
* In `TensorMath.lua`, add the `histc2` for `wrap`
* In `test/test.lua`, add a test for new function `histc2`
* In `doc/maths.md`, add a new description for `torch.histc2` with some toy use instances

[ Compile ]
All these changes can be compiled pass locally.