### PR TITLE
simd.h: really fix the arm64 (i.e. Aarch64) build

### DIFF
--- a/lib/TH/generic/simd/simd.h
+++ b/lib/TH/generic/simd/simd.h
@@ -53,7 +53,7 @@ enum SIMDExtensions
 };
 
 
-#if defined(__arm__) || defined(__NEON__)
+#if defined(__arm__) || defined(__aarch64__) // incl. armel, armhf, arm64
 
  #if defined(__NEON__)
 
@@ -80,7 +80,7 @@ static inline uint32_t detectHostSIMDExtensions()
   return SIMDExtension_VSX;
 }
 
- #else
+ #else //PPC64 without VSX
 
 static inline uint32_t detectHostSIMDExtensions()
 {


### PR DESCRIPTION
`__NEON__` is an ISA indicator instead of architecture indicator.