### PR TITLE
Fix dimension check for cat

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -2510,7 +2510,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
 
   // When the user input dimension is -1 (i.e. -2 in C)
   // Then we pick the maximum last dimension across all tensors.
-  if ( dimension == -2 )
+  if ( dimension + TH_INDEX_BASE == -1 )
   {
     ldimension = maxDim?(maxDim-1):0;
   }

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -2501,7 +2501,9 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   int maxDim = dimension + 1;
   int allEmpty = 1;
   int allContiguous = 1;
-  int ldimension = dimension;
+
+  // cat_dimension is the actual dimension we cat along
+  int cat_dimension = dimension;
 
   for (i = 0; i < numInputs; i++)
   {
@@ -2512,11 +2514,11 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   // Then we pick the maximum last dimension across all tensors.
   if ( dimension + TH_INDEX_BASE == -1 )
   {
-    ldimension = maxDim?(maxDim-1):0;
+    cat_dimension = maxDim?(maxDim-1):0;
   }
 
   THArgCheck(numInputs > 0, 3, "invalid number of inputs %d", numInputs);
-  THArgCheck(ldimension >= 0, 4, "invalid dimension %d", dimension + TH_INDEX_BASE);
+  THArgCheck(cat_dimension >= 0, 4, "invalid dimension %d", dimension + TH_INDEX_BASE);
 
   size = THLongStorage_newWithSize(maxDim);
 
@@ -2524,7 +2526,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   {
     // dimSize is either the size of the dim if it exists, either 1 if #dim > 0, otherwise 0
     long dimSize = i < inputs[0]->nDimension ? inputs[0]->size[i] : THMin(inputs[0]->nDimension, 1);
-    if (i == ldimension)
+    if (i == cat_dimension)
     {
       for (j = 1; j < numInputs; j++)
       {
@@ -2571,7 +2573,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
 
     // First path is for contiguous inputs along dim 1
     // Second path for non-contiguous
-    if (ldimension == 0 && allContiguous)
+    if (cat_dimension == 0 && allContiguous)
     {
       real* result_data = result->storage->data + result->storageOffset;
       offset = 0;
@@ -2594,9 +2596,9 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
       {
         if (inputs[j]->nDimension)
         {
-          long dimSize = ldimension < inputs[j]->nDimension ? inputs[j]->size[ldimension] : 1;
+          long dimSize = cat_dimension < inputs[j]->nDimension ? inputs[j]->size[cat_dimension] : 1;
           THTensor *nt = THTensor_(newWithTensor)(result);
-          THTensor_(narrow)(nt, NULL, ldimension, offset, dimSize);
+          THTensor_(narrow)(nt, NULL, cat_dimension, offset, dimSize);
           THTensor_(copy)(nt, inputs[j]);
           THTensor_(free)(nt);
           offset += dimSize;

--- a/test/test.lua
+++ b/test/test.lua
@@ -597,34 +597,34 @@ function torchtest.fill()
       'torch.FloatTensor',
       'torch.DoubleTensor',
       'torch.LongTensor',
-   }   
+   }
 
    for k,t in ipairs(types) do
       -- [res] torch.fill([res,] tensor, value)
       local m1 = torch.ones(100,100):type(t)
       local res1 = m1:clone()
       res1[{ 3,{} }]:fill(2)
-      
+
       local res2 = m1:clone()
       for i = 1,m1:size(1) do
 	 res2[{ 3,i }] = 2
       end
-      
+
       local err = (res1-res2):double():abs():max()
-      
+
       mytester:assertlt(err, precision, 'error in torch.fill - contiguous')
-      
+
       local m1 = torch.ones(100,100):type(t)
       local res1 = m1:clone()
       res1[{ {},3 }]:fill(2)
-      
+
       local res2 = m1:clone()
       for i = 1,m1:size(1) do
 	 res2[{ i,3 }] = 2
       end
-      
+
       local err = (res1-res2):double():abs():max()
-      
+
       mytester:assertlt(err, precision, 'error in torch.fill - non contiguous')
    end
 end
@@ -2166,6 +2166,29 @@ function torchtest.catArray()
    local y = torch.Tensor()
    local mx = torch.cat({x,y})
    mytester:asserteq(mx:dim(),0,'torch.cat dim')
+end
+function torchtest.catNoDim()
+   local a
+   local b
+   local c
+
+   a = torch.Tensor(msize):uniform()
+   b = torch.Tensor(msize):uniform()
+   c = torch.cat(a, b)
+   mytester:assertTensorEq(c:narrow(1, 1, msize), a, 0, 'torch.cat value')
+   mytester:assertTensorEq(c:narrow(1, msize + 1, msize), b, 0, 'torch.cat value')
+
+   a = torch.Tensor(1, msize):uniform()
+   b = torch.Tensor(1, msize):uniform()
+   c = torch.cat(a, b)
+   mytester:assertTensorEq(c:narrow(2, 1, msize), a, 0, 'torch.cat value')
+   mytester:assertTensorEq(c:narrow(2, msize + 1, msize), b, 0, 'torch.cat value')
+
+   a = torch.Tensor(10, msize):uniform()
+   b = torch.Tensor(10, msize):uniform()
+   c = torch.cat(a, b)
+   mytester:assertTensorEq(c:narrow(2, 1, msize), a, 0, 'torch.cat value')
+   mytester:assertTensorEq(c:narrow(2, msize + 1, msize), b, 0, 'torch.cat value')
 end
 function torchtest.sin_2()
    local x = torch.rand(msize,msize,msize)


### PR DESCRIPTION
- Fixes  default dimension check from -2 to use `TH_INDEX_BASE`. I think master probably fails on PyTorch.(haven't checked). 
- Also added tests for cat when no dimension is specified (Similar to what is happening in https://github.com/torch/cutorch/pull/719)
- As done with cutorch, changed the variable name to make life easier when debugging this function.