### PR TITLE
Speed up reductions on non-contiguous dimensions

### DIFF
--- a/lib/TH/THTensorApply.h
+++ b/lib/TH/THTensorApply.h
@@ -1,484 +1,6 @@
 #ifndef TH_TENSOR_APPLY_INC
 #define TH_TENSOR_APPLY_INC
 
-#define TH_TENSOR_APPLY3(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, CODE) \
-{ \
-  TYPE1 *TENSOR1##_data = NULL; \
-  long *TENSOR1##_counter = NULL, *TENSOR1##_sizes = NULL, *TENSOR1##_strides = NULL; \
-  long TENSOR1##_stride = 0, TENSOR1##_size = 0, TENSOR1##_dim = 0, TENSOR1##_i, TENSOR1##_n; \
-  TYPE2 *TENSOR2##_data = NULL; \
-  long *TENSOR2##_counter = NULL, *TENSOR2##_sizes = NULL, *TENSOR2##_strides = NULL; \
-  long TENSOR2##_stride = 0, TENSOR2##_size = 0, TENSOR2##_dim = 0, TENSOR2##_i, TENSOR2##_n; \
-  TYPE3 *TENSOR3##_data = NULL; \
-  long *TENSOR3##_counter = NULL, *TENSOR3##_sizes = NULL, *TENSOR3##_strides = NULL; \
-  long TENSOR3##_stride = 0, TENSOR3##_size = 0, TENSOR3##_dim = 0, TENSOR3##_i, TENSOR3##_n; \
-  int TH_TENSOR_APPLY_hasFinished = 0; \
-  int TH_TENSOR1_contiguous = 1, TH_TENSOR2_contiguous = 1, TH_TENSOR3_contiguous = 1; \
-  long TH_TENSOR_dim_index = 0; \
-\
-  TENSOR1##_n = (TENSOR1->nDimension ? 1 : 0); \
-  for(TENSOR1##_i = 0; TENSOR1##_i < TENSOR1->nDimension; TENSOR1##_i++) \
-    TENSOR1##_n *= TENSOR1->size[TENSOR1##_i]; \
-\
-  TENSOR2##_n = (TENSOR2->nDimension ? 1 : 0); \
-  for(TENSOR2##_i = 0; TENSOR2##_i < TENSOR2->nDimension; TENSOR2##_i++) \
-    TENSOR2##_n *= TENSOR2->size[TENSOR2##_i]; \
-\
-  TENSOR3##_n = (TENSOR3->nDimension ? 1 : 0); \
-  for(TENSOR3##_i = 0; TENSOR3##_i < TENSOR3->nDimension; TENSOR3##_i++) \
-    TENSOR3##_n *= TENSOR3->size[TENSOR3##_i]; \
-\
-  if(TENSOR1##_n != TENSOR2##_n || TENSOR1##_n != TENSOR3##_n) /* should we do the check in the function instead? i think so */ \
-    THError("inconsistent tensor size"); \
-\
-  if(TENSOR1->nDimension == 0) \
-    TH_TENSOR_APPLY_hasFinished = 1; \
-  else \
-  { \
-    TENSOR1##_data = TENSOR1->storage->data+TENSOR1->storageOffset; \
-    TENSOR1##_size = 1; \
-    TENSOR1##_stride = 1; \
-    for(TENSOR1##_i = TENSOR1->nDimension-1; TENSOR1##_i >= 0; TENSOR1##_i--) { \
-      if(TENSOR1->size[TENSOR1##_i] != 1) { \
-        if(TENSOR1->stride[TENSOR1##_i] == TENSOR1##_size) \
-          TENSOR1##_size *= TENSOR1->size[TENSOR1##_i]; \
-        else{ \
-          TH_TENSOR1_contiguous = 0; \
-          break; \
-        } \
-      } \
-    } \
-    if (!TH_TENSOR1_contiguous) { \
-      TENSOR1##_dim = 1; \
-      for(TENSOR1##_i = TENSOR1->nDimension-2; TENSOR1##_i >= 0; TENSOR1##_i--) \
-      { \
-        if(TENSOR1->stride[TENSOR1##_i] != TENSOR1->stride[TENSOR1##_i+1] * TENSOR1->size[TENSOR1##_i+1]) \
-          TENSOR1##_dim++; \
-      } \
-      TENSOR1##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR1##_dim)); \
-      TENSOR1##_sizes = TENSOR1##_counter + TENSOR1##_dim; \
-      TENSOR1##_strides = TENSOR1##_counter + 2*TENSOR1##_dim; \
-      TH_TENSOR_dim_index = TENSOR1##_dim-1; \
-      TENSOR1##_sizes[TH_TENSOR_dim_index] = TENSOR1->size[TENSOR1->nDimension-1]; \
-      TENSOR1##_strides[TH_TENSOR_dim_index] = TENSOR1->stride[TENSOR1->nDimension-1]; \
-      for(TENSOR1##_i = TENSOR1##_dim-1; TENSOR1##_i >= 0; --TENSOR1##_i) { \
-        TENSOR1##_counter[TENSOR1##_i] = 0; \
-      } \
-      for(TENSOR1##_i = TENSOR1->nDimension-2; TENSOR1##_i >= 0; --TENSOR1##_i) { \
-        if (TENSOR1->stride[TENSOR1##_i] == TENSOR1->stride[TENSOR1##_i+1] * TENSOR1->size[TENSOR1##_i+1]) { \
-          TENSOR1##_sizes[TH_TENSOR_dim_index] = TENSOR1->size[TENSOR1##_i] * TENSOR1##_sizes[TH_TENSOR_dim_index]; \
-        } else { \
-          --TH_TENSOR_dim_index; \
-          TENSOR1##_sizes[TH_TENSOR_dim_index] = TENSOR1->size[TENSOR1##_i]; \
-          TENSOR1##_strides[TH_TENSOR_dim_index] = TENSOR1->stride[TENSOR1##_i]; \
-        } \
-      } \
-      TENSOR1##_size = TENSOR1##_sizes[TENSOR1##_dim-1]; \
-      TENSOR1##_stride = TENSOR1##_strides[TENSOR1##_dim-1]; \
-    } \
-\
-    TENSOR2##_data = TENSOR2->storage->data+TENSOR2->storageOffset; \
-    TENSOR2##_size = 1; \
-    TENSOR2##_stride = 1; \
-    for(TENSOR2##_i = TENSOR2->nDimension-1; TENSOR2##_i >= 0; TENSOR2##_i--) { \
-      if(TENSOR2->size[TENSOR2##_i] != 1) { \
-        if(TENSOR2->stride[TENSOR2##_i] == TENSOR2##_size) \
-          TENSOR2##_size *= TENSOR2->size[TENSOR2##_i]; \
-        else{ \
-          TH_TENSOR2_contiguous = 0; \
-          break; \
-        } \
-      } \
-    } \
-    if (!TH_TENSOR2_contiguous) { \
-      TENSOR2##_dim = 1; \
-      for(TENSOR2##_i = TENSOR2->nDimension-2; TENSOR2##_i >= 0; TENSOR2##_i--) \
-      { \
-        if(TENSOR2->stride[TENSOR2##_i] != TENSOR2->stride[TENSOR2##_i+1] * TENSOR2->size[TENSOR2##_i+1]) \
-          TENSOR2##_dim++; \
-      } \
-      TENSOR2##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR2##_dim)); \
-      TENSOR2##_sizes = TENSOR2##_counter + TENSOR2##_dim; \
-      TENSOR2##_strides = TENSOR2##_counter + 2*TENSOR2##_dim; \
-      TH_TENSOR_dim_index = TENSOR2##_dim-1; \
-      TENSOR2##_sizes[TH_TENSOR_dim_index] = TENSOR2->size[TENSOR2->nDimension-1]; \
-      TENSOR2##_strides[TH_TENSOR_dim_index] = TENSOR2->stride[TENSOR2->nDimension-1]; \
-      for(TENSOR2##_i = TENSOR2##_dim-1; TENSOR2##_i >= 0; --TENSOR2##_i) { \
-        TENSOR2##_counter[TENSOR2##_i] = 0; \
-      } \
-      for(TENSOR2##_i = TENSOR2->nDimension-2; TENSOR2##_i >= 0; --TENSOR2##_i) { \
-        if (TENSOR2->stride[TENSOR2##_i] == TENSOR2->stride[TENSOR2##_i+1] * TENSOR2->size[TENSOR2##_i+1]) { \
-          TENSOR2##_sizes[TH_TENSOR_dim_index] = TENSOR2->size[TENSOR2##_i] * TENSOR2##_sizes[TH_TENSOR_dim_index]; \
-        } else { \
-          --TH_TENSOR_dim_index; \
-          TENSOR2##_sizes[TH_TENSOR_dim_index] = TENSOR2->size[TENSOR2##_i]; \
-          TENSOR2##_strides[TH_TENSOR_dim_index] = TENSOR2->stride[TENSOR2##_i]; \
-        } \
-      } \
-      TENSOR2##_size = TENSOR2##_sizes[TENSOR2##_dim-1]; \
-      TENSOR2##_stride = TENSOR2##_strides[TENSOR2##_dim-1]; \
-    } \
-\
-    TENSOR3##_data = TENSOR3->storage->data+TENSOR3->storageOffset; \
-    TENSOR3##_size = 1; \
-    TENSOR3##_stride = 1; \
-    for(TENSOR3##_i = TENSOR3->nDimension-1; TENSOR3##_i >= 0; TENSOR3##_i--) { \
-      if(TENSOR3->size[TENSOR3##_i] != 1) { \
-        if(TENSOR3->stride[TENSOR3##_i] == TENSOR3##_size) \
-          TENSOR3##_size *= TENSOR3->size[TENSOR3##_i]; \
-        else{ \
-          TH_TENSOR3_contiguous = 0; \
-          break; \
-        } \
-      } \
-    } \
-    if (!TH_TENSOR3_contiguous) { \
-      TENSOR3##_data = TENSOR3->storage->data+TENSOR3->storageOffset; \
-      TENSOR3##_dim = 1; \
-      for(TENSOR3##_i = TENSOR3->nDimension-2; TENSOR3##_i >= 0; TENSOR3##_i--) \
-      { \
-        if(TENSOR3->stride[TENSOR3##_i] != TENSOR3->stride[TENSOR3##_i+1] * TENSOR3->size[TENSOR3##_i+1]) \
-          TENSOR3##_dim++; \
-      } \
-      TENSOR3##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR3##_dim)); \
-      TENSOR3##_sizes = TENSOR3##_counter + TENSOR3##_dim; \
-      TENSOR3##_strides = TENSOR3##_counter + 2*TENSOR3##_dim; \
-      TH_TENSOR_dim_index = TENSOR3##_dim-1; \
-      TENSOR3##_sizes[TH_TENSOR_dim_index] = TENSOR3->size[TENSOR3->nDimension-1]; \
-      TENSOR3##_strides[TH_TENSOR_dim_index] = TENSOR3->stride[TENSOR3->nDimension-1]; \
-      for(TENSOR3##_i = TENSOR3##_dim-1; TENSOR3##_i >= 0; --TENSOR3##_i) { \
-        TENSOR3##_counter[TENSOR3##_i] = 0; \
-      } \
-      for(TENSOR3##_i = TENSOR3->nDimension-2; TENSOR3##_i >= 0; --TENSOR3##_i) { \
-        if (TENSOR3->stride[TENSOR3##_i] == TENSOR3->stride[TENSOR3##_i+1] * TENSOR3->size[TENSOR3##_i+1]) { \
-          TENSOR3##_sizes[TH_TENSOR_dim_index] = TENSOR3->size[TENSOR3##_i] * TENSOR3##_sizes[TH_TENSOR_dim_index]; \
-        } else { \
-          --TH_TENSOR_dim_index; \
-          TENSOR3##_sizes[TH_TENSOR_dim_index] = TENSOR3->size[TENSOR3##_i]; \
-          TENSOR3##_strides[TH_TENSOR_dim_index] = TENSOR3->stride[TENSOR3##_i]; \
-        } \
-      } \
-      TENSOR3##_size = TENSOR3##_sizes[TENSOR3##_dim-1]; \
-      TENSOR3##_stride = TENSOR3##_strides[TENSOR3##_dim-1]; \
-    } \
-  } \
-\
-  TENSOR1##_i = 0; \
-  TENSOR2##_i = 0; \
-  TENSOR3##_i = 0; \
-  while(!TH_TENSOR_APPLY_hasFinished) \
-  { \
-    for(; TENSOR1##_i < TENSOR1##_size && TENSOR2##_i < TENSOR2##_size && TENSOR3##_i < TENSOR3##_size; TENSOR1##_i++, TENSOR2##_i++, TENSOR3##_i++, TENSOR1##_data += TENSOR1##_stride, TENSOR2##_data += TENSOR2##_stride, TENSOR3##_data += TENSOR3##_stride) /* 0 et pas TENSOR##_dim! */ \
-    { \
-      CODE \
-    } \
-\
-    if(TENSOR1##_i == TENSOR1##_size) \
-    { \
-      if(TH_TENSOR1_contiguous) \
-        break; \
-\
-      if(TENSOR1##_dim == 1) \
-         break; \
-\
-      TENSOR1##_data -= TENSOR1##_size*TENSOR1##_stride; \
-      for(TENSOR1##_i = TENSOR1##_dim-2; TENSOR1##_i >= 0; TENSOR1##_i--) \
-      { \
-        TENSOR1##_counter[TENSOR1##_i]++; \
-        TENSOR1##_data += TENSOR1##_strides[TENSOR1##_i]; \
-\
-        if(TENSOR1##_counter[TENSOR1##_i]  == TENSOR1##_sizes[TENSOR1##_i]) \
-        { \
-          if(TENSOR1##_i == 0) \
-          { \
-            TH_TENSOR_APPLY_hasFinished = 1; \
-            break; \
-          } \
-            else \
-          { \
-            TENSOR1##_data -= TENSOR1##_counter[TENSOR1##_i]*TENSOR1##_strides[TENSOR1##_i]; \
-            TENSOR1##_counter[TENSOR1##_i] = 0; \
-          } \
-        } \
-        else \
-          break; \
-      } \
-      TENSOR1##_i = 0; \
-    } \
-\
-    if(TENSOR2##_i == TENSOR2##_size) \
-    { \
-      if(TH_TENSOR2_contiguous) \
-        break; \
-\
-      if(TENSOR2##_dim == 1) \
-         break; \
-\
-      TENSOR2##_data -= TENSOR2##_size*TENSOR2##_stride; \
-      for(TENSOR2##_i = TENSOR2##_dim-2; TENSOR2##_i >= 0; TENSOR2##_i--) \
-      { \
-        TENSOR2##_counter[TENSOR2##_i]++; \
-        TENSOR2##_data += TENSOR2##_strides[TENSOR2##_i]; \
-\
-        if(TENSOR2##_counter[TENSOR2##_i]  == TENSOR2##_sizes[TENSOR2##_i]) \
-        { \
-          if(TENSOR2##_i == 0) \
-          { \
-            TH_TENSOR_APPLY_hasFinished = 1; \
-            break; \
-          } \
-            else \
-          { \
-            TENSOR2##_data -= TENSOR2##_counter[TENSOR2##_i]*TENSOR2##_strides[TENSOR2##_i]; \
-            TENSOR2##_counter[TENSOR2##_i] = 0; \
-          } \
-        } \
-        else \
-          break; \
-      } \
-      TENSOR2##_i = 0; \
-    } \
-\
-    if(TENSOR3##_i == TENSOR3##_size) \
-    { \
-      if(TH_TENSOR3_contiguous) \
-        break; \
-\
-      if(TENSOR3##_dim == 1) \
-         break; \
-\
-      TENSOR3##_data -= TENSOR3##_size*TENSOR3##_stride; \
-      for(TENSOR3##_i = TENSOR3##_dim-2; TENSOR3##_i >= 0; TENSOR3##_i--) \
-      { \
-        TENSOR3##_counter[TENSOR3##_i]++; \
-        TENSOR3##_data += TENSOR3##_strides[TENSOR3##_i]; \
-\
-        if(TENSOR3##_counter[TENSOR3##_i]  == TENSOR3##_sizes[TENSOR3##_i]) \
-        { \
-          if(TENSOR3##_i == 0) \
-          { \
-            TH_TENSOR_APPLY_hasFinished = 1; \
-            break; \
-          } \
-            else \
-          { \
-            TENSOR3##_data -= TENSOR3##_counter[TENSOR3##_i]*TENSOR3##_strides[TENSOR3##_i]; \
-            TENSOR3##_counter[TENSOR3##_i] = 0; \
-          } \
-        } \
-        else \
-          break; \
-      } \
-      TENSOR3##_i = 0; \
-    } \
-  } \
-  if(!TH_TENSOR1_contiguous) \
-    THFree(TENSOR1##_counter); \
-  if(!TH_TENSOR2_contiguous) \
-    THFree(TENSOR2##_counter); \
-  if(!TH_TENSOR3_contiguous) \
-    THFree(TENSOR3##_counter); \
-}
-
-#define TH_TENSOR_APPLY2(TYPE1, TENSOR1, TYPE2, TENSOR2, CODE) \
-{ \
-  TYPE1 *TENSOR1##_data = NULL; \
-  long *TENSOR1##_counter = NULL, *TENSOR1##_sizes = NULL, *TENSOR1##_strides = NULL; \
-  long TENSOR1##_stride = 0, TENSOR1##_size = 0, TENSOR1##_dim = 0, TENSOR1##_i, TENSOR1##_n; \
-  TYPE2 *TENSOR2##_data = NULL; \
-  long *TENSOR2##_counter = NULL, *TENSOR2##_sizes = NULL, *TENSOR2##_strides = NULL; \
-  long TENSOR2##_stride = 0, TENSOR2##_size = 0, TENSOR2##_dim = 0, TENSOR2##_i, TENSOR2##_n; \
-  int TH_TENSOR_APPLY_hasFinished = 0; \
-  int TH_TENSOR1_contiguous = 1, TH_TENSOR2_contiguous = 1; \
-  long TH_TENSOR_dim_index = 0; \
-\
-  TENSOR1##_n = (TENSOR1->nDimension ? 1 : 0); \
-  for(TENSOR1##_i = 0; TENSOR1##_i < TENSOR1->nDimension; TENSOR1##_i++) \
-    TENSOR1##_n *= TENSOR1->size[TENSOR1##_i]; \
-\
-  TENSOR2##_n = (TENSOR2->nDimension ? 1 : 0); \
-  for(TENSOR2##_i = 0; TENSOR2##_i < TENSOR2->nDimension; TENSOR2##_i++) \
-    TENSOR2##_n *= TENSOR2->size[TENSOR2##_i]; \
-\
-  if(TENSOR1##_n != TENSOR2##_n) /* should we do the check in the function instead? i think so */ \
-    THError("inconsistent tensor size"); \
-\
-  if(TENSOR1->nDimension == 0) \
-    TH_TENSOR_APPLY_hasFinished = 1; \
-  else \
-  { \
-    TENSOR1##_data = TENSOR1->storage->data+TENSOR1->storageOffset; \
-    TENSOR1##_size = 1; \
-    TENSOR1##_stride = 1; \
-    for(TENSOR1##_i = TENSOR1->nDimension-1; TENSOR1##_i >= 0; TENSOR1##_i--) { \
-      if(TENSOR1->size[TENSOR1##_i] != 1) { \
-        if(TENSOR1->stride[TENSOR1##_i] == TENSOR1##_size) \
-          TENSOR1##_size *= TENSOR1->size[TENSOR1##_i]; \
-        else{ \
-          TH_TENSOR1_contiguous = 0; \
-          break; \
-        } \
-      } \
-    } \
-    if (!TH_TENSOR1_contiguous) { \
-      TENSOR1##_dim = 1; \
-      for(TENSOR1##_i = TENSOR1->nDimension-2; TENSOR1##_i >= 0; TENSOR1##_i--) \
-      { \
-        if(TENSOR1->stride[TENSOR1##_i] != TENSOR1->stride[TENSOR1##_i+1] * TENSOR1->size[TENSOR1##_i+1]) \
-          TENSOR1##_dim++; \
-      } \
-      TENSOR1##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR1##_dim)); \
-      TENSOR1##_sizes = TENSOR1##_counter + TENSOR1##_dim; \
-      TENSOR1##_strides = TENSOR1##_counter + 2*TENSOR1##_dim; \
-      TH_TENSOR_dim_index = TENSOR1##_dim-1; \
-      TENSOR1##_sizes[TH_TENSOR_dim_index] = TENSOR1->size[TENSOR1->nDimension-1]; \
-      TENSOR1##_strides[TH_TENSOR_dim_index] = TENSOR1->stride[TENSOR1->nDimension-1]; \
-      for(TENSOR1##_i = TENSOR1##_dim-1; TENSOR1##_i >= 0; --TENSOR1##_i) { \
-        TENSOR1##_counter[TENSOR1##_i] = 0; \
-      } \
-      for(TENSOR1##_i = TENSOR1->nDimension-2; TENSOR1##_i >= 0; --TENSOR1##_i) { \
-        if(TENSOR1->stride[TENSOR1##_i] == TENSOR1->stride[TENSOR1##_i+1] * TENSOR1->size[TENSOR1##_i+1]) { \
-          TENSOR1##_sizes[TH_TENSOR_dim_index] = TENSOR1->size[TENSOR1##_i] * TENSOR1##_sizes[TH_TENSOR_dim_index]; \
-        } else { \
-          --TH_TENSOR_dim_index; \
-          TENSOR1##_sizes[TH_TENSOR_dim_index] = TENSOR1->size[TENSOR1##_i]; \
-          TENSOR1##_strides[TH_TENSOR_dim_index] = TENSOR1->stride[TENSOR1##_i]; \
-        } \
-      } \
-      TENSOR1##_size = TENSOR1##_sizes[TENSOR1##_dim-1]; \
-      TENSOR1##_stride = TENSOR1##_strides[TENSOR1##_dim-1]; \
-    } \
-\
-    TENSOR2##_data = TENSOR2->storage->data+TENSOR2->storageOffset; \
-    TENSOR2##_size = 1; \
-    TENSOR2##_stride = 1; \
-    for(TENSOR2##_i = TENSOR2->nDimension-1; TENSOR2##_i >= 0; TENSOR2##_i--) { \
-      if(TENSOR2->size[TENSOR2##_i] != 1) { \
-        if(TENSOR2->stride[TENSOR2##_i] == TENSOR2##_size) \
-          TENSOR2##_size *= TENSOR2->size[TENSOR2##_i]; \
-        else{ \
-          TH_TENSOR2_contiguous = 0; \
-          break; \
-        } \
-      } \
-    } \
-    if(!TH_TENSOR2_contiguous) { \
-      TENSOR2##_dim = 1; \
-      for(TENSOR2##_i = TENSOR2->nDimension-2; TENSOR2##_i >= 0; TENSOR2##_i--) \
-      { \
-        if(TENSOR2->stride[TENSOR2##_i] != TENSOR2->stride[TENSOR2##_i+1] * TENSOR2->size[TENSOR2##_i+1]) \
-          TENSOR2##_dim++; \
-      } \
-      TENSOR2##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR2##_dim)); \
-      TENSOR2##_sizes = TENSOR2##_counter + TENSOR2##_dim; \
-      TENSOR2##_strides = TENSOR2##_counter + 2*TENSOR2##_dim; \
-      TH_TENSOR_dim_index = TENSOR2##_dim-1; \
-      TENSOR2##_sizes[TH_TENSOR_dim_index] = TENSOR2->size[TENSOR2->nDimension-1]; \
-      TENSOR2##_strides[TH_TENSOR_dim_index] = TENSOR2->stride[TENSOR2->nDimension-1]; \
-      for(TENSOR2##_i = TENSOR2##_dim-1; TENSOR2##_i >= 0; --TENSOR2##_i) { \
-        TENSOR2##_counter[TENSOR2##_i] = 0; \
-      } \
-      for(TENSOR2##_i = TENSOR2->nDimension-2; TENSOR2##_i >= 0; --TENSOR2##_i) { \
-        if (TENSOR2->stride[TENSOR2##_i] == TENSOR2->stride[TENSOR2##_i+1] * TENSOR2->size[TENSOR2##_i+1]) { \
-          TENSOR2##_sizes[TH_TENSOR_dim_index] = TENSOR2->size[TENSOR2##_i] * TENSOR2##_sizes[TH_TENSOR_dim_index]; \
-        } else { \
-          --TH_TENSOR_dim_index; \
-          TENSOR2##_sizes[TH_TENSOR_dim_index] = TENSOR2->size[TENSOR2##_i]; \
-          TENSOR2##_strides[TH_TENSOR_dim_index] = TENSOR2->stride[TENSOR2##_i]; \
-        } \
-      } \
-      TENSOR2##_size = TENSOR2##_sizes[TENSOR2##_dim-1]; \
-      TENSOR2##_stride = TENSOR2##_strides[TENSOR2##_dim-1]; \
-    } else { \
-      TENSOR2##_size = 1; \
-      for(TENSOR2##_i = TENSOR2->nDimension-1; TENSOR2##_i >= 0; --TENSOR2##_i) { \
-        TENSOR2##_size *= TENSOR2->size[TENSOR2##_i]; \
-      } \
-      TENSOR2##_stride = 1; \
-    } \
-  } \
-\
-  TENSOR1##_i = 0; \
-  TENSOR2##_i = 0; \
-  while(!TH_TENSOR_APPLY_hasFinished) \
-  { \
-    for(; TENSOR1##_i < TENSOR1##_size && TENSOR2##_i < TENSOR2##_size; TENSOR1##_i++, TENSOR2##_i++, TENSOR1##_data += TENSOR1##_stride, TENSOR2##_data += TENSOR2##_stride) /* 0 et pas TENSOR##_dim! */ \
-    { \
-      CODE \
-    } \
-\
-    if(TENSOR1##_i == TENSOR1##_size) \
-    { \
-      if(TH_TENSOR1_contiguous == 1) \
-        break; \
-\
-      if(TENSOR1##_dim == 1) \
-         break; \
-\
-      TENSOR1##_data -= TENSOR1##_size*TENSOR1##_stride; \
-      for(TENSOR1##_i = TENSOR1##_dim-2; TENSOR1##_i >= 0; TENSOR1##_i--) \
-      { \
-        TENSOR1##_counter[TENSOR1##_i]++; \
-        TENSOR1##_data += TENSOR1##_strides[TENSOR1##_i]; \
-\
-        if(TENSOR1##_counter[TENSOR1##_i]  == TENSOR1##_sizes[TENSOR1##_i]) \
-        { \
-          if(TENSOR1##_i == 0) \
-          { \
-            TH_TENSOR_APPLY_hasFinished = 1; \
-            break; \
-          } \
-            else \
-          { \
-            TENSOR1##_data -= TENSOR1##_counter[TENSOR1##_i]*TENSOR1##_strides[TENSOR1##_i]; \
-            TENSOR1##_counter[TENSOR1##_i] = 0; \
-          } \
-        } \
-        else \
-          break; \
-      } \
-      TENSOR1##_i = 0; \
-    } \
-\
-    if(TENSOR2##_i == TENSOR2##_size) \
-    { \
-      if(TH_TENSOR2_contiguous == 1) \
-        break; \
-\
-      if(TENSOR2##_dim == 1) \
-        break; \
-\
-      TENSOR2##_data -= TENSOR2##_size*TENSOR2##_stride; \
-      for(TENSOR2##_i = TENSOR2##_dim-2; TENSOR2##_i >= 0; TENSOR2##_i--) \
-      { \
-        TENSOR2##_counter[TENSOR2##_i]++; \
-        TENSOR2##_data += TENSOR2##_strides[TENSOR2##_i]; \
-\
-        if(TENSOR2##_counter[TENSOR2##_i]  == TENSOR2##_sizes[TENSOR2##_i]) \
-        { \
-          if(TENSOR2##_i == 0) \
-          { \
-            TH_TENSOR_APPLY_hasFinished = 1; \
-            break; \
-          } \
-            else \
-          { \
-            TENSOR2##_data -= TENSOR2##_counter[TENSOR2##_i]*TENSOR2##_strides[TENSOR2##_i]; \
-            TENSOR2##_counter[TENSOR2##_i] = 0; \
-          } \
-        } \
-        else \
-          break; \
-      } \
-      TENSOR2##_i = 0; \
-    } \
-  } \
-  if (!TH_TENSOR1_contiguous) \
-    THFree(TENSOR1##_counter); \
-  if (!TH_TENSOR2_contiguous) \
-    THFree(TENSOR2##_counter); \
-}
-
 /*
  * The basic strategy for apply is as follows:
  *
@@ -507,85 +29,99 @@
  * dimensions can be merged for the purposes of APPLY, reducing the number of nested
  * loops.
  */
-#define TH_TENSOR_APPLY(TYPE, TENSOR, CODE) \
-{ \
+
+#define __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, DIM, ALLOW_CONTIGUOUS) \
   TYPE *TENSOR##_data = NULL; \
-  long *TENSOR##_counter = NULL, *TENSOR##_sizes = NULL, *TENSOR##_strides = NULL; \
-  long TENSOR##_stride = 0, TENSOR##_size = 0, TENSOR##_dim = 0, TENSOR##_i; \
-  int TH_TENSOR_APPLY_hasFinished = 0; \
-  long TH_TENSOR_dim_index = 0; \
+  long *TENSOR##_counter = NULL, *TENSOR##_sizes = NULL, *TENSOR##_strides = NULL, *TENSOR##_dimOffset = NULL; \
+  long TENSOR##_stride = 0, TENSOR##_size = 0, TENSOR##_dim = 0, TENSOR##_i, TENSOR##_n; \
+  int TENSOR##_contiguous = ALLOW_CONTIGUOUS; \
+  TENSOR##_n = (TENSOR->nDimension ? 1 : 0); \
+  for(TENSOR##_i = 0; TENSOR##_i < TENSOR->nDimension; TENSOR##_i++) \
+    TENSOR##_n *= TENSOR->size[TENSOR##_i]; \
 \
   if(TENSOR->nDimension == 0) \
     TH_TENSOR_APPLY_hasFinished = 1; \
   else \
   { \
     TENSOR##_data = TENSOR->storage->data+TENSOR->storageOffset; \
-\
-    /* Find the dimension of contiguous sections */ \
-    TENSOR##_dim = 1; \
-    for(TENSOR##_i = TENSOR->nDimension-2; TENSOR##_i >= 0; TENSOR##_i--) \
-    { \
-      if(TENSOR->stride[TENSOR##_i] != TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1]) \
-        TENSOR##_dim++; \
-    } \
-\
-    /* Allocate an array of 3*dim elements, where dim is the number of contiguous sections */ \
-    TENSOR##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR##_dim)); \
-    TENSOR##_sizes = TENSOR##_counter + TENSOR##_dim; \
-    TENSOR##_strides = TENSOR##_counter + 2*TENSOR##_dim; \
-    TH_TENSOR_dim_index = TENSOR##_dim-1; \
-    TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR->nDimension-1]; \
-    TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR->nDimension-1]; \
-    /* TENSOR##_counter tracks where we are in the storage. The offset into the */ \
-    /* storage is given by storage_offset + (i * j), where i is the stride */ \
-    /* vector and j is tensor_counter vector. This sets the starting position for the loop. */ \
-    for(TENSOR##_i = TENSOR##_dim-1; TENSOR##_i >= 0; --TENSOR##_i) { \
-      TENSOR##_counter[TENSOR##_i] = 0; \
-    } \
-    for(TENSOR##_i = TENSOR->nDimension-2; TENSOR##_i >= 0; --TENSOR##_i) { \
-      if (TENSOR->stride[TENSOR##_i] == TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1]) { \
-        TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i] * TENSOR##_sizes[TH_TENSOR_dim_index]; \
-      } else { \
-        --TH_TENSOR_dim_index; \
-        TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i]; \
-        TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR##_i]; \
+    TENSOR##_size = 1; \
+    TENSOR##_stride = 1; \
+    for(TENSOR##_i = TENSOR->nDimension-1; TENSOR##_i >= 0; TENSOR##_i--) { \
+      if(TENSOR->size[TENSOR##_i] != 1) { \
+        if(TENSOR->stride[TENSOR##_i] == TENSOR##_size && TENSOR##_i != DIM) \
+          TENSOR##_size *= TENSOR->size[TENSOR##_i]; \
+        else{ \
+          TENSOR##_contiguous = 0; \
+          break; \
+        } \
       } \
     } \
-    /* Size of the inner most section */ \
-    TENSOR##_size = TENSOR##_sizes[TENSOR##_dim-1]; \
-    /* Stride of the inner most section */ \
-    TENSOR##_stride = TENSOR##_strides[TENSOR##_dim-1]; \
-  } \
-\
-\
-  while(!TH_TENSOR_APPLY_hasFinished) \
-  { \
-    /* Loop through the inner most region of the Tensor */ \
-    for(TENSOR##_i = 0; TENSOR##_i < TENSOR##_size; TENSOR##_i++, TENSOR##_data += TENSOR##_stride) /* 0 et pas TENSOR##_dim! */ \
-    { \
-      CODE \
+    if (!TENSOR##_contiguous) { \
+      /* Find the dimension of contiguous sections */ \
+      TENSOR##_dim = 1; \
+      for(TENSOR##_i = TENSOR->nDimension-2; TENSOR##_i >= 0; TENSOR##_i--) \
+      { \
+        if(TENSOR->stride[TENSOR##_i] != TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1] || TENSOR##_i == DIM) \
+          TENSOR##_dim++; \
+      } \
+      /* Allocate an array of 3*dim elements, where dim is the number of contiguous sections */ \
+      TENSOR##_counter = (long*)THAlloc(sizeof(long)*(3*TENSOR##_dim)); \
+      TENSOR##_sizes = TENSOR##_counter + TENSOR##_dim; \
+      TENSOR##_strides = TENSOR##_counter + 2*TENSOR##_dim; \
+      TH_TENSOR_dim_index = TENSOR##_dim-1; \
+      TENSOR##_dimOffset = &TENSOR##_counter[DIM]; \
+      TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR->nDimension-1]; \
+      TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR->nDimension-1]; \
+      /* TENSOR##_counter tracks where we are in the storage. The offset into the */ \
+      /* storage is given by storage_offset + (i * j), where i is the stride */ \
+      /* vector and j is tensor_counter vector. This sets the starting position for the loop. */ \
+      for(TENSOR##_i = TENSOR##_dim-1; TENSOR##_i >= 0; --TENSOR##_i) { \
+        TENSOR##_counter[TENSOR##_i] = 0; \
+      } \
+      for(TENSOR##_i = TENSOR->nDimension-2; TENSOR##_i >= 0; --TENSOR##_i) { \
+        if (TENSOR->stride[TENSOR##_i] == TENSOR->stride[TENSOR##_i+1] * TENSOR->size[TENSOR##_i+1] && TENSOR##_i != DIM) { \
+          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i] * TENSOR##_sizes[TH_TENSOR_dim_index]; \
+          if (TENSOR##_i < DIM) \
+            TENSOR##_dimOffset--; \
+        } else { \
+          --TH_TENSOR_dim_index; \
+          TENSOR##_sizes[TH_TENSOR_dim_index] = TENSOR->size[TENSOR##_i]; \
+          TENSOR##_strides[TH_TENSOR_dim_index] = TENSOR->stride[TENSOR##_i]; \
+        } \
+      } \
+      /* Size of the inner most section */ \
+      TENSOR##_size = TENSOR##_sizes[TENSOR##_dim-1]; \
+      /* Stride of the inner most section */ \
+      TENSOR##_stride = TENSOR##_strides[TENSOR##_dim-1]; \
     } \
-\
-    if(TENSOR##_dim == 1) \
+  } \
+  TENSOR##_i = 0;
+
+#define  __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR, ALWAYS_UPDATE) \
+  if(TENSOR##_i == TENSOR##_size || ALWAYS_UPDATE) \
+  { \
+    if(TENSOR##_contiguous) \
       break; \
 \
+    if(TENSOR##_dim == 1) \
+       break; \
+\
     /* Reset pointer to beginning of loop */ \
-    TENSOR##_data -= TENSOR##_i*TENSOR##_stride; \
+    TENSOR##_data -= TENSOR##_size*TENSOR##_stride; \
     for(TENSOR##_i = TENSOR##_dim-2; TENSOR##_i >= 0; TENSOR##_i--) \
     { \
       TENSOR##_counter[TENSOR##_i]++; \
-\
       /* Jump ahread by the stride of this dimension */ \
       TENSOR##_data += TENSOR##_strides[TENSOR##_i]; \
 \
-      if(TENSOR##_counter[TENSOR##_i] == TENSOR##_sizes[TENSOR##_i]) \
+      if(TENSOR##_counter[TENSOR##_i]  == TENSOR##_sizes[TENSOR##_i]) \
       { \
         if(TENSOR##_i == 0) \
         { \
           TH_TENSOR_APPLY_hasFinished = 1; \
           break; \
         } \
-        else \
+          else \
         { \
           /* Reset the pointer to the beginning of the chunk defined by this dimension */ \
           TENSOR##_data -= TENSOR##_counter[TENSOR##_i]*TENSOR##_strides[TENSOR##_i]; \
@@ -595,8 +131,90 @@
       else \
         break; \
     } \
+    TENSOR##_i = 0; \
+  } \
+
+#define TH_TENSOR_APPLY3_D(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, DIM, CODE) \
+{ \
+  int TH_TENSOR_APPLY_hasFinished = 0; \
+  long TH_TENSOR_dim_index = 0; \
+  __TH_TENSOR_APPLYX_PREAMBLE(TYPE1, TENSOR1, DIM, 1) \
+  __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, DIM, 1) \
+  __TH_TENSOR_APPLYX_PREAMBLE(TYPE3, TENSOR3, DIM, 1) \
+\
+  if(TENSOR1##_n != TENSOR2##_n || TENSOR1##_n != TENSOR3##_n) /* should we do the check in the function instead? i think so */ \
+    THError("inconsistent tensor size"); \
+\
+  while(!TH_TENSOR_APPLY_hasFinished) \
+  { \
+    /* Loop through the inner most region of the Tensor */ \
+    for(; TENSOR1##_i < TENSOR1##_size && TENSOR2##_i < TENSOR2##_size && TENSOR3##_i < TENSOR3##_size; TENSOR1##_i++, TENSOR2##_i++, TENSOR3##_i++, TENSOR1##_data += TENSOR1##_stride, TENSOR2##_data += TENSOR2##_stride, TENSOR3##_data += TENSOR3##_stride) /* 0 et pas TENSOR##_dim! */ \
+    { \
+      CODE \
+    } \
+    __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR1, 0) \
+    __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR2, 0) \
+    __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR3, 0) \
+  } \
+  if(TENSOR1##_counter != NULL) \
+    THFree(TENSOR1##_counter); \
+  if(TENSOR2##_counter != NULL) \
+    THFree(TENSOR2##_counter); \
+  if(TENSOR3##_counter != NULL) \
+    THFree(TENSOR3##_counter); \
+}
+
+#define TH_TENSOR_APPLY3(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, CODE) \
+  TH_TENSOR_APPLY3_D(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, -1, CODE)
+
+#define TH_TENSOR_APPLY2_D(TYPE1, TENSOR1, TYPE2, TENSOR2, DIM, CODE) \
+{ \
+  int TH_TENSOR_APPLY_hasFinished = 0; \
+  long TH_TENSOR_dim_index = 0; \
+  __TH_TENSOR_APPLYX_PREAMBLE(TYPE1, TENSOR1, DIM, 1) \
+  __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, DIM, 1) \
+\
+  if(TENSOR1##_n != TENSOR2##_n) /* should we do the check in the function instead? i think so */ \
+    THError("inconsistent tensor size"); \
+\
+  while(!TH_TENSOR_APPLY_hasFinished) \
+  { \
+    /* Loop through the inner most region of the Tensor */ \
+    for(; TENSOR1##_i < TENSOR1##_size && TENSOR2##_i < TENSOR2##_size; TENSOR1##_i++, TENSOR2##_i++, TENSOR1##_data += TENSOR1##_stride, TENSOR2##_data += TENSOR2##_stride) /* 0 et pas TENSOR##_dim! */ \
+    { \
+      CODE \
+    } \
+    __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR1, 0) \
+    __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR2, 0) \
+  } \
+  if(TENSOR1##_counter != NULL) \
+    THFree(TENSOR1##_counter); \
+  if(TENSOR2##_counter != NULL) \
+    THFree(TENSOR2##_counter); \
+}
+
+#define TH_TENSOR_APPLY2(TYPE1, TENSOR1, TYPE2, TENSOR2, CODE) \
+  TH_TENSOR_APPLY2_D(TYPE1, TENSOR1, TYPE2, TENSOR2, -1, CODE)
+
+#define TH_TENSOR_APPLY_D(TYPE, TENSOR, DIM, CODE) \
+{ \
+  int TH_TENSOR_APPLY_hasFinished = 0; \
+  long TH_TENSOR_dim_index = 0; \
+  __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, DIM, 0) \
+\
+  while(!TH_TENSOR_APPLY_hasFinished) \
+  { \
+    /* Loop through the inner most region of the Tensor */ \
+    for(; TENSOR##_i < TENSOR##_size; TENSOR##_i++, TENSOR##_data += TENSOR##_stride) /* 0 et pas TENSOR##_dim! */ \
+    { \
+      CODE \
+    } \
+    __TH_TENSOR_APPLYX_UPDATE_COUNTERS(TENSOR, 1) \
   } \
   THFree(TENSOR##_counter); \
 }
+
+#define TH_TENSOR_APPLY(TYPE, TENSOR, CODE) \
+  TH_TENSOR_APPLY_D(TYPE, TENSOR, -1, CODE)
 
 #endif

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1527,17 +1527,11 @@ void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     tempIndices_->size[dimension] = t->size[dimension];
     tempIndices_->stride[dimension] = 0;
 
-    // this shows the flexibility of using TH_TENSOR_APPLY in place of
-    // TH_TENSOR_DIM_APPLY. Unfortunately, I'm leveraging the fact that since
-    // tempIndices has stride 0 and size >1 in dimension, there will definitely
-    // be an instantiated counter dimension there; this might not be true after
-    // some new optimizations to TH_TENSOR_APPLY3, so we'll need a different
-    // set of macros.
-    TH_TENSOR_APPLY3(real, t, real, tempValues_, long, tempIndices_,
-                     if(!(*t_data <= *tempValues__data) && !th_isnan(*tempValues__data)) {
-                       *tempValues__data = *t_data;
-                       *tempIndices__data = tempIndices__counter[dimension];
-                     });
+    TH_TENSOR_APPLY3_D(real, t, real, tempValues_, long, tempIndices_, dimension,
+                          if(!(*t_data <= *tempValues__data) && !th_isnan(*tempValues__data)) {
+                            *tempValues__data = *t_data;
+                            *tempIndices__data = *tempIndices__dimOffset;
+                          });
 
     THTensor_(free)(tempValues_);
     THLongTensor_free(tempIndices_);
@@ -1604,17 +1598,11 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
     tempIndices_->size[dimension] = t->size[dimension];
     tempIndices_->stride[dimension] = 0;
 
-    // this shows the flexibility of using TH_TENSOR_APPLY in place of
-    // TH_TENSOR_DIM_APPLY. Unfortunately, I'm leveraging the fact that since
-    // tempIndices has stride 0 and size >1 in dimension, there will definitely
-    // be an instantiated counter dimension there; this might not be true after
-    // some new optimizations to TH_TENSOR_APPLY3, so we'll need a different
-    // set of macros.
-    TH_TENSOR_APPLY3(real, t, real, tempValues_, long, tempIndices_,
-                     if(!(*t_data >= *tempValues__data) && !th_isnan(*tempValues__data)) {
-                       *tempValues__data = *t_data;
-                       *tempIndices__data = tempIndices__counter[dimension];
-                     });
+    TH_TENSOR_APPLY3_D(real, t, real, tempValues_, long, tempIndices_, dimension,
+                          if(!(*t_data >= *tempValues__data) && !th_isnan(*tempValues__data)) {
+                            *tempValues__data = *t_data;
+                            *tempIndices__data = *tempIndices__dimOffset;
+                          });
   }
 }
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -343,6 +343,7 @@ function torchtest.round()
 end
 
 function torchtest.max()  -- torch.max([resval, resind,] x [,dim])
+
    -- torch.max( x )
    -- contiguous
    local m1 = torch.randn(100,100)
@@ -357,6 +358,7 @@ function torchtest.max()  -- torch.max([resval, resind,] x [,dim])
    end
    local err = res1 - res2
    mytester:assertlt(err, precision, 'error in torch.max - contiguous')
+
    -- non-contiguous
    local m1 = torch.randn(10,10,10)
    local m2 = m1[{{}, 4, {}}]
@@ -371,33 +373,34 @@ function torchtest.max()  -- torch.max([resval, resind,] x [,dim])
    end
    local err = res1 - res2
    mytester:assertlt(err, precision, 'error in torch.max - non-contiguous')
+
    -- torch.max([resval, resind,] x ,dim])
-   local m1 = torch.randn(100,100)
-   local res1val, res1ind = torch.max(m1, 2)
-   local res2val = res1val:clone():zero()
-   local res2ind = res1ind:clone():zero()
-   for i=1, m1:size(1) do
-      res2val[i] = m1[i][1]
-      res2ind[i] = 1
-      for j=1, m1:size(2) do
-         if m1[i][j] > res2val[i][1] then
-            res2val[i] = m1[i][j]
-            res2ind[i] = j
+   function lua_max(t, dim)
+      assert(t:nDimension() == 2)
+      max_val = t:narrow(dim, 1, 1):clone()
+      max_ind = t:narrow(dim, 1, 1):clone():long():fill(1)
+      other = 3 - dim
+      for i = 1, t:size(other) do
+         for j = 1, t:size(dim) do
+            val = t:select(other, i):select(dim, j)
+            max = max_val:select(other, i):select(dim, 1)
+            if val > max then
+               max_val:select(other, i):fill(val)
+               max_ind:select(other, i):fill(j)
+            end
          end
       end
+      return max_val, max_ind
    end
-   local errval = res1val:clone():zero()
-   for i = 1, res1val:size(1) do
-      errval[i] = math.abs(res1val[i][1] - res2val[i][1])
-      mytester:asserteq(res1ind[i][1], res2ind[i][1], 'error in torch.max - non-contiguous')
+
+   local m1 = torch.randn(100,100)
+   for dim = 1,2 do
+      local res1val, res1ind = torch.max(m1, dim)
+      local res2val, res2ind = lua_max(m1, dim)
+      mytester:asserteq((res1val-res2val):abs():max(), 0, 'error in torch.max')
+      mytester:asserteq((res1ind-res2ind):abs():max(), 0, 'error in torch.max')
    end
-   local maxerr = 0
-   for i = 1, errval:size(1) do
-      if errval[i][1] > maxerr then
-         maxerr = errval[i]
-      end
-   end
-   mytester:assertlt(maxerr, precision, 'error in torch.max - non-contiguous')
+
    -- NaNs
    for index in pairs{1, 5, 100} do
       local m1 = torch.randn(100)
@@ -439,33 +442,34 @@ function torchtest.min()  -- torch.min([resval, resind,] x [,dim])
    end
    local err = res1 - res2
    mytester:assertlt(err, precision, 'error in torch.min - non-contiguous')
-   -- torch.min([resval, resind,] x ,dim])
-   local m1 = torch.randn(100,100)
-   local res1val, res1ind = torch.min(m1, 2)
-   local res2val = res1val:clone():zero()
-   local res2ind = res1ind:clone():zero()
-   for i=1, m1:size(1) do
-      res2val[i] = m1[i][1]
-      res2ind[i] = 1
-      for j=1, m1:size(2) do
-         if m1[i][j] < res2val[i][1] then
-            res2val[i] = m1[i][j]
-            res2ind[i] = j
+
+   -- torch.max([resval, resind,] x ,dim])
+   function lua_min(t, dim)
+      assert(t:nDimension() == 2)
+      max_val = t:narrow(dim, 1, 1):clone()
+      max_ind = t:narrow(dim, 1, 1):clone():long():fill(1)
+      other = 3 - dim
+      for i = 1, t:size(other) do
+         for j = 1, t:size(dim) do
+            val = t:select(other, i):select(dim, j)
+            max = max_val:select(other, i):select(dim, 1)
+            if val < max then
+               max_val:select(other, i):fill(val)
+               max_ind:select(other, i):fill(j)
+            end
          end
       end
+      return max_val, max_ind
    end
-   local errval = res1val:clone():zero()
-   for i = 1, res1val:size(1) do
-      errval[i] = math.abs(res1val[i][1] - res2val[i][1])
-      mytester:asserteq(res1ind[i][1], res2ind[i][1], 'error in torch.min - non-contiguous')
+
+   local m1 = torch.randn(100,100)
+   for dim = 1,2 do
+      local res1val, res1ind = torch.min(m1, dim)
+      local res2val, res2ind = lua_min(m1, dim)
+      mytester:asserteq((res1val-res2val):abs():max(), 0, 'error in torch.max')
+      mytester:asserteq((res1ind-res2ind):abs():max(), 0, 'error in torch.max')
    end
-   local minerr = 0
-   for i = 1, errval:size(1) do
-      if errval[i][1] < minerr then
-         minerr = errval[i]
-      end
-   end
-   mytester:assertlt(minerr, precision, 'error in torch.min - non-contiguous')
+
    -- NaNs
    for index in pairs{1, 5, 100} do
       local m1 = torch.randn(100)
@@ -1533,6 +1537,16 @@ function torchtest.sum()
    local mxx = torch.Tensor()
    torch.sum(mxx,x,2)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.sum value')
+
+   local y = torch.rand(5, 5, 5)
+   for i=1,3 do
+      local a = y:sum(i)
+      local b = y:narrow(i, 1, 1):clone():zero()
+      for j = 1, 5 do
+         b:add(y:narrow(i, j, 1))
+      end
+      mytester:asserteq(maxdiff(a, b), 0, 'torch.sum value')
+   end
 end
 function torchtest.prod()
    local x = torch.rand(msize,msize)
@@ -1540,6 +1554,16 @@ function torchtest.prod()
    local mxx = torch.Tensor()
    torch.prod(mxx,x,2)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.prod value')
+
+   local y = torch.rand(5, 5, 5)
+   for i=1,3 do
+      local a = y:prod(i)
+      local b = y:narrow(i, 1, 1):clone():fill(1)
+      for j = 1, 5 do
+         b:cmul(y:narrow(i, j, 1))
+      end
+      mytester:asserteq(maxdiff(a, b), 0, 'torch.sum value')
+   end
 end
 function torchtest.cumsum()
    local x = torch.rand(msize,msize)

--- a/test/test.lua
+++ b/test/test.lua
@@ -344,6 +344,11 @@ end
 
 function torchtest.max()  -- torch.max([resval, resind,] x [,dim])
 
+   -- TH_TENSOR_BASE
+   local m1 = torch.Tensor(8,2):fill(3):select(2, 1)
+   local resval, resind = torch.max(m1, 1)
+   mytester:assert(resind[1] == 1)
+
    -- torch.max( x )
    -- contiguous
    local m1 = torch.randn(100,100)
@@ -480,6 +485,11 @@ function torchtest.min()  -- torch.min([resval, resind,] x [,dim])
       local res1val = torch.min(m1)
       mytester:assert(res1val ~= res1val, 'error in torch.min - NaNs')
    end
+
+   -- TH_TENSOR_BASE
+   local m1 = torch.Tensor(4):fill(3)
+   local resval, resind = torch.min(m1, 1)
+   mytester:assert(resind[1] == 1)
 end
 
 function torchtest.cmax()


### PR DESCRIPTION
I just did `sum`, `prod`, `mean`, `max`, and `min` for now, but you can do a bunch of the other pointwise reductions like this too. 

before:
```
th> t = torch.randn(64,1024,1024)
                                                                      [5.6855s]
th> t:max(1);
                                                                      [1.7969s]
th> t:max(2);
                                                                      [0.9834s]
th> t:max(3);
                                                                      [0.1487s]
th> t:sum(1);
                                                                      [1.5895s]
th> t:sum(2);
                                                                      [0.9665s]
th> t:sum(3);
                                                                      [0.1610s]
```

after:
```
th> t = torch.randn(64,1024,1024)
                                                                      [5.7820s]
th> t:max(1);
                                                                      [0.3097s]
th> t:max(2);
                                                                      [0.2392s]
th> t:max(3);
                                                                      [0.1456s]
th> t:sum(1);
                                                                      [0.1985s]
th> t:sum(2);
                                                                      [0.2219s]
th> t:sum(3);
```

I think the optimizations for `max` and `min` will conflict with the TH_TENSOR_APPLY improvements in https://github.com/torch/torch7/pull/852, but we can always add special macros for this purpose if we want to keep the max and min optimizations. That new macro could also support stuff like `cumsum`.