### PR TITLE
fast sigmoid

### DIFF
--- a/lib/TH/THMath.h
+++ b/lib/TH/THMath.h
@@ -2,7 +2,11 @@
 #define _THMATH_H
 
 static inline double TH_sigmoid(double value) {
-  return 1.0 / (1.0 + exp(-value));
+  // faster version of 1.0 / (1.0 + exp(-value));
+  double x = fabs(value);
+  double x2 = x*x;
+  double e = 1.0f + x + x2*0.555f + x2*x2*0.143f;
+  return 1.0f / (1.0f + (value > 0 ? 1.0f / e : e));
 }
 
 static inline double TH_frac(double x) {

--- a/test/test.lua
+++ b/test/test.lua
@@ -217,7 +217,7 @@ function torchtest.sigmoid()
    local inputValues = {-1000,-1,0,0.5,1,2,1000}
    local expectedOutput = {0.0000, 0.2689, 0.5, 0.6225, 0.7311, 0.8808, 1.000}
 
-   local precision_4dps = 0.0002
+   local precision_4dps = 0.002
 
    -- float
    local inputFT = torch.FloatTensor(inputValues)


### PR DESCRIPTION
This PR provides a faster implement of `torch.Tensor.sigmoid`. As outlined in  #1026, the rationale for this PR is that TensorFlow has a 1.77x speedup over Torch LSTMs on CPU using Float tensors. This PR brings us to par with TF LSTMs. 

The downside is that `torch.Tensor.sigmoid` will lose some precision. The rough approximation introduces about 0.2% error. The speedup seems to warrant the approximation because the throughput for a typical LSTM goes from 455 samples/sec to 910 samples/sec, which compares well to the 809 samples/sec for TF. For a smaller LSTM those numbers are respectively, 3087 to 3900 for Torch vs  4139 for TF.

An alternative could be to implement a separate THTensor_(fastsigmoid) for this rough approximation.