### PR TITLE
Implementation of Alias Multinomial for faster Multinomial sampling

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -1269,16 +1269,30 @@ static void THTensor_random1__(THTensor *self, THGenerator *gen, long b)
       wrap("multinomial",
            cname("multinomial"),
            {{name="IndexTensor", default=true, returned=true, method={default='nil'}},
-            {name='Generator', default=true},
-            {name=Tensor},
-            {name="int"},
-            {name="boolean", default=false}})
-
+              {name='Generator', default=true},
+              {name=Tensor},
+              {name="int"},
+              {name="boolean", default=false}})
+      
+      wrap("multinomialAliasSetup_",
+           cname("multinomialAliasSetup"),
+           {{name=Tensor},
+              {name="IndexTensor", default=true, returned=true, method={default='nil'}},
+              {name=Tensor, default=true, returned=true, method={default='nil'}}})
+      
+      wrap("multinomialAlias_",
+           cname("multinomialAliasDraw"),
+           {{name="IndexTensor", default=true, returned=true, method={default='nil'}},
+              {name='Generator', default=true},
+              {name="IndexTensor"},
+              {name=Tensor}
+              })
+      
       for _,f in ipairs({{name='uniform', a=0, b=1},
-                         {name='normal', a=0, b=1},
-                         {name='cauchy', a=0, b=1},
-                         {name='logNormal', a=1, b=2}}) do
-
+            {name='normal', a=0, b=1},
+            {name='cauchy', a=0, b=1},
+            {name='logNormal', a=1, b=2}}) do
+         
          wrap(f.name,
               string.format("THRandom_%s", f.name),
               {{name='Generator', default=true},

--- a/doc/maths.md
+++ b/doc/maths.md
@@ -255,6 +255,104 @@ p.multinomial(res, p, n, replacement) -- p.multinomial instead of torch.multinom
 
 This is due to the fact that the result here is of a `LongTensor` type, and we do not define a `torch.multinomial` over long `Tensor`s.
 
+<a name="torch.AliasMultinomial()"></a>
+### [state] torch.multinomialAliasSetup(probs) ###
+### [res] torch.multinomialAlias(output, state)
+`state = torch.multinomialAliasSetup(probs)` returns a table `state` consisting of two `tensors` : `probability table` and an `alias table`. This is required once for each `probs` vectors. We can then sample from the multinomial distribution multiple times by consulting these tensors `state` table.
+
+`torch.multinomialAlias(output, state)` returns `output` filled with indices drawn from the multinomial distribution `probs`. `output` itself is filled with the indices and it is not necessary to get the return value of the statement.
+
+The sampling is done through a technique defined in a very simple way in this blog about [The Alias Method](https://hips.seas.harvard.edu/blog/2013/03/03/the-alias-method-efficient-sampling-with-many-discrete-outcomes/). The paper that describes this technique is present [here](http://www.tandfonline.com/doi/abs/10.1080/00031305.1979.10482697). This can only sample with replacement.
+
+The `output` `Tensor` that is fed into the `multinomialAlias` method need not be contiguous. The `output` tensor can only be a 1d tensor. If you are required to fill a nd tensor enter a 1d view of the same tensor. This method is exceptionally faster than `torch.multinomial` when you want to sample a lot of samples from the same distrbution or sample from the same distribution a large number of times. `torch.multinomial` is faster for sampling few samples from a distribution once because the `multinomialAliasSetup` method takes some time in this case. To see and compare how these two methods differ in speed run `th test/test_aliasMultinomial.lua`.
+
+```lua
+th> probs = torch.DoubleTensor({0.2, 0.2, 0.3, 0.3})
+                                                                      [0.0001s]
+                                                                      
+th> prob_tbl, alias_tbl = torch.multinomialAliasSetup(probs)
+                                                                      [0.0002s]
+                                                                      
+th> output = torch.LongTensor(2,3)
+                                                                      [0.0001s]
+                                                                      
+
+th> alias_tbl.multinomialAliasDraw(output:view(-1), prob_tbl, alias_tbl)
+ 3
+ 4
+ 3
+ 1
+ 2
+ 3
+[torch.LongTensor of size 6]
+
+                                                                      [0.0003s]
+                                                                      
+th> output
+ 3  4  3
+ 1  2  3
+[torch.LongTensor of size 2x3]th> probs = torch.DoubleTensor({0.2, 0.2, 0.3, 0.3})
+                                                                      [0.0001s]
+th> state = torch.multinomialAliasSetup(probs)
+                                                                      [0.0001s]
+th> state
+{
+  1 : LongTensor - size: 4
+  2 : DoubleTensor - size: 4
+}
+                                                                      [0.0002s]
+th> output = torch.LongTensor(2,3)
+   
+                                                                      [0.0003s]
+th> torch.multinomialAlias(output:view(-1), state)
+ 4
+ 1
+ 2
+ 3
+ 2
+ 2
+[torch.LongTensor of size 6]
+
+                                                                      [0.0002s]
+th> output
+ 4  1  2
+ 3  2  2
+[torch.LongTensor of size 2x3]
+
+                                                                      [0.0001s]
+th>
+
+```
+
+You can also allocate memory and reuse it for the state table.
+
+```
+th> state = {torch.LongTensor(), torch.DoubleTensor()}
+                                                                      [0.0001s]
+th> probs = torch.Double
+torch.DoubleStorage. torch.DoubleTensor.
+th> probs = torch.DoubleTensor({0.2, 0.3, 0.5})
+                                                                      [0.0001s]
+th> state = torch.multinomialAliasSetup(probs, state)
+                                                                      [0.0001s]
+th> state
+{
+  1 : LongTensor - size: 3
+  2 : DoubleTensor - size: 3
+}
+                                                                      [0.0002s]
+th> output = torch.LongTensor(7)
+th> torch.multinomialAlias(output, state)
+ 2
+ 2
+ 3
+ 1
+ 2
+ 2
+ 2
+[torch.LongTensor of size 7]
+```
+
 <a name="torch.ones"></a>
 ### [res] torch.ones([res,] m [,n...]) ###
 <a name="torch.ones"></a>

--- a/init.lua
+++ b/init.lua
@@ -189,21 +189,17 @@ torch.Tensor.isTensor = torch.isTensor
 torch.setheaptracking(true)
 
 function torch.multinomialAliasSetup(probs, state)
-    local prob_tbl, alias_tbl
-    if state then 
-      assert(torch.type(state) == 'table')
+   if torch.type(state) == 'table' then 
       state[1], state[2] = torch.multinomialAliasSetup_(probs, state[1], state[2])
-    else 
-      prob_tbl, alias_tbl = torch.multinomialAliasSetup_(probs)
-      state = {prob_tbl, alias_tbl}
-    end
-    return state
+   else
+      state = {}
+      state[1], state[2] = torch.multinomialAliasSetup_(probs)
+   end
+   return state
 end
 
 function torch.multinomialAlias(output, state)
-   local prob_tbl, alias_tbl
-   prob_tbl, alias_tbl = state[1], state[2]
-   torch.DoubleTensor.multinomialAlias_(output, prob_tbl, alias_tbl)
+   torch.DoubleTensor.multinomialAlias_(output, state[1], state[2])
    return output
 end
 

--- a/init.lua
+++ b/init.lua
@@ -159,7 +159,6 @@ require('torch.FFInterface')
 require('torch.Tester')
 require('torch.TestSuite')
 require('torch.test')
-
 function torch.totable(obj)
    if torch.isTensor(obj) or torch.isStorage(obj) then
       return obj:totable()
@@ -188,5 +187,24 @@ torch.Tensor.isTensor = torch.isTensor
 
 -- remove this line to disable automatic heap-tracking for garbage collection
 torch.setheaptracking(true)
+
+function torch.multinomialAliasSetup(probs, state)
+    local prob_tbl, alias_tbl
+    if state then 
+      assert(torch.type(state) == 'table')
+      state[1], state[2] = torch.multinomialAliasSetup_(probs, state[1], state[2])
+    else 
+      prob_tbl, alias_tbl = torch.multinomialAliasSetup_(probs)
+      state = {prob_tbl, alias_tbl}
+    end
+    return state
+end
+
+function torch.multinomialAlias(output, state)
+   local prob_tbl, alias_tbl
+   prob_tbl, alias_tbl = state[1], state[2]
+   torch.DoubleTensor.multinomialAlias_(output, prob_tbl, alias_tbl)
+   return output
+end
 
 return torch

--- a/lib/TH/generic/THTensorCopy.c
+++ b/lib/TH/generic/THTensorCopy.c
@@ -68,6 +68,7 @@ void THTensor_(copyTranspose)(THTensor *tensor, THTensor *src) {
 
 void THTensor_(copy)(THTensor *tensor, THTensor *src)
 {
+  if (tensor == src) return;
   if (THTensor_(isContiguous)(tensor) && THTensor_(isContiguous)(src) && THTensor_(nElement)(tensor) == THTensor_(nElement)(src)) {
     real *sp = THTensor_(data)(src);
     real *rp = THTensor_(data)(tensor);

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -70,6 +70,118 @@ void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, 
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_logNormal(_generator, mean, stdv););
 }
 
+
+void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor *q)
+{
+  long inputsize = THTensor_(nElement)(probs);
+  long i = 0;
+  THLongTensor *smaller = THLongTensor_newWithSize1d(inputsize);
+  THLongTensor *larger = THLongTensor_newWithSize1d(inputsize);
+  long small_c = 0;
+  long large_c = 0;
+  THLongTensor_resize1d(J, inputsize);
+  THTensor_(resize1d)(q, inputsize);
+  
+  for(i = 0; i < inputsize; i++)
+    {
+      THTensor_fastSet1d(J, i, 0L);
+      
+      real val = THStorage_(get)(probs->storage,
+                                 probs->storageOffset+i*probs->stride[0]);
+      THTensor_fastSet1d(q, i, inputsize*val);
+      
+      if (inputsize * val < 1.0)
+        {
+          THTensor_fastSet1d(smaller, small_c, i);
+          small_c += 1;
+        }
+      else
+        {
+          THTensor_fastSet1d(larger, large_c, i);
+          large_c += 1;
+        }
+    }
+
+  // Loop through and create little binary mixtures that
+  // appropriately allocate the larger outcomes over the
+  // overall uniform mixture.
+  long large, small;
+  while(small_c > 0 && large_c > 0)
+    {
+      large = THTensor_fastGet1d(larger, large_c-1);
+      small = THTensor_fastGet1d(smaller, small_c-1);
+      
+      THTensor_fastSet1d(J, small, large);
+      
+       THTensor_(data)(q)[large*q->stride[0]] -= 1.0 - THTensor_fastGet1d(q, small);
+      
+      if(q->storage->data[large] < 1.0)
+        {
+          THTensor_fastSet1d(smaller, small_c-1, large);
+          large_c -= 1;
+        }
+      else
+        {
+          THTensor_fastSet1d(larger, large_c-1, large);
+          small_c -= 1;
+        }
+    }
+
+  real q_min = THTensor_fastGet1d(q, inputsize-1);
+  real q_max = q_min;
+  real q_temp;
+  for(i=0; i < inputsize; i++)
+    {
+      q_temp = THTensor_fastGet1d(q, i);
+      if(q_temp < q_min)
+        q_min = q_temp;
+      else if(q_temp > q_max)
+        q_max = q_temp;
+    }
+  THArgCheckWithCleanup((q_min > 0),
+                        THCleanup(THLongTensor_free(smaller); THLongTensor_free(larger);), 2,
+                        "q_min is less than 0");
+  
+  if(q_max > 1)
+    {
+      for(i=0; i < inputsize; i++)
+        {
+          THTensor_(data)(q)[i*q->stride[0]] /= q_max;
+        }
+    }
+  for(i=0; i<inputsize; i++)
+    {
+      // sometimes an large index isn't added to J. 
+      // fix it by making the probability 1 so that J isn't indexed.
+      if(J->storage->data[i] <= 0)
+        q->storage->data[i] = 1.0;
+    }
+  THLongTensor_free(smaller);
+  THLongTensor_free(larger);
+}
+void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator, THLongTensor *J, THTensor *q)
+{
+  long K = THLongTensor_nElement(J);
+  long output_nelem = THLongTensor_nElement(self);
+  THGenerator* gen = THGenerator_new();
+  
+  int i = 0, _mask=0;
+  real _q;
+  long rand_ind, sample_idx, J_sample, kk_sample;
+  for(i=0; i< output_nelem; i++)
+    {
+      rand_ind = (long)THRandom_uniform(gen, 0, K) ;
+      _q = THTensor_fastGet1d(q, rand_ind);
+
+      _mask = THRandom_bernoulli(gen, _q);
+      
+      J_sample = THTensor_fastGet1d(J, rand_ind);
+
+      sample_idx = J_sample*(1 -_mask) + (rand_ind+1L) * _mask;
+
+      THTensor_fastSet1d(self, i, sample_idx-1L);
+    }
+}
 void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement)
 {
   int start_dim = THTensor_(nDimension)(prob_dist);

--- a/lib/TH/generic/THTensorRandom.h
+++ b/lib/TH/generic/THTensorRandom.h
@@ -15,6 +15,8 @@ TH_API void THTensor_(exponential)(THTensor *self, THGenerator *_generator, doub
 TH_API void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma);
 TH_API void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, double stdv);
 TH_API void THTensor_(multinomial)(THLongTensor *self, THGenerator *_generator, THTensor *prob_dist, int n_sample, int with_replacement);
+TH_API void THTensor_(multinomialAliasSetup)(THTensor *prob_dist, THLongTensor *J, THTensor *q);
+TH_API void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator, THLongTensor *J, THTensor *q);
 #endif
 
 #if defined(TH_REAL_IS_BYTE)

--- a/test/test.lua
+++ b/test/test.lua
@@ -1811,6 +1811,29 @@ function torchtest.multinomialwithoutreplacement()
       end
    end
 end
+function torchtest.aliasMultinomial()
+   for i =1,5 do
+      local n_class = 5
+      local t=os.time()
+      torch.manualSeed(t)
+      local probs = torch.Tensor(n_class):uniform(0,1)
+      probs:div(probs:sum())
+      local output = torch.LongTensor(1000, 10000)
+      local n_samples = output:nElement()
+      local prob_state = torch.multinomialAliasSetup(probs)
+      mytester:assert(prob_state[1]:min() > 0, "Index ="..prob_state[1]:min().."alias indices has an index below or equal to 0")
+      mytester:assert(prob_state[1]:max() <= n_class, prob_state[1]:max().." alias indices has an index exceeding num_class")
+      local prob_state = torch.multinomialAliasSetup(probs, prob_state)
+      mytester:assert(prob_state[1]:min() > 0, "Index ="..prob_state[1]:min().."alias indices has an index below or equal to 0(cold)")
+      mytester:assert(prob_state[1]:max() <= n_class, prob_state[1]:max()..","..prob_state[1]:min().." alias indices has an index exceeding num_class(cold)")
+      local output = torch.LongTensor(n_samples)
+      output = torch.multinomialAlias(output, prob_state)
+      mytester:assert(output:nElement() == n_samples, "wrong number of samples")
+      mytester:assert(output:min() > 0, "sampled indices has an index below or equal to 0")
+      mytester:assert(output:max() <= n_class, "indices has an index exceeding num_class")
+   end
+
+end
 function torchtest.multinomialvector()
    local n_col = 4
    local t=os.time()

--- a/test/test_aliasMultinomial.lua
+++ b/test/test_aliasMultinomial.lua
@@ -1,0 +1,40 @@
+local tester = torch.Tester()
+
+
+local function aliasMultinomial()
+   local n_class = 10000
+   local probs = torch.Tensor(n_class):uniform(0,1)
+   probs:div(probs:sum())
+   local a = torch.Timer()
+   local state = torch.multinomialAliasSetup(probs)
+   print("AliasMultinomial setup in "..a:time().real.." seconds(hot)")
+   a:reset()
+   state = torch.multinomialAliasSetup(probs, state)
+   print("AliasMultinomial setup in "..a:time().real.." seconds(cold)")
+   a:reset()
+   
+   tester:assert(state[1]:min() >= 0, "Index ="..state[1]:min().."alias indices has an index below or equal to 0")
+   tester:assert(state[1]:max() <= n_class, state[1]:max().." alias indices has an index exceeding num_class")
+   local output = torch.LongTensor(1000000)
+   torch.multinomialAlias(output, state)
+   local n_samples = output:nElement()
+   print("AliasMultinomial draw "..n_samples.." elements from "..n_class.." classes ".."in "..a:time().real.." seconds")
+   local counts = torch.Tensor(n_class):zero()
+   mult_output = torch.multinomial(probs, n_samples, true)
+   print("Multinomial draw "..n_samples.." elements from "..n_class.." classes ".." in "..a:time().real.." seconds")
+   tester:assert(output:min() > 0, "sampled indices has an index below or equal to 0")
+   tester:assert(output:max() <= n_class, "indices has an index exceeding num_class")
+   output:apply(function(x)
+         counts[x] = counts[x] + 1
+   end)
+   a:reset()
+   
+   counts:div(counts:sum())
+   
+   tester:assert(state[1]:min() >= 0, "Index ="..state[1]:min().."alias indices has an index below or equal to 0")
+   tester:assert(state[1]:max() <= n_class, state[1]:max().." alias indices has an index exceeding num_class")
+   tester:eq(probs, counts, 0.001, "probs and counts should be approximately equal")
+end
+
+tester:add(aliasMultinomial)
+tester:run()


### PR DESCRIPTION
This allows for faster sampling from a multinomial distribution using the __Alias__ method which is described in this [paper](http://www.tandfonline.com/doi/abs/10.1080/00031305.1979.10482697).

It allows almost `5x` speed in sampling than `torch.multinomial`. To see the difference on your machine run ` th test/test_aliasMultinomial.lua`