### PR TITLE
Minor change to TH/CMakeLists.txt

### DIFF
--- a/lib/TH/CMakeLists.txt
+++ b/lib/TH/CMakeLists.txt
@@ -215,6 +215,7 @@ ENDIF()
 # IF ANY SIMD FOUND
 IF(C_AVX2_FOUND OR C_AVX_FOUND OR C_SSE4_2_FOUND OR C_SSE4_1_FOUND)
   SET(simd generic/simd/convolve.c)
+  SET(simd ${simd} generic/simd/convolve5x5_sse.c)
 ENDIF(C_AVX2_FOUND OR C_AVX_FOUND OR C_SSE4_2_FOUND OR C_SSE4_1_FOUND)
 
 # IF SSE4 FOUND


### PR DESCRIPTION
With this change, I've managed to get Torch to compile on Windows via LuaRocks and MSVC. By configuring LuaRocks for Lua 5.3 and maintaining a directory with the corresponding Lua source and binaries, in addition to the headers and libraries for GNU Readline as a dependency for TREPL, the installation proceeds with a few equation warnings, but no compiler errors. I plan to publish a Batch file for ease of installation via command line using the MSVC tools, but in the meantime this pull is more pressing.