### PR TITLE
Update CmdLine.lua

### DIFF
--- a/CmdLine.lua
+++ b/CmdLine.lua
@@ -227,9 +227,9 @@ end
 function CmdLine:help(arg)
    io.write('Usage: ')
    if arg then io.write(arg[0] .. ' ') end
-   io.write('[options] ')
+   io.write('[options]')
    for i=1,#self.arguments do
-      io.write('<' .. strip(self.arguments[i].key) .. '>')
+      io.write(' <' .. strip(self.arguments[i].key) .. '>')
    end
    io.write('\n')
 


### PR DESCRIPTION
Very small cosmetic change to make positional arguments look better.

Previously, positional arguments would look like:
```
$ th my_script.lua --help
Usage: [options] <arg1><arg2>
-opt1 blah blah [default]
```
and now it should look like
```
$ th my_script.lua --help
Usage: [options] <arg1> <arg2>
-opt1 blah blah [default]
```
Very minorly cosmetic.