### PR TITLE
Fix contiguous assertion in View implementation

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -458,7 +458,7 @@ function Tensor.view(result, src, ...)
    local origNElement = tensor:nElement()
    size = specifyFully(size, origNElement)
 
-   assert(tensor:isContiguous(), "expecting a contiguous tensor")
+   if not tensor:isContiguous() then tensor = tensor:clone() end
    view:set(tensor:storage(), tensor:storageOffset(), size)
    if view:nElement() ~= origNElement then
       local inputSize = table.concat(tensor:size():totable(), "x")


### PR DESCRIPTION
Replace the assertion in View implementation with automatic cloning if tensor not contiguous.